### PR TITLE
fix: display help even outside git repo

### DIFF
--- a/mergify_cli/tests/test_mergify_cli.py
+++ b/mergify_cli/tests/test_mergify_cli.py
@@ -1,5 +1,5 @@
 #
-#  Copyright © 2021 Mergify SAS
+#  Copyright © 2021-2023 Mergify SAS
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -13,6 +13,23 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import subprocess
+from unittest import mock
 
-def test_noop() -> None:
-    pass
+import pytest
+
+import mergify_cli
+
+
+def test_cli_help(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit, match="0"):
+        with mock.patch(
+            "subprocess.check_output",
+            side_effect=subprocess.CalledProcessError(2, ""),
+        ):
+            mergify_cli.parse_args(["--help"])
+
+    stdout = capsys.readouterr().out
+    assert "usage: " in stdout
+    assert "positional arguments:" in stdout
+    assert "options:" in stdout


### PR DESCRIPTION
Mergify CLI raises an error when the user invokes `mergify --help`
outside a git repository and the git config `mergify-cli.stack-trunk`
is not set.

Fixes MRGFY-2858

Change-Id: Icf3cfd073774fff2b9551a3eff77d1ce1b505414