### PR TITLE
fix(release): add gh token to env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,16 @@ jobs:
       - name: Get version
         run: |
           echo "version=$(date +'%Y.%m.%d.%H.%M')" >> "$GITHUB_ENV"
-      - run: |
-          git tag $version
-          git push origin $version
-          pip install poetry
-          poetry self add poetry-dynamic-versioning[plugin]
-          poetry install --sync
-          poetry build
-          gh release create --generate-notes $version ./dist/*
+      - name: Tag and release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+            git tag $version
+            git push origin $version
+            pip install poetry
+            poetry self add poetry-dynamic-versioning[plugin]
+            poetry install --sync
+            poetry build
+            gh release create --generate-notes $version ./dist/*
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Release script is failing, asking to set the GH_TOKEN env variable to use gh CLI. This adds it in the step.
https://cli.github.com/manual/gh_auth_login
