### PR TITLE
chore: don't push the aio branch

### DIFF
--- a/mergify_cli/__init__.py
+++ b/mergify_cli/__init__.py
@@ -41,6 +41,7 @@ DRAFT_TEMPLATE = 'mutation { convertPullRequestToDraft(input: { pullRequestId: "
 console = rich.console.Console(log_path=False, log_time=False)
 
 DEBUG = False
+TMP_STACK_BRANCH = "mergify-cli-tmp"
 
 
 def check_for_graphql_errors(response: httpx.Response) -> None:
@@ -310,6 +311,7 @@ class StackComment:
 
 async def create_or_update_stack(  # noqa: PLR0913,PLR0917
     client: httpx.AsyncClient,
+    remote: str,
     stacked_base_branch: str,
     stacked_dest_branch: str,
     changeid: ChangeId,
@@ -322,23 +324,18 @@ async def create_or_update_stack(  # noqa: PLR0913,PLR0917
 ) -> tuple[PullRequest, str]:
     if changeid in known_changeids:
         pull = known_changeids.get(changeid)
-        with console.status(
-            f"* updating stacked branch `{stacked_dest_branch}` ({commit[-7:]}) - {pull['html_url'] if pull else '<stack branch without associated pull>'})",
-        ):
-            r = await client.patch(
-                f"git/refs/heads/{stacked_dest_branch}",
-                json={"sha": commit, "force": True},
-            )
+        status_message = f"* updating stacked branch `{stacked_dest_branch}` ({commit[-7:]}) - {pull['html_url'] if pull else '<stack branch without associated pull>'})"
     else:
-        with console.status(
-            f"* creating stacked branch `{stacked_dest_branch}` ({commit[-7:]})",
-        ):
-            r = await client.post(
-                "git/refs",
-                json={"ref": f"refs/heads/{stacked_dest_branch}", "sha": commit},
-            )
+        status_message = (
+            f"* creating stacked branch `{stacked_dest_branch}` ({commit[-7:]})"
+        )
 
-    check_for_status(r)
+    with console.status(status_message):
+        await git(f"branch {TMP_STACK_BRANCH} {commit}")
+        try:
+            await git(f"push -f {remote} {TMP_STACK_BRANCH}:{stacked_dest_branch}")
+        finally:
+            await git(f"branch -D {TMP_STACK_BRANCH}")
 
     pull = known_changeids.get(changeid)
     if pull and pull["head"]["sha"] == commit:
@@ -536,12 +533,6 @@ async def stack(  # noqa: PLR0913,PLR0914,PLR0915,PLR0917
                 await git(f"pull --rebase {remote} {base_branch}")
             console.log(f"branch `{dest_branch}` rebased on `{remote}/{base_branch}`")
 
-        with console.status(
-            f"Pushing branch `{dest_branch}` to `{remote}/{stack_prefix}/aio`...",
-        ):
-            await git(f"push -f {remote} {dest_branch}:{stack_prefix}/aio")
-        console.log(f"branch `{dest_branch}` pushed to `{remote}/{stack_prefix}/aio` ")
-
     base_commit_sha = await git(f"merge-base --fork-point {remote}/{base_branch}")
     if not base_commit_sha:
         console.log(
@@ -587,6 +578,7 @@ async def stack(  # noqa: PLR0913,PLR0914,PLR0915,PLR0917
                     get_changeid_and_pull(client, user, stack_prefix, ref),
                 )
                 for ref in refs
+                # For backward compat
                 if not ref["ref"].endswith("/aio")
             ]
             if tasks:
@@ -621,6 +613,7 @@ async def stack(  # noqa: PLR0913,PLR0914,PLR0915,PLR0917
             if continue_create_or_update:
                 pull, action = await create_or_update_stack(
                     client,
+                    remote,
                     stacked_base_branch,
                     stacked_dest_branch,
                     changeid,

--- a/mergify_cli/tests/test_mergify_cli.py
+++ b/mergify_cli/tests/test_mergify_cli.py
@@ -122,7 +122,6 @@ async def test_stack_create(
         200,
         json=[],
     )
-    respx_mock.post("/repos/user/repo/git/refs").respond(200, json={})
     post_pull1_mock = respx_mock.post(
         "/repos/user/repo/pulls",
         json__title="Title commit 1",
@@ -232,7 +231,6 @@ async def test_stack_create_single_pull(
         200,
         json=[],
     )
-    respx_mock.post("/repos/user/repo/git/refs").respond(200, json={})
     post_pull_mock = respx_mock.post(
         "/repos/user/repo/pulls",
         json__title="Title commit 1",
@@ -311,9 +309,6 @@ async def test_stack_update_no_rebase(
             },
         ],
     )
-    respx_mock.patch(
-        "/repos/user/repo/git/refs/heads//current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
-    ).respond(200, json={})
     patch_pull_mock = respx_mock.patch("/repos/user/repo/pulls/123").respond(
         200,
         json={},
@@ -390,9 +385,6 @@ async def test_stack_update(
             },
         ],
     )
-    respx_mock.patch(
-        "/repos/user/repo/git/refs/heads//current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
-    ).respond(200, json={})
     patch_pull_mock = respx_mock.patch("/repos/user/repo/pulls/123").respond(
         200,
         json={},
@@ -469,9 +461,6 @@ async def test_stack_update_keep_title_and_body(
             },
         ],
     )
-    respx_mock.patch(
-        "/repos/user/repo/git/refs/heads//current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
-    ).respond(200, json={})
     patch_pull_mock = respx_mock.patch("/repos/user/repo/pulls/123").respond(
         200,
         json={},

--- a/mergify_cli/tests/utils.py
+++ b/mergify_cli/tests/utils.py
@@ -60,3 +60,9 @@ class GitMock:
             "log --format='%H' base_commit_sha..current-branch",
             "\n".join(c["sha"] for c in reversed(self._commits)),
         )
+        self.mock(f"branch mergify-cli-tmp {commit['sha']}", "")
+        self.mock("branch -D mergify-cli-tmp", "")
+        self.mock(
+            f"push -f origin mergify-cli-tmp:/current-branch/{commit['change_id']}",
+            "",
+        )


### PR DESCRIPTION
This branch does not need to be synced remotely.

This change instead creates a temporary branch for commit and push this one.