### PR TITLE
fix: set default action correctly

### DIFF
--- a/mergify_cli/__init__.py
+++ b/mergify_cli/__init__.py
@@ -679,7 +679,7 @@ async def stack_main(args: argparse.Namespace) -> None:
     )
 
 
-def parse_args(args: typing.Sequence[str]) -> argparse.Namespace:
+def parse_args(args: typing.MutableSequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--version",
@@ -738,7 +738,7 @@ def parse_args(args: typing.Sequence[str]) -> argparse.Namespace:
 
     known_args, _ = parser.parse_known_args(args)
     if known_args.action is None:
-        sys.argv.insert(1, "stack")
+        args.insert(1, "stack")
 
     return parser.parse_args(args)
 


### PR DESCRIPTION
This will avoid:
```
$ mergify
Traceback (most recent call last):
  File "/Users/sileht/.local/bin/mergify", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/Users/sileht/.local/pipx/venvs/mergify-cli/lib/python3.12/site-packages/mergify_cli/__init__.py", line 746, in cli
    asyncio.run(args.func(args))
                ^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'func'
```