### PR TITLE
fix: always manage depends-on

### DIFF
--- a/mergify_cli/tests/test_mergify_cli.py
+++ b/mergify_cli/tests/test_mergify_cli.py
@@ -498,6 +498,7 @@ async def test_stack_update_keep_title_and_body(
                 "state": "open",
                 "draft": False,
                 "node_id": "",
+                "body": "DONT TOUCH ME\n\nDepends-On: #12345\n",
             },
         ],
     )
@@ -531,6 +532,7 @@ async def test_stack_update_keep_title_and_body(
     assert json.loads(patch_pull_mock.calls.last.request.content) == {
         "head": "/current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
         "base": "main",
+        "body": "DONT TOUCH ME",
     }
 
 


### PR DESCRIPTION
If --keep-pull-request-title-and-body is used, body was not updated.
If a dependant PR is closed/deleted, the depends-on is not removed.

Even if the option intent is to keep the PR description as-is. But
mergify cli should continue to manage the Depends-On to avoid issues.