### PR TITLE
fix: handle correctly when client side error without body request read

### DIFF
--- a/mergify_cli/__init__.py
+++ b/mergify_cli/__init__.py
@@ -16,6 +16,7 @@
 
 import argparse
 import asyncio
+import contextlib
 import dataclasses
 import importlib.metadata
 import os
@@ -63,7 +64,8 @@ def check_for_status(response: httpx.Response) -> None:
     if response.status_code < 500:
         data = response.json()
         console.print(f"url: {response.request.url}", style="red")
-        console.print(f"data: {response.request.content.decode()}", style="red")
+        with contextlib.suppress(httpx.RequestNotRead):
+            console.print(f"data: {response.request.content.decode()}", style="red")
         console.print(
             f"HTTPError {response.status_code}: {data['message']}",
             style="red",


### PR DESCRIPTION
GitHub may return 422 before it finishes to read the request body.

This change makes our logging working when this occurs.
