### PR TITLE
fix(chore): use a callable for defaults

### DIFF
--- a/mergify_cli/cli.py
+++ b/mergify_cli/cli.py
@@ -70,11 +70,11 @@ async def get_default_token() -> str:
 @click.version_option(VERSION)
 @click.option(
     "--github-server",
-    default=asyncio.run(get_default_github_server()),
+    default=lambda: asyncio.run(get_default_github_server()),
 )
 @click.option(
     "--token",
-    default=asyncio.run(get_default_token()),
+    default=lambda: asyncio.run(get_default_token()),
     help="GitHub personal access token",
 )
 @click.pass_context

--- a/mergify_cli/stack/cli.py
+++ b/mergify_cli/stack/cli.py
@@ -75,7 +75,9 @@ async def edit() -> None:
     "--keep-pull-request-title-and-body",
     "-k",
     is_flag=True,
-    default=asyncio.run(utils.get_default_keep_pr_title_body()),
+    # NOTE: `flag_value` here is used to allow the default's lazy loading with `is_flag`
+    flag_value=True,
+    default=lambda: asyncio.run(utils.get_default_keep_pr_title_body()),
     help="Don't update the title and body of already opened pull requests. "
     "Default fetched from git config if added with `git config --add mergify-cli.stack-keep-pr-title-body true`",
 )
@@ -87,7 +89,7 @@ async def edit() -> None:
     "--trunk",
     "-t",
     type=click.UNPROCESSED,
-    default=asyncio.run(utils.get_trunk()),
+    default=lambda: asyncio.run(utils.get_trunk()),
     callback=trunk_type,
     help="Change the target branch of the stack.",
 )
@@ -168,7 +170,7 @@ async def push(  # noqa: PLR0913, PLR0917
     "--trunk",
     "-t",
     type=click.UNPROCESSED,
-    default=asyncio.run(utils.get_trunk()),
+    default=lambda: asyncio.run(utils.get_trunk()),
     callback=trunk_type,
     help="Change the target branch of the stack.",
 )


### PR DESCRIPTION
Without a callable the defaults are evaluated on import which causes unexpected errors with other commands.
