### PR TITLE
feat: allow to not rebase the stack

### DIFF
--- a/mergify_cli/tests/test_mergify_cli.py
+++ b/mergify_cli/tests/test_mergify_cli.py
@@ -164,6 +164,7 @@ async def test_stack_create(
 
     await mergify_cli.stack(
         token="",
+        skip_rebase=False,
         next_only=False,
         branch_prefix="",
         dry_run=False,
@@ -251,6 +252,7 @@ async def test_stack_create_single_pull(
 
     await mergify_cli.stack(
         token="",
+        skip_rebase=False,
         next_only=False,
         branch_prefix="",
         dry_run=False,
@@ -265,6 +267,85 @@ async def test_stack_create_single_pull(
         "title": "Title commit 1",
         "body": "Message commit 1",
         "draft": False,
+    }
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_stack_update_no_rebase(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    # Mock 1 commits on branch `current-branch`
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit_sha",
+            title="Title",
+            message="Message",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+
+    # Mock HTTP calls: the stack already exists but it's out of date, it should
+    # be updated
+    respx_mock.get("/repos/user/repo/git/matching-refs/heads//current-branch/").respond(
+        200,
+        json=[
+            {
+                "ref": "refs/heads//current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+        ],
+    )
+    respx_mock.get(
+        "/repos/user/repo/pulls?head=user:/current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50&state=open",
+    ).respond(
+        200,
+        json=[
+            {
+                "html_url": "",
+                "number": "123",
+                "title": "Title",
+                "head": {"sha": "previous_commit_sha"},
+                "state": "open",
+                "draft": False,
+                "node_id": "",
+            },
+        ],
+    )
+    respx_mock.patch(
+        "/repos/user/repo/git/refs/heads//current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+    ).respond(200, json={})
+    patch_pull_mock = respx_mock.patch("/repos/user/repo/pulls/123").respond(
+        200,
+        json={},
+    )
+    respx_mock.get("/repos/user/repo/issues/123/comments").respond(
+        200,
+        json=[
+            {
+                "body": "This pull request is part of a stack:\n...",
+                "url": "https://api.github.com/repos/user/repo/issues/comments/456",
+            },
+        ],
+    )
+    respx_mock.patch("/repos/user/repo/issues/comments/456").respond(200)
+
+    await mergify_cli.stack(
+        token="",
+        skip_rebase=True,
+        next_only=False,
+        branch_prefix="",
+        dry_run=False,
+        trunk=("origin", "main"),
+    )
+    assert not git_mock.has_been_called_with("pull --rebase origin main")
+
+    # The pull request is updated
+    assert len(patch_pull_mock.calls) == 1
+    assert json.loads(patch_pull_mock.calls.last.request.content) == {
+        "head": "/current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        "base": "main",
+        "title": "Title",
+        "body": "Message",
     }
 
 
@@ -329,11 +410,13 @@ async def test_stack_update(
 
     await mergify_cli.stack(
         token="",
+        skip_rebase=False,
         next_only=False,
         branch_prefix="",
         dry_run=False,
         trunk=("origin", "main"),
     )
+    assert git_mock.has_been_called_with("pull --rebase origin main")
 
     # The pull request is updated
     assert len(patch_pull_mock.calls) == 1
@@ -354,6 +437,7 @@ async def test_stack_on_destination_branch_raises_an_error(
     with pytest.raises(SystemExit, match="1"):
         await mergify_cli.stack(
             token="",
+            skip_rebase=False,
             next_only=False,
             branch_prefix="",
             dry_run=False,
@@ -370,6 +454,7 @@ async def test_stack_without_common_commit_raises_an_error(
     with pytest.raises(SystemExit, match="1"):
         await mergify_cli.stack(
             token="",
+            skip_rebase=False,
             next_only=False,
             branch_prefix="",
             dry_run=False,

--- a/mergify_cli/tests/utils.py
+++ b/mergify_cli/tests/utils.py
@@ -27,12 +27,17 @@ class Commit(typing.TypedDict):
 class GitMock:
     _mocked: dict[str, str] = dataclasses.field(init=False, default_factory=dict)
     _commits: list[Commit] = dataclasses.field(init=False, default_factory=list)
+    _called: list[str] = dataclasses.field(init=False, default_factory=list)
 
     def mock(self, command: str, output: str) -> None:
         self._mocked[command] = output
 
+    def has_been_called_with(self, args: str) -> bool:
+        return args in self._called
+
     async def __call__(self, args: str) -> str:
         if args in self._mocked:
+            self._called.append(args)
             return self._mocked[args]
 
         msg = f"git_mock called with `{args}`, not mocked!"


### PR DESCRIPTION
When pull request are ready to be merged or queued in a merge
queue, rebasing the stack may unqueue the pull request or removed
approvals.

This change adds an option to not rebase the stack and just update it.