### PR TITLE
chore: remove `MERGIFY_TESTS_TARGET_BRANCH` and add `GITHUB_REF_NAME` environment variable

### DIFF
--- a/mergify_cli/ci/cli.py
+++ b/mergify_cli/ci/cli.py
@@ -65,7 +65,7 @@ ci = click.Group(
     "-ttb",
     help="The branch used to check if failing tests can be ignored with Mergify's Quarantine.",
     required=True,
-    envvar=["MERGIFY_TESTS_TARGET_BRANCH", "GITHUB_BASE_REF", "GITHUB_REF"],
+    envvar=["GITHUB_BASE_REF", "GITHUB_REF_NAME", "GITHUB_REF"],
     callback=_process_tests_target_branch,
 )
 @click.argument(
@@ -136,7 +136,7 @@ async def junit_upload(  # noqa: PLR0913
     "-ttb",
     help="The branch used to check if failing tests can be ignored with Mergify's Quarantine.",
     required=True,
-    envvar=["MERGIFY_TESTS_TARGET_BRANCH", "GITHUB_BASE_REF", "GITHUB_REF"],
+    envvar=["GITHUB_BASE_REF", "GITHUB_REF_NAME", "GITHUB_REF"],
     callback=_process_tests_target_branch,
 )
 @click.argument(

--- a/mergify_cli/tests/ci/test_cli.py
+++ b/mergify_cli/tests/ci/test_cli.py
@@ -38,7 +38,7 @@ REPORT_XML = pathlib.Path(__file__).parent / "report.xml"
                 "CIRCLE_REPOSITORY_URL": "https://github.com/user/repo",
                 "CIRCLE_SHA1": "3af96aa24f1d32fcfbb7067793cacc6dc0c6b199",
                 "CIRCLE_JOB": "JOB",
-                "MERGIFY_TESTS_TARGET_BRANCH": "main",
+                "GITHUB_REF_NAME": "main",
             },
             id="CircleCI",
         ),
@@ -132,21 +132,6 @@ def test_cli(env: dict[str, str], monkeypatch: pytest.MonkeyPatch) -> None:
                 "GITHUB_REPOSITORY": "user/repo",
                 "GITHUB_SHA": "3af96aa24f1d32fcfbb7067793cacc6dc0c6b199",
                 "GITHUB_WORKFLOW": "JOB",
-                "MERGIFY_TESTS_TARGET_BRANCH": "develop",
-                "GITHUB_REF": "refs/heads/feature-branch",
-            },
-            "develop",
-            id="MERGIFY_TESTS_TARGET_BRANCH takes precedence over GITHUB_REF",
-        ),
-        pytest.param(
-            {
-                "GITHUB_EVENT_NAME": "push",
-                "GITHUB_ACTIONS": "true",
-                "MERGIFY_API_URL": "https://api.mergify.com",
-                "MERGIFY_TOKEN": "abc",
-                "GITHUB_REPOSITORY": "user/repo",
-                "GITHUB_SHA": "3af96aa24f1d32fcfbb7067793cacc6dc0c6b199",
-                "GITHUB_WORKFLOW": "JOB",
                 "GITHUB_REF": "refs/tags/v1.0.0",
             },
             "refs/tags/v1.0.0",
@@ -160,7 +145,11 @@ def test_tests_target_branch_environment_variable_processing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that tests_target_branch environment variable processing works correctly."""
-    for key in ["GITHUB_REF", "GITHUB_BASE_REF"]:  # Override value from CI runner
+    for key in [
+        "GITHUB_REF",
+        "GITHUB_REF_NAME",
+        "GITHUB_BASE_REF",
+    ]:  # Override value from CI runner
         monkeypatch.delenv(key, raising=False)
 
     for key, value in env.items():


### PR DESCRIPTION
It shouldn't be necessary to configure this `MERGIFY_TESTS_TARGET_BRANCH` variable manually.