### PR TITLE
fix: set test.run.id as str

### DIFF
--- a/mergify_cli/ci/junit.py
+++ b/mergify_cli/ci/junit.py
@@ -25,7 +25,7 @@ class InvalidJunitXMLError(Exception):
 
 
 async def junit_to_spans(
-    run_id: int,
+    run_id: str,
     xml_content: bytes,
     test_language: str | None = None,
     test_framework: str | None = None,

--- a/mergify_cli/ci/upload.py
+++ b/mergify_cli/ci/upload.py
@@ -55,10 +55,10 @@ def upload_spans(
             raise UploadError(logstr.getvalue())
 
 
-def connect_traces(run_id: int) -> None:
+def connect_traces(run_id: str) -> None:
     if detector.get_ci_provider() == "github_actions":
         console.print(
-            f"::notice title=Mergify CI::MERGIFY_TEST_RUN_ID={run_id.to_bytes(8, 'big').hex()}",
+            f"::notice title=Mergify CI::MERGIFY_TEST_RUN_ID={run_id}",
             soft_wrap=True,
         )
 
@@ -73,7 +73,7 @@ async def upload(  # noqa: PLR0913, PLR0917
 ) -> None:
     spans = []
 
-    run_id = junit.ID_GENERATOR.generate_span_id()
+    run_id = junit.ID_GENERATOR.generate_span_id().to_bytes(8, "big").hex()
 
     for filename in files:
         try:

--- a/mergify_cli/tests/ci/test_junit.py
+++ b/mergify_cli/tests/ci/test_junit.py
@@ -26,7 +26,7 @@ async def test_parse(
     _get_cicd_pipeline_run_attempt: mock.Mock,
 ) -> None:
     filename = pathlib.Path(__file__).parent / "junit_example.xml"
-    run_id = 32312
+    run_id = (32312).to_bytes(8, "big").hex()
     spans = await junit.junit_to_spans(
         run_id,
         filename.read_bytes(),


### PR DESCRIPTION
OpenTelemetry cannot encode 8 bytes integer in protobuf.