### PR TITLE
feat(stack): add common-mistakes and conflict-resolution to skill

### DIFF
--- a/mergify_cli/stack/skill.md
+++ b/mergify_cli/stack/skill.md
@@ -28,6 +28,17 @@ A branch is a stack. Keep stacks short and focused:
 - **Draft PRs**: NEVER mark a PR as ready-for-review — all PRs stay as drafts. The user will manually move them out of draft after reviewing.
 - **Each commit must pass CI independently**: Every commit in a stack becomes its own PR. Each PR runs CI separately, so every commit must be self-contained — it must compile, pass linters, and pass tests on its own without depending on later commits in the stack. When formatting or linting fixes are needed, they must be included in the commit that introduced the issue, not deferred to a later commit.
 
+## Common Mistakes
+
+| Wrong | Right | Why |
+|-------|-------|-----|
+| `git push` | `mergify stack push` | Git push bypasses stack management and breaks PR relationships |
+| New commit to fix lint/typo | `git commit --amend` (HEAD) or `git commit --fixup <SHA>` + `git rebase --autosquash` (mid-stack) | Each commit = a PR; fix commits create unwanted extra PRs |
+| `gh pr edit --title "..."` | Edit the commit message, then `mergify stack push` | PR title/body are overwritten from commit messages on every push |
+| `gh pr merge` or `gh pr close` | PR lifecycle is fully managed — do nothing | PR lifecycle is fully managed by the stack tool |
+| `git commit` on `main` | `mergify stack new <name>` first | `mergify stack push` will fail on the default branch |
+| Deferring lint fixes to a later commit | Include the fix in the commit that caused it | Each commit runs CI independently; later commits won't save earlier ones |
+
 ## Commands
 
 ```bash
@@ -41,10 +52,11 @@ Use `mergify stack list` to see which commits have been pushed, which PRs they m
 
 ## CRITICAL: Check Branch Before ANY Commit
 
-**BEFORE staging or committing anything**, always check:
+**BEFORE staging or committing anything**, always check the current branch and assess stack state:
 
 ```bash
 git branch --show-current
+mergify stack list
 ```
 
 - If you're on `main` (or the repo's default branch): you **MUST** create a feature branch first
@@ -68,3 +80,15 @@ When continuing work on an existing feature branch:
 1. **Check current branch**: `git branch --show-current`
    - If on the right branch: proceed with commits
    - If on `main`: switch to the feature branch first with `git checkout <branch>` or create a new stack
+
+## Conflict Resolution
+
+When a rebase causes conflicts (during `git rebase -i` or `mergify stack push`):
+
+1. Resolve conflicts in your editor
+2. Stage resolved files with `git add`
+3. Continue with `git rebase --continue`
+
+To abort instead: `git rebase --abort`
+
+After resolving, run `mergify stack push` to sync the updated stack.


### PR DESCRIPTION
Add two new sections to the stack skill to reduce agent errors:
- "Common Mistakes" table with wrong/right/why patterns for the 6 most
  frequent agent errors (git push, fix commits, manual PR edits, etc.)
- "Conflict Resolution" guide for rebase conflict handling

Also enhance the CRITICAL section to include `mergify stack list` as
part of the pre-operation check, so agents assess stack state before
acting.