### PR TITLE
refactor: `envvar` order for `tests-target-branch` option

### DIFF
--- a/mergify_cli/ci/cli.py
+++ b/mergify_cli/ci/cli.py
@@ -65,7 +65,7 @@ ci = click.Group(
     "-ttb",
     help="The branch used to check if failing tests can be ignored with Mergify's Quarantine.",
     required=True,
-    envvar=["GITHUB_BASE_REF", "MERGIFY_TESTS_TARGET_BRANCH", "GITHUB_REF"],
+    envvar=["MERGIFY_TESTS_TARGET_BRANCH", "GITHUB_BASE_REF", "GITHUB_REF"],
     callback=_process_tests_target_branch,
 )
 @click.argument(
@@ -136,7 +136,7 @@ async def junit_upload(  # noqa: PLR0913
     "-ttb",
     help="The branch used to check if failing tests can be ignored with Mergify's Quarantine.",
     required=True,
-    envvar=["GITHUB_BASE_REF", "MERGIFY_TESTS_TARGET_BRANCH", "GITHUB_REF"],
+    envvar=["MERGIFY_TESTS_TARGET_BRANCH", "GITHUB_BASE_REF", "GITHUB_REF"],
     callback=_process_tests_target_branch,
 )
 @click.argument(


### PR DESCRIPTION
This keeps it in sync with the other ways to interact with the
quarantine.