### PR TITLE
feat: add helper to interactively rebase the stack

### DIFF
--- a/mergify_cli/tests/utils.py
+++ b/mergify_cli/tests/utils.py
@@ -46,6 +46,14 @@ class GitMock:
         msg = f"git_mock called with `{args}`, not mocked!"
         raise AssertionError(msg)
 
+    def default_cli_args(self) -> None:
+        self.mock("config", "--get", "mergify-cli.github-server", output="")
+        self.mock("config", "--get", "mergify-cli.stack-keep-pr-title-body", output="")
+        self.mock("config", "--get", "branch.current-branch.merge", output="")
+        self.mock("config", "--get", "branch.current-branch.remote", output="")
+        self.mock("config", "--get", "mergify-cli.stack-branch-prefix", output="")
+        self.mock("merge-base", "--fork-point", "origin/main", output="")
+
     def commit(self, commit: Commit) -> None:
         self._commits.append(commit)
 


### PR DESCRIPTION
This adds `mergify stack edit` to interactively rebase the stack.

Add `mergify stack` becomes `mergify stack push`

`mergify stack push` being the default when `mergify` or `mergify stack`
is used.