### PR TITLE
fix: use console print instead of log for annotation

### DIFF
--- a/mergify_cli/ci/junit_upload.py
+++ b/mergify_cli/ci/junit_upload.py
@@ -78,5 +78,8 @@ async def upload(  # noqa: PLR0913, PLR0917
             )
 
     gigid = response.json()["gigid"]
-    console.log(f"::notice title=CI Issues report::CI_ISSUE_GIGID={gigid}")
+    console.print(
+        f"::notice title=CI Issues report::CI_ISSUE_GIGID={gigid}",
+        soft_wrap=True,
+    )
     console.log("[green]:tada: File(s) uploaded[/]")

--- a/mergify_cli/tests/ci_issues/test_junit_upload.py
+++ b/mergify_cli/tests/ci_issues/test_junit_upload.py
@@ -131,12 +131,16 @@ def test_get_files_to_upload() -> None:
     assert files_to_upload[0][1][1].closed
 
 
-async def test_junit_upload(respx_mock: respx.MockRouter) -> None:
+async def test_junit_upload(
+    respx_mock: respx.MockRouter,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    gigid = "eyJjaV9qb2JfaWQiOjcwNzQyLCJzaWduYXR1cmUiOiI2NjcxN2QwZDdiZjZkMzAxMmFmNGE4NWQ1YTFlZDhmYjNkNDBjYmM4MmZjZjgxZTVmNzEzNzEyZjRlZjIxOTFmIn0="
     respx_mock.post(
         "/v1/repos/user/repo/ci_issues_upload",
     ).respond(
         200,
-        json={"gigid": "1234azertyuiop"},
+        json={"gigid": gigid},
     )
 
     await junit_upload_mod.upload(
@@ -147,6 +151,12 @@ async def test_junit_upload(respx_mock: respx.MockRouter) -> None:
         "ci-test-job",
         "circleci",
         (str(REPORT_XML),),
+    )
+
+    captured = capsys.readouterr()
+    assert (
+        captured.out.split("\n")[0]
+        == f"::notice title=CI Issues report::CI_ISSUE_GIGID={gigid}"
     )
 
 


### PR DESCRIPTION
`console.log` may wrap or add some whitespaces at end of the annotation.
