### PR TITLE
ci: fix branches-ignore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: upload release to PyPI
 on:
   push:
     branches-ignore:
-      - '*'
+      - '**'
     tags:
       - '*'
 


### PR DESCRIPTION
We must double the * to match branch with namespaces (eg: /)