### PR TITLE
feat: detect target branch using standard Git configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,8 @@ ignore = [
     "S404",
     # NOTE(charly): `subprocess` call with `shell=True`
     "S602",
+    # NOTE(jd): likely a false positive https://github.com/PyCQA/bandit/issues/333
+    "S603",
     # NOTE(charly): Starting a process with a partial executable path
     "S607",
     # NOTE(charly): Boolean-typed positional argument in function definition.


### PR DESCRIPTION
The current code forces the user to choose a single target branch which
prevents stacks from working on multiple target branches. This leverage
the standard git configuration to retrieve the target branch.

Change-Id: Ia1455d68eaa76af503b6e6cf4c24c19efcdd9b7b