### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -54,3 +54,15 @@ pull_request_rules:
       request_reviews:
         teams:
           - devs
+
+  - name: changelog requirements
+    conditions:
+      - base=main
+    actions:
+      post_check:
+        title: |
+          {% if check_succeed %}
+          Changelog requirements are present.
+          {% else %}
+          Changelog requirements are missing.
+          {% endif %}


### PR DESCRIPTION
This change has been made by @lecrepont01 from Mergify config editor.

Overrides changelog base rule from `Mergifyio/github` because there is no changelog in repo.