### PR TITLE
fix: modify commit-msg hook to work with verbose commits

### DIFF
--- a/mergify_cli/stack/hooks/commit-msg
+++ b/mergify_cli/stack/hooks/commit-msg
@@ -39,7 +39,8 @@ dest="$1.tmp.${random}"
 
 trap 'rm -f "${dest}"' EXIT
 
-if ! git stripspace --strip-comments < "$1" > "${dest}" ; then
+# cut everything from the scissor marker downwards, then strip comments/whitespace
+if ! (sed '/^# -\{24\} >8 -\{24\}$/,$d' | git stripspace --strip-comments) < "$1" > "${dest}" ; then
    echo "cannot strip comments from $1"
    exit 1
 fi


### PR DESCRIPTION
Small suggestion for the commit-msg hook to strip everything below the scissor line (added by [`git commit -v`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---verbose)) before stripping all of the comments. If this doesn't get stripped the commit message will never be detected as empty because of the diff below the scissor line (which are not comments).

This change is merely a suggestion, feel free to take it and modify it as you see fit. Preferably it would also check the `--cleanup`/`git config commit.cleanup` option and only strip as much as that specifies but that's maybe something for in the future.

Tested `git commit` with and without `-v`, and with and without a commit message.