### PR TITLE
fix: correctly get the target remote

### DIFF
--- a/mergify_cli/__init__.py
+++ b/mergify_cli/__init__.py
@@ -443,7 +443,7 @@ async def git_get_target_branch(branch: str) -> str:
     )
 
 
-async def git_get_remote_for_branch(branch: str) -> str:
+async def git_get_target_remote(branch: str) -> str:
     return await git("config", "--get", "branch." + branch + ".remote")
 
 
@@ -463,15 +463,16 @@ async def get_trunk() -> str:
             style="red",
         )
         raise
+
     try:
-        remote = await git_get_remote_for_branch(target_branch)
+        target_remote = await git_get_target_remote(branch_name)
     except CommandError:
         console.print(
-            f"error: can't get the remote for branch {target_branch}",
+            f"error: can't get the target remote for branch {branch_name}",
             style="red",
         )
         raise
-    return f"{remote}/{target_branch}"
+    return f"{target_remote}/{target_branch}"
 
 
 def trunk_type(trunk: str) -> tuple[str, str]:

--- a/mergify_cli/tests/test_mergify_cli.py
+++ b/mergify_cli/tests/test_mergify_cli.py
@@ -98,8 +98,8 @@ async def test_get_target_branch() -> None:
 
 
 @pytest.mark.usefixtures("_git_repo")
-async def test_get_remote_for_branch() -> None:
-    assert await mergify_cli.git_get_remote_for_branch("main") == "origin"
+async def test_get_target_remote() -> None:
+    assert await mergify_cli.git_get_target_remote("main") == "origin"
 
 
 @pytest.mark.usefixtures("_git_repo")


### PR DESCRIPTION
In `git `<branch>` --set-upstream-to=<target_remote>/<target_branch>`:
* `target_remote` is `git config branch.<branch>.remote`
* `target_branch` is `git config branch.<branch>.merge`

Before this change, the code was getting the `target_remote` from `git config branch.<target_branch>.remote` which is wrong.