### PR TITLE
fix(cli): don't use lambda for default

### DIFF
--- a/mergify_cli/stack/cli.py
+++ b/mergify_cli/stack/cli.py
@@ -76,7 +76,7 @@ async def edit() -> None:
     "--keep-pull-request-title-and-body",
     "-k",
     is_flag=True,
-    default=lambda: asyncio.run(utils.get_default_keep_pr_title_body()),
+    default=asyncio.run(utils.get_default_keep_pr_title_body()),
     help="Don't update the title and body of already opened pull requests. "
     "Default fetched from git config if added with `git config --add mergify-cli.stack-keep-pr-title-body true`",
 )
@@ -88,7 +88,7 @@ async def edit() -> None:
     "--trunk",
     "-t",
     type=click.UNPROCESSED,
-    default=lambda: asyncio.run(utils.get_trunk()),
+    default=asyncio.run(utils.get_trunk()),
     callback=trunk_type,
     help="Change the target branch of the stack.",
 )
@@ -169,7 +169,7 @@ async def push(  # noqa: PLR0913, PLR0917
     "--trunk",
     "-t",
     type=click.UNPROCESSED,
-    default=lambda: asyncio.run(utils.get_trunk()),
+    default=asyncio.run(utils.get_trunk()),
     callback=trunk_type,
     help="Change the target branch of the stack.",
 )


### PR DESCRIPTION
Using callable in option default has a particular meaning for click.
I though it only lazy loads the default, but it has a special meaning
for Click call Dynamic Default, it overrides the value passed in the cli
arguments.

This changes remove them.