### PR TITLE
feat(setup): install skill stub to .agents/skills/ for multi-agent support

### DIFF
--- a/mergify_cli/stack/cli.py
+++ b/mergify_cli/stack/cli.py
@@ -176,7 +176,7 @@ def _print_hooks_status(status: dict[str, Any]) -> None:
 
     # Skill stub section
     skill_stub = claude_hooks["skill_stub"]
-    console.print("  skill stub:")
+    console.print("  skill stub (.agents/skills/):")
     if skill_stub["installed"]:
         if skill_stub["needs_update"]:
             console.print(
@@ -187,6 +187,24 @@ def _print_hooks_status(status: dict[str, Any]) -> None:
             console.print(
                 f"    Status: [green]up to date[/] ({skill_stub['path']})",
             )
+    else:
+        console.print("    Status: [red]not installed[/]")
+        needs_setup = True
+    console.print()
+
+    # Claude symlink section
+    skill_symlink = claude_hooks["skill_symlink"]
+    console.print("  claude skill symlink:")
+    if skill_symlink["installed"]:
+        if skill_symlink["correct"]:
+            console.print(
+                f"    Status: [green]up to date[/] ({skill_symlink['path']})",
+            )
+        else:
+            console.print(
+                f"    Status: [yellow]needs update[/] ({skill_symlink['path']})",
+            )
+            needs_setup = True
     else:
         console.print("    Status: [red]not installed[/]")
         needs_setup = True
@@ -219,7 +237,7 @@ def _print_hooks_status(status: dict[str, Any]) -> None:
     "--global",
     "global_install",
     is_flag=True,
-    help="Also install AI skill stub globally (~/.claude/skills/)",
+    help="Also install AI skill stub globally (~/.agents/skills/)",
 )
 @utils.run_with_asyncio
 async def hooks(*, do_setup: bool, force: bool, global_install: bool) -> None:
@@ -246,7 +264,7 @@ async def hooks(*, do_setup: bool, force: bool, global_install: bool) -> None:
     "--global",
     "global_install",
     is_flag=True,
-    help="Also install AI skill stub globally (~/.claude/skills/)",
+    help="Also install AI skill stub globally (~/.agents/skills/)",
 )
 @utils.run_with_asyncio
 async def setup(*, force: bool, check: bool, global_install: bool) -> None:

--- a/mergify_cli/stack/setup.py
+++ b/mergify_cli/stack/setup.py
@@ -19,6 +19,7 @@ import enum
 import importlib.resources
 import importlib.resources.abc
 import json
+import os
 import pathlib
 import shutil
 from typing import TYPE_CHECKING
@@ -71,11 +72,22 @@ def _get_wrapper_resource(hook_name: str) -> importlib.resources.abc.Traversable
 
 def _get_global_skill_stub_path() -> pathlib.Path:
     """Get the global path for the Mergify stack skill stub file."""
-    return pathlib.Path.home() / ".claude" / "skills" / "mergify-stack" / "SKILL.md"
+    return pathlib.Path.home() / ".agents" / "skills" / "mergify-stack" / "SKILL.md"
 
 
 async def _get_project_skill_stub_path() -> pathlib.Path:
     """Get the project-level path for the skill stub file."""
+    project_root = pathlib.Path(await utils.git("rev-parse", "--show-toplevel"))
+    return project_root / ".agents" / "skills" / "mergify-stack" / "SKILL.md"
+
+
+def _get_global_claude_symlink_path() -> pathlib.Path:
+    """Get the global Claude Code symlink path for the skill stub."""
+    return pathlib.Path.home() / ".claude" / "skills" / "mergify-stack" / "SKILL.md"
+
+
+async def _get_project_claude_symlink_path() -> pathlib.Path:
+    """Get the project-level Claude Code symlink path for the skill stub."""
     project_root = pathlib.Path(await utils.git("rev-parse", "--show-toplevel"))
     return project_root / ".claude" / "skills" / "mergify-stack" / "SKILL.md"
 
@@ -110,7 +122,7 @@ def _install_skill_stub(
         if existing_content == _SKILL_STUB_CONTENT:
             if verbose:
                 console.print(
-                    f"  ✅ Skill stub: up to date ({skill_stub_path})",
+                    f"  ✓ Skill stub: up to date ({skill_stub_path})",
                     style="green",
                 )
             return
@@ -118,10 +130,47 @@ def _install_skill_stub(
     skill_stub_path.write_text(_SKILL_STUB_CONTENT, encoding="utf-8")
     if verbose:
         action = "updated" if is_update else "installed"
-        emoji = "🔄" if is_update else "📦"
         console.print(
-            f"  {emoji} Skill stub: {action} ({skill_stub_path})",
+            f"  ✓ Skill stub: {action} ({skill_stub_path})",
             style="bold green",
+        )
+
+
+def _install_skill_symlink(
+    symlink_path: pathlib.Path,
+    target_path: pathlib.Path,
+    *,
+    verbose: bool = False,
+) -> None:
+    """Create a symlink from symlink_path to target_path using a relative path.
+
+    Handles migration from existing real files and broken symlinks.
+    Only acts if the symlink doesn't exist or points to the wrong target.
+    """
+    symlink_path.parent.mkdir(parents=True, exist_ok=True)
+
+    rel_target = os.path.relpath(target_path, symlink_path.parent)
+
+    # Check if symlink already correct
+    if symlink_path.is_symlink():
+        if str(symlink_path.readlink()) == rel_target:
+            if verbose:
+                console.print(
+                    f"  ✓ Skill symlink: up to date ({symlink_path})",
+                    style="green",
+                )
+            return
+        # Wrong target — remove and recreate
+        symlink_path.unlink()
+    elif symlink_path.exists():
+        # Real file exists (migration case) — remove it
+        symlink_path.unlink()
+
+    symlink_path.symlink_to(rel_target)
+    if verbose:
+        console.print(
+            f"  ✓ Skill symlink: installed ({symlink_path} -> {rel_target})",
+            style="bold cyan",
         )
 
 
@@ -143,6 +192,27 @@ def _get_skill_stub_status(skill_stub_path: pathlib.Path) -> dict[str, Any]:
         "needs_update": needs_update,
         "path": str(skill_stub_path),
     }
+
+
+def _get_skill_symlink_status(
+    symlink_path: pathlib.Path,
+    target_path: pathlib.Path,
+) -> dict[str, Any]:
+    """Get status of the skill symlink.
+
+    Returns:
+        Dictionary with 'installed', 'correct', and 'path' keys.
+    """
+    if not symlink_path.is_symlink() and not symlink_path.exists():
+        return {"installed": False, "correct": False, "path": str(symlink_path)}
+
+    if not symlink_path.is_symlink():
+        # Real file exists — needs migration
+        return {"installed": True, "correct": False, "path": str(symlink_path)}
+
+    rel_target = os.path.relpath(target_path, symlink_path.parent)
+    correct = str(symlink_path.readlink()) == rel_target
+    return {"installed": True, "correct": correct, "path": str(symlink_path)}
 
 
 def _get_claude_hooks_dir() -> pathlib.Path:
@@ -390,6 +460,7 @@ def _install_claude_hooks(*, verbose: bool = False) -> None:
 
 def _get_claude_hooks_status(
     project_skill_stub_path: pathlib.Path,
+    project_claude_symlink_path: pathlib.Path,
 ) -> dict[str, Any]:
     """Get detailed status of Claude hooks for display.
 
@@ -427,6 +498,10 @@ def _get_claude_hooks_status(
         "settings_installed": settings_installed,
         "settings_path": str(settings_file),
         "skill_stub": _get_skill_stub_status(project_skill_stub_path),
+        "skill_symlink": _get_skill_symlink_status(
+            project_claude_symlink_path,
+            project_skill_stub_path,
+        ),
     }
 
 
@@ -439,6 +514,7 @@ async def get_hooks_status() -> dict[str, Any]:
     hooks_dir = await _get_hooks_dir()
     managed_dir = hooks_dir / "mergify-hooks"
     project_skill_stub_path = await _get_project_skill_stub_path()
+    project_claude_symlink = await _get_project_claude_symlink_path()
 
     git_hooks = {}
     for hook_name in _get_git_hook_names():
@@ -463,7 +539,10 @@ async def get_hooks_status() -> dict[str, Any]:
 
     return {
         "git_hooks": git_hooks,
-        "claude_hooks": _get_claude_hooks_status(project_skill_stub_path),
+        "claude_hooks": _get_claude_hooks_status(
+            project_skill_stub_path,
+            project_claude_symlink,
+        ),
     }
 
 
@@ -480,15 +559,30 @@ async def stack_setup(*, force: bool = False, global_install: bool = False) -> N
         _install_git_hook(hooks_dir, hook_name, force=force)
 
     # Install Claude hooks for session ID tracking (global)
-    console.print("\n🤖 Claude Code integration:", style="bold")
+    console.print("\nClaude Code integration:", style="bold")
     _install_claude_hooks(verbose=True)
 
-    # Install skill stub for AI tool bootstrapping (project-level)
+    # Install skill stub to .agents/skills/ (agent-agnostic)
+    console.print("\nAI skill stub:", style="bold")
     project_skill_stub_path = await _get_project_skill_stub_path()
     _install_skill_stub(project_skill_stub_path, verbose=True)
 
+    # Symlink from .claude/skills/ for Claude Code
+    project_claude_symlink = await _get_project_claude_symlink_path()
+    _install_skill_symlink(
+        project_claude_symlink,
+        project_skill_stub_path,
+        verbose=True,
+    )
+
     if global_install:
-        _install_skill_stub(_get_global_skill_stub_path(), verbose=True)
+        global_stub_path = _get_global_skill_stub_path()
+        _install_skill_stub(global_stub_path, verbose=True)
+        _install_skill_symlink(
+            _get_global_claude_symlink_path(),
+            global_stub_path,
+            verbose=True,
+        )
 
 
 async def ensure_hooks_updated() -> None:

--- a/mergify_cli/tests/stack/test_skill.py
+++ b/mergify_cli/tests/stack/test_skill.py
@@ -98,7 +98,7 @@ def test_skill_stub_install(
     tmp_path: pathlib.Path,
 ) -> None:
     """Verify _install_skill_stub creates the file with correct content."""
-    stub_path = tmp_path / ".claude" / "skills" / "mergify-stack" / "SKILL.md"
+    stub_path = tmp_path / ".agents" / "skills" / "mergify-stack" / "SKILL.md"
     assert not stub_path.exists()
 
     stack_setup_mod._install_skill_stub(stub_path)
@@ -117,10 +117,72 @@ def test_skill_stub_updates_when_content_differs(
     tmp_path: pathlib.Path,
 ) -> None:
     """Verify _install_skill_stub updates the file when content differs."""
-    stub_path = tmp_path / ".claude" / "skills" / "mergify-stack" / "SKILL.md"
+    stub_path = tmp_path / ".agents" / "skills" / "mergify-stack" / "SKILL.md"
     stub_path.parent.mkdir(parents=True)
     stub_path.write_text("old content", encoding="utf-8")
 
     stack_setup_mod._install_skill_stub(stub_path)
 
     assert stub_path.read_text(encoding="utf-8") == stack_setup_mod._SKILL_STUB_CONTENT
+
+
+def test_claude_symlink_created(tmp_path: pathlib.Path) -> None:
+    """Symlink at .claude/skills/ points to .agents/skills/ canonical file."""
+    canonical = tmp_path / ".agents" / "skills" / "mergify-stack" / "SKILL.md"
+    symlink = tmp_path / ".claude" / "skills" / "mergify-stack" / "SKILL.md"
+
+    stack_setup_mod._install_skill_stub(canonical)
+    stack_setup_mod._install_skill_symlink(symlink, canonical)
+
+    assert symlink.is_symlink()
+    assert symlink.resolve() == canonical.resolve()
+    assert symlink.read_text(encoding="utf-8") == stack_setup_mod._SKILL_STUB_CONTENT
+
+
+def test_migration_replaces_real_file_with_symlink(tmp_path: pathlib.Path) -> None:
+    """Existing real file at .claude/skills/ is replaced by symlink."""
+    canonical = tmp_path / ".agents" / "skills" / "mergify-stack" / "SKILL.md"
+    symlink = tmp_path / ".claude" / "skills" / "mergify-stack" / "SKILL.md"
+
+    symlink.parent.mkdir(parents=True)
+    symlink.write_text(stack_setup_mod._SKILL_STUB_CONTENT, encoding="utf-8")
+    assert not symlink.is_symlink()
+
+    stack_setup_mod._install_skill_stub(canonical)
+    stack_setup_mod._install_skill_symlink(symlink, canonical)
+
+    assert symlink.is_symlink()
+    assert symlink.resolve() == canonical.resolve()
+
+
+def test_broken_symlink_recreated(tmp_path: pathlib.Path) -> None:
+    """Broken symlink is replaced with a correct one."""
+    canonical = tmp_path / ".agents" / "skills" / "mergify-stack" / "SKILL.md"
+    symlink = tmp_path / ".claude" / "skills" / "mergify-stack" / "SKILL.md"
+
+    symlink.parent.mkdir(parents=True)
+    symlink.symlink_to("/nonexistent/path/SKILL.md")
+    assert symlink.is_symlink()
+    assert not symlink.exists()
+
+    stack_setup_mod._install_skill_stub(canonical)
+    stack_setup_mod._install_skill_symlink(symlink, canonical)
+
+    assert symlink.is_symlink()
+    assert symlink.exists()
+    assert symlink.read_text(encoding="utf-8") == stack_setup_mod._SKILL_STUB_CONTENT
+
+
+def test_symlink_install_idempotent(tmp_path: pathlib.Path) -> None:
+    """Running symlink install twice is a no-op."""
+    canonical = tmp_path / ".agents" / "skills" / "mergify-stack" / "SKILL.md"
+    symlink = tmp_path / ".claude" / "skills" / "mergify-stack" / "SKILL.md"
+
+    stack_setup_mod._install_skill_stub(canonical)
+    stack_setup_mod._install_skill_symlink(symlink, canonical)
+
+    original_target = symlink.readlink()
+
+    stack_setup_mod._install_skill_symlink(symlink, canonical)
+
+    assert symlink.readlink() == original_target


### PR DESCRIPTION
Move the canonical SKILL.md stub from .claude/skills/ to .agents/skills/
which is discoverable by Cursor, Copilot, Cline, and other coding agents.
Claude Code gets a relative symlink from .claude/skills/.

Existing real files at .claude/skills/ are automatically migrated to
symlinks on next setup.