### PR TITLE
refactor: set correct status name

### DIFF
--- a/mergify_cli/ci/junit.py
+++ b/mergify_cli/ci/junit.py
@@ -141,7 +141,7 @@ async def junit_to_spans(
                 testcase.find("failure") is not None
                 or testcase.find("error") is not None
             ):
-                attributes["test.case.result.status"] = "failure"
+                attributes["test.case.result.status"] = "failed"
                 span_status = opentelemetry.trace.Status(
                     status_code=opentelemetry.trace.StatusCode.ERROR,
                 )
@@ -161,7 +161,7 @@ async def junit_to_spans(
                         # We only care about the first failure/error
                         break
             else:
-                attributes["test.case.result.status"] = "success"
+                attributes["test.case.result.status"] = "passed"
                 span_status = opentelemetry.trace.Status(
                     status_code=opentelemetry.trace.StatusCode.OK,
                 )

--- a/mergify_cli/tests/ci/test_junit.py
+++ b/mergify_cli/tests/ci/test_junit.py
@@ -87,7 +87,7 @@ async def test_parse(
         {
             "attributes": {
                 "test.case.name": "Tests.Registration.testCase1",
-                "test.case.result.status": "success",
+                "test.case.result.status": "passed",
                 "test.scope": "case",
                 "test.framework": "unittest",
                 "test.language": "python",
@@ -146,7 +146,7 @@ async def test_parse(
                 "exception.stacktrace": "bip, bip, bip, error!",
                 "exception.type": "ValueError",
                 "test.case.name": "Tests.Registration.testCase3",
-                "test.case.result.status": "failure",
+                "test.case.result.status": "failed",
                 "test.scope": "case",
                 "test.framework": "unittest",
                 "test.language": "python",
@@ -201,7 +201,7 @@ async def test_parse(
         {
             "attributes": {
                 "test.case.name": "Tests.Authentication.testCase7",
-                "test.case.result.status": "success",
+                "test.case.result.status": "passed",
                 "test.scope": "case",
                 "test.framework": "unittest",
                 "test.language": "python",
@@ -229,7 +229,7 @@ async def test_parse(
         {
             "attributes": {
                 "test.case.name": "Tests.Authentication.testCase8",
-                "test.case.result.status": "success",
+                "test.case.result.status": "passed",
                 "test.scope": "case",
                 "test.framework": "unittest",
                 "test.language": "python",
@@ -260,7 +260,7 @@ async def test_parse(
                 "exception.stacktrace": "Such a mess, the failure is unrecoverable",
                 "exception.type": "AssertionError",
                 "test.case.name": "Tests.Authentication.testCase9",
-                "test.case.result.status": "failure",
+                "test.case.result.status": "failed",
                 "test.scope": "case",
                 "test.framework": "unittest",
                 "test.language": "python",
@@ -292,7 +292,7 @@ async def test_parse(
                 "With a second line!",
                 "exception.type": "ZeroDivisionError",
                 "test.case.name": "Tests.Permission.testCase10",
-                "test.case.result.status": "failure",
+                "test.case.result.status": "failed",
                 "test.scope": "case",
                 "test.framework": "unittest",
                 "test.language": "python",
@@ -347,7 +347,7 @@ async def test_parse(
         {
             "attributes": {
                 "test.case.name": "Tests.Authentication.Login.testCase4",
-                "test.case.result.status": "success",
+                "test.case.result.status": "passed",
                 "test.scope": "case",
                 "test.framework": "unittest",
                 "test.language": "python",
@@ -378,7 +378,7 @@ async def test_parse(
                 "exception.stacktrace": "bad syntax, bad!",
                 "exception.type": "SyntaxError",
                 "test.case.name": "Tests.Authentication.Login.testCase5",
-                "test.case.result.status": "failure",
+                "test.case.result.status": "failed",
                 "test.scope": "case",
                 "test.framework": "unittest",
                 "test.language": "python",
@@ -406,7 +406,7 @@ async def test_parse(
         {
             "attributes": {
                 "test.case.name": "Tests.Authentication.Login.testCase6",
-                "test.case.result.status": "success",
+                "test.case.result.status": "passed",
                 "test.scope": "case",
                 "test.framework": "unittest",
                 "test.language": "python",


### PR DESCRIPTION
Use failed/passed.