### PR TITLE
chore(workflow): disable metadata checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,5 @@ jobs:
           poetry build
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verify-metadata: false


### PR DESCRIPTION
disable twine artifact checking before upload to PyPi