### PR TITLE
feat: add inline CI, review, and merge status to `mergify stack list`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Agent Instructions
+
+## CLI Output Style
+
+Use compact Unicode symbols for terminal output, not emoji. This keeps new and
+updated terminal output consistent and avoids rendering issues across terminals.
+
+**Preferred symbols:**
+- `✓` success, approved, merged
+- `✗` failure, conflict, changes requested
+- `●` active, pending, in progress
+- `○` inactive, skipped, none
+- `—` unknown, not applicable
+
+**Avoid in terminal output:** `✅`, `❌`, `🟢`, `🔴`, `📝`, `⚠️`, `🔄`, `📦`, `🤖`, `🔗`
+and other emoji. They can render at inconsistent widths across terminals and
+break column alignment.
+
+**Exception:** Emoji are acceptable in markdown output destined for GitHub
+(PR comments, CI summaries) where they render consistently.

--- a/mergify_cli/github_types.py
+++ b/mergify_cli/github_types.py
@@ -20,6 +20,7 @@ class PullRequest(typing.TypedDict):
     node_id: str
     merged_at: str | None
     merge_commit_sha: str | None
+    mergeable: bool | None
 
 
 class Comment(typing.TypedDict):

--- a/mergify_cli/stack/cli.py
+++ b/mergify_cli/stack/cli.py
@@ -22,6 +22,7 @@ from mergify_cli.stack import push as stack_push_mod
 from mergify_cli.stack import session as stack_session_mod
 from mergify_cli.stack import setup as stack_setup_mod
 from mergify_cli.stack import skill as stack_skill_mod
+from mergify_cli.stack import sync as stack_sync_mod
 
 
 def trunk_type(
@@ -502,6 +503,38 @@ async def session(*, commit: str, launch: bool) -> None:
 @stack.command(help="Output the AI skill for the Mergify stack workflow")
 def skill() -> None:
     click.echo(stack_skill_mod.get_skill_content(), nl=False)
+
+
+@stack.command(help="Sync the stack: fetch trunk, remove merged commits, rebase")
+@click.pass_context
+@click.option(
+    "--dry-run",
+    "-n",
+    is_flag=True,
+    default=False,
+    help="Show what would happen without making changes",
+)
+@click.option(
+    "--trunk",
+    "-t",
+    type=click.UNPROCESSED,
+    default=lambda: asyncio.run(utils.get_trunk()),
+    callback=trunk_type,
+    help="Change the target branch of the stack.",
+)
+@utils.run_with_asyncio
+async def sync(
+    ctx: click.Context,
+    *,
+    dry_run: bool,
+    trunk: tuple[str, str],
+) -> None:
+    await stack_sync_mod.stack_sync(
+        github_server=ctx.obj["github_server"],
+        token=ctx.obj["token"],
+        trunk=trunk,
+        dry_run=dry_run,
+    )
 
 
 @stack.command(name="list", help="List the stack's commits and their associated PRs")

--- a/mergify_cli/stack/cli.py
+++ b/mergify_cli/stack/cli.py
@@ -553,18 +553,26 @@ async def sync(
     is_flag=True,
     help="Output in JSON format for scripting",
 )
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="Show detailed CI check names and reviewer names",
+)
 @utils.run_with_asyncio
 async def list_cmd(
     ctx: click.Context,
     *,
     trunk: tuple[str, str],
     output_json: bool,
+    verbose: bool,
 ) -> None:
     await stack_list_mod.stack_list(
         github_server=ctx.obj["github_server"],
         token=ctx.obj["token"],
         trunk=trunk,
         output_json=output_json,
+        verbose=verbose,
     )
 
 

--- a/mergify_cli/stack/hooks/scripts/pre-push.sh
+++ b/mergify_cli/stack/hooks/scripts/pre-push.sh
@@ -40,7 +40,7 @@ if test "$has_change_id" -eq 0; then
 fi
 
 echo ""
-echo "⚠  This branch is managed by Mergify stacks."
+echo "This branch is managed by Mergify stacks."
 echo "   Use 'mergify stack push' instead of 'git push'."
 echo ""
 echo "   'mergify stack push' will:"

--- a/mergify_cli/stack/list.py
+++ b/mergify_cli/stack/list.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import json
 import sys
@@ -28,16 +29,52 @@ from mergify_cli.stack.push import check_local_branch
 
 
 StackEntryStatusT = typing.Literal["merged", "draft", "open", "no_pr"]
+CIStatusT = typing.Literal["passing", "failing", "pending", "unknown"]
+ReviewStatusT = typing.Literal["approved", "changes_requested", "pending", "unknown"]
 
 _STATUS_DISPLAY: dict[StackEntryStatusT, tuple[str, str]] = {
-    "merged": ("merged", "purple"),
-    "draft": ("draft", "yellow"),
-    "open": ("open", "green"),
-    "no_pr": ("no PR", "dim"),
+    "merged": ("✓ merged", "purple"),
+    "draft": ("● draft", "yellow"),
+    "open": ("● open", "green"),
+    "no_pr": ("○ no PR", "dim"),
+}
+
+_CI_STATUS_DISPLAY: dict[CIStatusT, tuple[str, str]] = {
+    "passing": ("✓ passing", "green"),
+    "failing": ("✗ failing", "red"),
+    "pending": ("● pending", "yellow"),
+    "unknown": ("—", "dim"),
+}
+
+_REVIEW_STATUS_DISPLAY: dict[ReviewStatusT, tuple[str, str]] = {
+    "approved": ("✓ approved", "green"),
+    "changes_requested": ("✗ changes requested", "red"),
+    "pending": ("● pending", "yellow"),
+    "unknown": ("—", "dim"),
 }
 
 if typing.TYPE_CHECKING:
+    import httpx
+
     from mergify_cli import github_types
+
+
+@dataclasses.dataclass
+class CICheck:
+    name: str
+    status: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"name": self.name, "status": self.status}
+
+
+@dataclasses.dataclass
+class Review:
+    user: str
+    state: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"user": self.user, "state": self.state}
 
 
 @dataclasses.dataclass
@@ -50,6 +87,11 @@ class StackListEntry:
     status: StackEntryStatusT
     pull_number: int | None = None
     pull_url: str | None = None
+    ci_status: CIStatusT = "unknown"
+    ci_checks: list[CICheck] = dataclasses.field(default_factory=list)
+    review_status: ReviewStatusT = "unknown"
+    reviews: list[Review] = dataclasses.field(default_factory=list)
+    mergeable: bool | None = None
 
     def to_dict(self) -> dict[str, typing.Any]:
         return {
@@ -59,6 +101,11 @@ class StackListEntry:
             "status": self.status,
             "pull_number": self.pull_number,
             "pull_url": self.pull_url,
+            "ci_status": self.ci_status,
+            "ci_checks": [c.to_dict() for c in self.ci_checks],
+            "review_status": self.review_status,
+            "reviews": [r.to_dict() for r in self.reviews],
+            "mergeable": self.mergeable,
         }
 
 
@@ -76,6 +123,40 @@ class StackListOutput:
             "trunk": self.trunk,
             "entries": [e.to_dict() for e in self.entries],
         }
+
+
+def _format_ci_display(entry: StackListEntry, *, verbose: bool) -> str:
+    if entry.ci_status == "unknown":
+        return ""
+    if verbose and entry.ci_checks:
+        checks = []
+        for check in entry.ci_checks:
+            if check.status == "success":
+                checks.append(f"[green]✓ {check.name}[/]")
+            elif check.status == "failure":
+                checks.append(f"[red]✗ {check.name}[/]")
+            else:
+                checks.append(f"[yellow]● {check.name}[/]")
+        return f"CI: {', '.join(checks)}"
+    text, color = _CI_STATUS_DISPLAY[entry.ci_status]
+    return f"CI: [{color}]{text}[/]"
+
+
+def _format_review_display(entry: StackListEntry, *, verbose: bool) -> str:
+    if entry.review_status == "unknown":
+        return ""
+    if verbose and entry.reviews:
+        reviewers = []
+        for review in entry.reviews:
+            if review.state == "APPROVED":
+                reviewers.append(f"[green]✓ {review.user}[/]")
+            elif review.state == "CHANGES_REQUESTED":
+                reviewers.append(f"[red]✗ {review.user}[/]")
+            else:
+                reviewers.append(f"[dim]{review.user}[/]")
+        return f"Review: {', '.join(reviewers)}"
+    text, color = _REVIEW_STATUS_DISPLAY[entry.review_status]
+    return f"Review: [{color}]{text}[/]"
 
 
 def _get_entry_status(
@@ -96,30 +177,151 @@ def _get_status_display(status: StackEntryStatusT) -> tuple[str, str]:
     return _STATUS_DISPLAY[status]
 
 
-def display_stack_list(output: StackListOutput) -> None:
+def _compute_ci_status(
+    check_runs: list[dict[str, typing.Any]],
+) -> tuple[CIStatusT, list[CICheck]]:
+    """Compute CI status from GitHub check run data."""
+    if not check_runs:
+        return ("unknown", [])
+
+    checks: list[CICheck] = []
+    has_pending = False
+    has_failure = False
+
+    for run in check_runs:
+        name = run.get("name", "")
+        if run.get("status") != "completed":
+            checks.append(CICheck(name=name, status="pending"))
+            has_pending = True
+        elif run.get("conclusion") in {"success", "skipped"}:
+            checks.append(CICheck(name=name, status="success"))
+        else:
+            checks.append(CICheck(name=name, status="failure"))
+            has_failure = True
+
+    if has_failure:
+        status: CIStatusT = "failing"
+    elif has_pending:
+        status = "pending"
+    else:
+        status = "passing"
+
+    return (status, checks)
+
+
+def _compute_review_status(
+    reviews_data: list[dict[str, typing.Any]],
+) -> tuple[ReviewStatusT, list[Review]]:
+    """Compute review status from GitHub review data."""
+    if not reviews_data:
+        return ("unknown", [])
+
+    # Keep latest review per user (APPROVED/CHANGES_REQUESTED/DISMISSED
+    # take precedence over COMMENTED)
+    latest_by_user: dict[str, str] = {}
+    for review in reviews_data:
+        user = review.get("user", {}).get("login", "")
+        state = review.get("state", "")
+        if not user:
+            continue
+        if (
+            state in {"APPROVED", "CHANGES_REQUESTED", "DISMISSED"}
+            or user not in latest_by_user
+        ):
+            latest_by_user[user] = state
+
+    reviews = [Review(user=u, state=s) for u, s in latest_by_user.items()]
+
+    has_changes_requested = any(r.state == "CHANGES_REQUESTED" for r in reviews)
+    has_approved = any(r.state == "APPROVED" for r in reviews)
+
+    if has_changes_requested:
+        status: ReviewStatusT = "changes_requested"
+    elif has_approved:
+        status = "approved"
+    else:
+        status = "pending"
+
+    return (status, reviews)
+
+
+_MAX_CONCURRENT_API_CALLS = 5
+
+
+async def _fetch_pr_details(
+    client: httpx.AsyncClient,
+    user: str,
+    repo: str,
+    entries: list[StackListEntry],
+    pulls: dict[int, github_types.PullRequest],
+) -> None:
+    """Fetch CI checks and reviews for each PR and update entries in place."""
+    sem = asyncio.Semaphore(_MAX_CONCURRENT_API_CALLS)
+
+    async def _fetch_for_entry(entry: StackListEntry) -> None:
+        if entry.pull_number is None:
+            return
+
+        pull = pulls.get(entry.pull_number)
+        if pull is None:
+            return
+
+        head_sha = pull["head"]["sha"]
+
+        async with sem:
+            r_checks, r_reviews = await asyncio.gather(
+                client.get(
+                    f"/repos/{user}/{repo}/commits/{head_sha}/check-runs",
+                ),
+                client.get(
+                    f"/repos/{user}/{repo}/pulls/{entry.pull_number}/reviews",
+                ),
+            )
+
+        check_runs = r_checks.json().get("check_runs", [])
+        entry.ci_status, entry.ci_checks = _compute_ci_status(check_runs)
+
+        reviews_data = r_reviews.json()
+        entry.review_status, entry.reviews = _compute_review_status(reviews_data)
+
+    await asyncio.gather(*[_fetch_for_entry(e) for e in entries])
+
+
+def display_stack_list(output: StackListOutput, *, verbose: bool = False) -> None:
     """Display the stack list in human-readable format using rich console."""
     console.print(
-        f"\nStack on `[cyan]{output.branch}[/]` targeting `[cyan]{output.trunk}[/]`:\n",
+        f"\nStack on [cyan]{output.branch}[/] → [cyan]{output.trunk}[/]:\n",
     )
 
     if not output.entries:
-        console.print("No commits in stack", style="dim")
+        console.print("  No commits in stack", style="dim")
         return
 
     for entry in output.entries:
         status_text, status_color = _get_status_display(entry.status)
         short_sha = entry.commit_sha[:7]
 
-        # Format: * [status] #number Title (sha)
         if entry.pull_number is not None:
+            conflict = " [red]✗ conflicting[/]" if entry.mergeable is False else ""
+
             console.print(
-                f"* [{status_color}]\\[{status_text}][/] "
-                f"[bold]#{entry.pull_number}[/] {entry.title} ({short_sha})",
+                f"  [{status_color}]{status_text}[/] "
+                f"[bold]#{entry.pull_number}[/] {entry.title} "
+                f"[dim]({short_sha})[/]{conflict}",
             )
-            console.print(f"  {entry.pull_url}\n")
+
+            # Status line (CI + review)
+            ci_display = _format_ci_display(entry, verbose=verbose)
+            review_display = _format_review_display(entry, verbose=verbose)
+            parts = [p for p in [ci_display, review_display] if p]
+            if parts:
+                console.print(f"     {' | '.join(parts)}")
+
+            console.print(f"     [dim]{entry.pull_url}[/]\n")
         else:
             console.print(
-                f"* [{status_color}]\\[{status_text}][/] {entry.title} ({short_sha})\n",
+                f"  [{status_color}]{status_text}[/] {entry.title} "
+                f"[dim]({short_sha})[/]\n",
             )
 
 
@@ -130,6 +332,7 @@ async def get_stack_list(
     trunk: tuple[str, str],
     branch_prefix: str | None = None,
     author: str | None = None,
+    include_status: bool = True,
 ) -> StackListOutput:
     """Get the current stack's commits and their associated PRs.
 
@@ -212,19 +415,31 @@ async def get_stack_list(
             next_only=False,
         )
 
-    # Build output structure
-    entries: list[StackListEntry] = []
-    for local_change in stack_changes.locals:
-        status = _get_entry_status(local_change.pull)
-        entry = StackListEntry(
-            commit_sha=local_change.commit_sha,
-            title=local_change.title,
-            change_id=local_change.id,
-            status=status,
-            pull_number=int(local_change.pull["number"]) if local_change.pull else None,
-            pull_url=local_change.pull["html_url"] if local_change.pull else None,
-        )
-        entries.append(entry)
+        # Build output structure
+        entries: list[StackListEntry] = []
+        pulls_by_number: dict[int, github_types.PullRequest] = {}
+        for local_change in stack_changes.locals:
+            status = _get_entry_status(local_change.pull)
+            pull_number = (
+                int(local_change.pull["number"]) if local_change.pull else None
+            )
+            entry = StackListEntry(
+                commit_sha=local_change.commit_sha,
+                title=local_change.title,
+                change_id=local_change.id,
+                status=status,
+                pull_number=pull_number,
+                pull_url=local_change.pull["html_url"] if local_change.pull else None,
+                mergeable=local_change.pull.get("mergeable")
+                if local_change.pull
+                else None,
+            )
+            entries.append(entry)
+            if pull_number is not None and local_change.pull is not None:
+                pulls_by_number[pull_number] = local_change.pull
+
+        if include_status:
+            await _fetch_pr_details(client, user, repo, entries, pulls_by_number)
 
     return StackListOutput(
         branch=dest_branch,
@@ -241,6 +456,7 @@ async def stack_list(
     branch_prefix: str | None = None,
     author: str | None = None,
     output_json: bool = False,
+    verbose: bool = False,
 ) -> None:
     """List the current stack's commits and their associated PRs.
 
@@ -251,6 +467,7 @@ async def stack_list(
         branch_prefix: Optional branch prefix for stack branches
         author: Optional author filter (defaults to token owner)
         output_json: If True, output JSON instead of human-readable format
+        verbose: If True, show detailed CI check names and reviewer names
     """
     output = await get_stack_list(
         github_server=github_server,
@@ -263,4 +480,4 @@ async def stack_list(
     if output_json:
         console.print(json.dumps(output.to_dict(), indent=2))
     else:
-        display_stack_list(output)
+        display_stack_list(output, verbose=verbose)

--- a/mergify_cli/stack/open.py
+++ b/mergify_cli/stack/open.py
@@ -66,6 +66,7 @@ async def stack_open(
         github_server=github_server,
         token=token,
         trunk=trunk,
+        include_status=False,
     )
 
     if not output.entries:

--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -213,11 +213,28 @@ async def stack_push(
         if skip_rebase:
             console.log(f"branch `{dest_branch}` rebase skipped (--skip-rebase)")
         else:
+            from mergify_cli.stack import sync as stack_sync_mod
+
             with console.status(
                 f"Rebasing branch `{dest_branch}` on `{remote}/{base_branch}`...",
             ):
-                await utils.git("pull", "--rebase", remote, base_branch)
-            console.log(f"branch `{dest_branch}` rebased on `{remote}/{base_branch}`")
+                await utils.git("fetch", remote, base_branch)
+                sync_status = await stack_sync_mod.smart_rebase(
+                    github_server,
+                    token,
+                    trunk=trunk,
+                    branch_prefix=branch_prefix,
+                    author=author,
+                )
+            if sync_status.merged:
+                console.log(
+                    f"branch `{dest_branch}` rebased on `{remote}/{base_branch}` "
+                    f"(dropped {len(sync_status.merged)} merged commit(s))",
+                )
+            else:
+                console.log(
+                    f"branch `{dest_branch}` rebased on `{remote}/{base_branch}`",
+                )
 
     rebase_required = False
     if dry_run and not skip_rebase:

--- a/mergify_cli/stack/setup.py
+++ b/mergify_cli/stack/setup.py
@@ -110,7 +110,7 @@ def _install_skill_stub(
         if existing_content == _SKILL_STUB_CONTENT:
             if verbose:
                 console.print(
-                    f"  ✅ Skill stub: up to date ({skill_stub_path})",
+                    f"  ✓ Skill stub: up to date ({skill_stub_path})",
                     style="green",
                 )
             return
@@ -118,9 +118,8 @@ def _install_skill_stub(
     skill_stub_path.write_text(_SKILL_STUB_CONTENT, encoding="utf-8")
     if verbose:
         action = "updated" if is_update else "installed"
-        emoji = "🔄" if is_update else "📦"
         console.print(
-            f"  {emoji} Skill stub: {action} ({skill_stub_path})",
+            f"  ✓ Skill stub: {action} ({skill_stub_path})",
             style="bold green",
         )
 
@@ -322,12 +321,12 @@ def _install_claude_hooks(*, verbose: bool = False) -> None:
             dest_file.chmod(0o755)
             if verbose:
                 console.print(
-                    f"  🔄 Hook script: updated ({src_file.name})",
+                    f"  ✓ Hook script: updated ({src_file.name})",
                     style="bold cyan",
                 )
         elif verbose:
             console.print(
-                f"  ✅ Hook script: up to date ({src_file.name})",
+                f"  ✓ Hook script: up to date ({src_file.name})",
                 style="green",
             )
 
@@ -362,7 +361,7 @@ def _install_claude_hooks(*, verbose: bool = False) -> None:
     if already_installed:
         if verbose:
             console.print(
-                f"  ✅ Settings hook: up to date ({settings_file})",
+                f"  ✓ Settings hook: up to date ({settings_file})",
                 style="green",
             )
     else:
@@ -383,7 +382,7 @@ def _install_claude_hooks(*, verbose: bool = False) -> None:
         )
         if verbose:
             console.print(
-                f"  🔗 Settings hook: installed ({settings_file})",
+                f"  ✓ Settings hook: installed ({settings_file})",
                 style="bold cyan",
             )
 
@@ -480,7 +479,7 @@ async def stack_setup(*, force: bool = False, global_install: bool = False) -> N
         _install_git_hook(hooks_dir, hook_name, force=force)
 
     # Install Claude hooks for session ID tracking (global)
-    console.print("\n🤖 Claude Code integration:", style="bold")
+    console.print("\nClaude Code integration:", style="bold")
     _install_claude_hooks(verbose=True)
 
     # Install skill stub for AI tool bootstrapping (project-level)

--- a/mergify_cli/stack/skill.md
+++ b/mergify_cli/stack/skill.md
@@ -33,9 +33,12 @@ A branch is a stack. Keep stacks short and focused:
 ```bash
 mergify stack new NAME       # Create a new stack/branch for new work
 mergify stack push           # Push and create/update PRs
+mergify stack sync           # Fetch trunk, remove merged commits, rebase
 mergify stack list           # Show commit <-> PR mapping for current stack
 mergify stack list --json    # Same, but machine-readable JSON output
 ```
+
+Use `mergify stack sync` to bring your stack up to date. It fetches the latest trunk, detects which PRs have been merged, removes those commits from your local branch, and rebases the remaining commits. Run this before starting new work on an existing stack.
 
 Use `mergify stack list` to see which commits have been pushed, which PRs they map to, and whether the stack is up to date with the remote. This is the go-to command to understand the current state of a stack. Use `--json` when you need to parse the output programmatically.
 

--- a/mergify_cli/stack/skill.md
+++ b/mergify_cli/stack/skill.md
@@ -40,7 +40,7 @@ mergify stack list --json    # Same, but machine-readable JSON output
 
 Use `mergify stack sync` to bring your stack up to date. It fetches the latest trunk, detects which PRs have been merged, removes those commits from your local branch, and rebases the remaining commits. Run this before starting new work on an existing stack.
 
-Use `mergify stack list` to see which commits have been pushed, which PRs they map to, and whether the stack is up to date with the remote. This is the go-to command to understand the current state of a stack. Use `--json` when you need to parse the output programmatically.
+Use `mergify stack list` to see which commits have been pushed, which PRs they map to, and whether the stack is up to date with the remote. It also shows CI status, review status, and merge conflicts for each PR. Use `--verbose` for detailed check names and reviewer names. Use `--json` when you need to parse the output programmatically — it includes full CI check details and review data.
 
 ## CRITICAL: Check Branch Before ANY Commit
 

--- a/mergify_cli/stack/sync.py
+++ b/mergify_cli/stack/sync.py
@@ -1,0 +1,266 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import pathlib
+import sys
+import tempfile
+import typing
+
+from mergify_cli import console
+from mergify_cli import utils
+from mergify_cli.stack import changes
+from mergify_cli.stack.push import LocalBranchInvalidError
+from mergify_cli.stack.push import check_local_branch
+
+
+@dataclasses.dataclass
+class MergedCommit:
+    """A commit whose PR has been merged."""
+
+    commit_sha: str
+    title: str
+    pull_number: int
+    pull_url: str
+
+
+@dataclasses.dataclass
+class RemainingCommit:
+    """A commit that still has an open PR or no PR yet."""
+
+    commit_sha: str
+    title: str
+
+
+@dataclasses.dataclass
+class SyncStatus:
+    """Result of a sync status check for the current stack."""
+
+    branch: str
+    trunk: str
+    merged: list[MergedCommit]
+    remaining: list[RemainingCommit]
+
+    @property
+    def all_merged(self) -> bool:
+        """True when every commit in the stack has been merged."""
+        return bool(self.merged) and not self.remaining
+
+    @property
+    def up_to_date(self) -> bool:
+        """True when there are no merged commits (nothing to rebase away)."""
+        return not self.merged
+
+
+async def get_sync_status(
+    github_server: str,
+    token: str,
+    *,
+    trunk: tuple[str, str],
+    branch_prefix: str | None = None,
+    author: str | None = None,
+) -> SyncStatus:
+    """Compute the sync status for the current stack.
+
+    Args:
+        github_server: GitHub API server URL
+        token: GitHub personal access token
+        trunk: Tuple of (remote, branch) for the trunk
+        branch_prefix: Optional branch prefix for stack branches
+        author: Optional author filter (defaults to token owner)
+
+    Returns:
+        SyncStatus classifying each commit as merged or remaining
+    """
+    dest_branch = await utils.git_get_branch_name()
+
+    if author is None:
+        async with utils.get_github_http_client(github_server, token) as client:
+            r_author = await client.get("/user")
+            author = typing.cast("str", r_author.json()["login"])
+
+    if branch_prefix is None:
+        branch_prefix = await utils.get_default_branch_prefix(author)
+
+    try:
+        check_local_branch(branch_name=dest_branch, branch_prefix=branch_prefix)
+    except LocalBranchInvalidError as e:
+        console.print(f"[red] {e.message} [/]")
+        console.print(
+            "You should run `mergify stack sync` on the branch you created in the first place",
+        )
+        sys.exit(1)
+
+    remote, base_branch = trunk
+
+    user, repo = utils.get_slug(
+        await utils.git("config", "--get", f"remote.{remote}.url"),
+    )
+
+    if base_branch == dest_branch:
+        remote_url = await utils.git("remote", "get-url", remote)
+        console.print(
+            f"Your local branch `{dest_branch}` targets itself: "
+            f"`{remote}/{base_branch}` (at {remote_url}@{base_branch}).\n"
+            "You should either fix the target branch or rename your local branch.\n\n"
+            f"* To fix the target branch: "
+            f"`git branch {dest_branch} --set-upstream-to={remote}/{base_branch}`\n"
+            f"* To rename your local branch: "
+            f"`git branch -M {dest_branch} new-branch-name`",
+            style="red",
+        )
+        sys.exit(1)
+
+    stack_prefix = f"{branch_prefix}/{dest_branch}" if branch_prefix else dest_branch
+
+    base_commit_sha = await utils.git(
+        "merge-base",
+        "--fork-point",
+        f"{remote}/{base_branch}",
+    )
+    if not base_commit_sha:
+        console.print(
+            f"Common commit between `{remote}/{base_branch}` and `{dest_branch}` branches not found",
+            style="red",
+        )
+        sys.exit(1)
+
+    async with utils.get_github_http_client(github_server, token) as client:
+        remote_changes = await changes.get_remote_changes(
+            client,
+            user,
+            repo,
+            stack_prefix,
+            author,
+        )
+
+        stack_changes = await changes.get_changes(
+            base_commit_sha=base_commit_sha,
+            stack_prefix=stack_prefix,
+            base_branch=base_branch,
+            dest_branch=dest_branch,
+            remote_changes=remote_changes,
+            only_update_existing_pulls=False,
+            next_only=False,
+        )
+
+    merged: list[MergedCommit] = []
+    remaining: list[RemainingCommit] = []
+
+    for local_change in stack_changes.locals:
+        if local_change.action == "skip-merged":
+            pull = local_change.pull
+            merged.append(
+                MergedCommit(
+                    commit_sha=local_change.commit_sha,
+                    title=local_change.title,
+                    pull_number=int(pull["number"]) if pull else 0,
+                    pull_url=pull["html_url"] if pull else "",
+                ),
+            )
+        else:
+            remaining.append(
+                RemainingCommit(
+                    commit_sha=local_change.commit_sha,
+                    title=local_change.title,
+                ),
+            )
+
+    return SyncStatus(
+        branch=dest_branch,
+        trunk=f"{remote}/{base_branch}",
+        merged=merged,
+        remaining=remaining,
+    )
+
+
+def _write_drop_script(merged_shas: set[str]) -> pathlib.Path:
+    """Write a temporary bash script that acts as GIT_SEQUENCE_EDITOR to drop merged commits.
+
+    The script reads the rebase todo file, replaces "pick <sha>" with
+    "drop <sha>" for each merged commit, and writes it back.
+
+    Returns the path to the script. Caller is responsible for cleanup.
+    """
+    short_shas = sorted(sha[:7] for sha in merged_shas)
+
+    # Build sed expressions — one per merged SHA
+    sed_expressions = " ".join(f"-e 's/^pick {sha}/drop {sha}/'" for sha in short_shas)
+
+    script = f'#!/bin/sh\nsed {sed_expressions} "$1" > "$1.tmp" && mv "$1.tmp" "$1"\n'
+
+    fd, path = tempfile.mkstemp(suffix=".sh", prefix="mergify_drop_")
+    script_path = pathlib.Path(path)
+    os.close(fd)
+    script_path.write_text(script, encoding="utf-8")
+    script_path.chmod(0o755)
+    return script_path
+
+
+async def smart_rebase(
+    github_server: str,
+    token: str,
+    *,
+    trunk: tuple[str, str],
+    branch_prefix: str | None = None,
+    author: str | None = None,
+) -> SyncStatus:
+    """Rebase the stack onto trunk, dropping any merged commits.
+
+    If merged commits are found, does a single `git rebase -i` that both
+    drops them and rebases onto the latest trunk. Otherwise, falls back
+    to a simple `git pull --rebase`.
+
+    Callers are responsible for fetching the remote before calling this.
+
+    Returns the SyncStatus so callers can inspect what happened.
+    """
+    remote, base_branch = trunk
+
+    status = await get_sync_status(
+        github_server,
+        token,
+        trunk=trunk,
+        branch_prefix=branch_prefix,
+        author=author,
+    )
+
+    if status.all_merged or status.up_to_date:
+        # Simple rebase — no merged commits to drop
+        await utils.git("pull", "--rebase", remote, base_branch)
+        return status
+
+    # Merged commits found — drop them and rebase in one operation.
+    # Using git rebase -i onto trunk with a script that changes "pick" to "drop"
+    # for merged commits. This avoids conflicts from trying to reapply commits
+    # whose content was modified on GitHub before merge.
+    merged_shas = {m.commit_sha for m in status.merged}
+    script_path = _write_drop_script(merged_shas)
+
+    env_backup = os.environ.get("GIT_SEQUENCE_EDITOR")
+    os.environ["GIT_SEQUENCE_EDITOR"] = str(script_path)
+    try:
+        await utils.git("rebase", "-i", f"{remote}/{base_branch}")
+    finally:
+        if env_backup is None:
+            os.environ.pop("GIT_SEQUENCE_EDITOR", None)
+        else:
+            os.environ["GIT_SEQUENCE_EDITOR"] = env_backup
+        script_path.unlink(missing_ok=True)
+
+    return status

--- a/mergify_cli/stack/sync.py
+++ b/mergify_cli/stack/sync.py
@@ -264,3 +264,82 @@ async def smart_rebase(
         script_path.unlink(missing_ok=True)
 
     return status
+
+
+async def stack_sync(
+    github_server: str,
+    token: str,
+    *,
+    trunk: tuple[str, str],
+    dry_run: bool = False,
+    branch_prefix: str | None = None,
+    author: str | None = None,
+) -> None:
+    """Sync the current stack by removing merged commits and rebasing.
+
+    Args:
+        github_server: GitHub API server URL
+        token: GitHub personal access token
+        trunk: Tuple of (remote, branch) for the trunk
+        dry_run: If True, only report what would be done
+        branch_prefix: Optional branch prefix for stack branches
+        author: Optional author filter (defaults to token owner)
+    """
+    remote, base_branch = trunk
+
+    # Dry-run: just check status and report
+    if dry_run:
+        with console.status("Checking sync status\u2026"):
+            status = await get_sync_status(
+                github_server,
+                token,
+                trunk=trunk,
+                branch_prefix=branch_prefix,
+                author=author,
+            )
+
+        if status.all_merged:
+            console.print(
+                f"All commits in the stack have been merged into {base_branch}.\n"
+                f"You can switch to {base_branch} with: git checkout {base_branch}",
+            )
+        elif status.up_to_date:
+            console.print("Stack is up to date.")
+        else:
+            console.print(
+                "[bold]Dry run:[/] the following merged commits would be removed:",
+            )
+            for m in status.merged:
+                console.print(f"  - {m.title} (#{m.pull_number}, merged)")
+            console.print(
+                f"\n{len(status.remaining)} commit(s) would remain in the stack.",
+            )
+        return
+
+    # Fetch and sync
+    with console.status(f"Fetching {remote}/{base_branch}\u2026"):
+        await utils.git("fetch", remote, base_branch)
+
+    with console.status(f"Rebasing onto {remote}/{base_branch}\u2026"):
+        status = await smart_rebase(
+            github_server,
+            token,
+            trunk=trunk,
+            branch_prefix=branch_prefix,
+            author=author,
+        )
+
+    if status.all_merged:
+        console.print(
+            f"All commits in the stack have been merged into {base_branch}.\n"
+            f"You can switch to {base_branch} with: git checkout {base_branch}",
+        )
+    elif status.up_to_date:
+        console.print("Stack is up to date.")
+    else:
+        for m in status.merged:
+            console.print(f"  ✓ Dropped: {m.title} (#{m.pull_number})")
+        console.print(
+            f"Dropped {len(status.merged)} merged commit(s). "
+            f"{len(status.remaining)} commit(s) remaining in the stack.",
+        )

--- a/mergify_cli/tests/conftest.py
+++ b/mergify_cli/tests/conftest.py
@@ -80,8 +80,13 @@ def git_mock(
         "remote.origin.url",
         output="https://github.com/user/repo",
     )
-    # Mock pull command
+    # Mock fetch and pull commands (used by smart_rebase)
+    git_mock_object.mock("fetch", "origin", "main", output="")
     git_mock_object.mock("pull", "--rebase", "origin", "main", output="")
+    # Mock branch prefix config (used by smart_rebase via get_sync_status)
+    git_mock_object.mock(
+        "config", "--get", "mergify-cli.stack-branch-prefix", output=""
+    )
 
     with mock.patch("mergify_cli.utils.git", git_mock_object):
         yield git_mock_object

--- a/mergify_cli/tests/stack/test_list.py
+++ b/mergify_cli/tests/stack/test_list.py
@@ -89,6 +89,7 @@ async def test_stack_list_with_prs(
             "merged_at": None,
             "draft": False,
             "node_id": "",
+            "mergeable": True,
         },
     )
     respx_mock.get("/repos/user/repo/pulls/124").respond(
@@ -105,8 +106,14 @@ async def test_stack_list_with_prs(
             "merged_at": None,
             "draft": True,
             "node_id": "",
+            "mergeable": None,
         },
     )
+    respx_mock.get(url__regex=r".*/commits/.*/check-runs$").respond(
+        200,
+        json={"check_runs": []},
+    )
+    respx_mock.get(url__regex=r".*/pulls/\d+/reviews$").respond(200, json=[])
 
     await stack_list_mod.stack_list(
         github_server="https://api.github.com/",
@@ -233,6 +240,7 @@ async def test_stack_list_mixed_pr_states(
             "merged_at": "2024-01-01T00:00:00Z",
             "draft": False,
             "node_id": "",
+            "mergeable": None,
         },
     )
     # Second PR: draft
@@ -250,6 +258,7 @@ async def test_stack_list_mixed_pr_states(
             "merged_at": None,
             "draft": True,
             "node_id": "",
+            "mergeable": None,
         },
     )
     # Third PR: open
@@ -267,8 +276,14 @@ async def test_stack_list_mixed_pr_states(
             "merged_at": None,
             "draft": False,
             "node_id": "",
+            "mergeable": True,
         },
     )
+    respx_mock.get(url__regex=r".*/commits/.*/check-runs$").respond(
+        200,
+        json={"check_runs": []},
+    )
+    respx_mock.get(url__regex=r".*/pulls/\d+/reviews$").respond(200, json=[])
 
     await stack_list_mod.stack_list(
         github_server="https://api.github.com/",
@@ -329,8 +344,14 @@ async def test_stack_list_json_output(
             "merged_at": None,
             "draft": False,
             "node_id": "",
+            "mergeable": True,
         },
     )
+    respx_mock.get(url__regex=r".*/commits/.*/check-runs$").respond(
+        200,
+        json={"check_runs": []},
+    )
+    respx_mock.get(url__regex=r".*/pulls/\d+/reviews$").respond(200, json=[])
 
     await stack_list_mod.stack_list(
         github_server="https://api.github.com/",
@@ -350,6 +371,11 @@ async def test_stack_list_json_output(
     assert output["entries"][0]["status"] == "open"
     assert output["entries"][0]["pull_number"] == 42
     assert output["entries"][0]["pull_url"] == "https://github.com/user/repo/pull/42"
+    assert output["entries"][0]["ci_status"] == "unknown"
+    assert output["entries"][0]["ci_checks"] == []
+    assert output["entries"][0]["review_status"] == "unknown"
+    assert output["entries"][0]["reviews"] == []
+    assert output["entries"][0]["mergeable"] is True
 
 
 @pytest.mark.respx(base_url="https://api.github.com/")
@@ -460,3 +486,272 @@ async def test_stack_list_no_fork_point_raises_error(
             token="",
             trunk=("origin", "main"),
         )
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_stack_list_json_includes_ci_and_review_status(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test that JSON output includes CI status, reviews, and mergeable fields."""
+    git_mock.mock("config", "--get", "mergify-cli.stack-branch-prefix", output="")
+
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="Add CI feature",
+            message="Message",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/99",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/99").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/99",
+            "number": "99",
+            "title": "Add CI feature",
+            "head": {
+                "sha": "commit1_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+            "mergeable": True,
+        },
+    )
+    respx_mock.get("/repos/user/repo/commits/commit1_sha/check-runs").respond(
+        200,
+        json={
+            "check_runs": [
+                {
+                    "name": "tests",
+                    "status": "completed",
+                    "conclusion": "success",
+                },
+                {
+                    "name": "lint",
+                    "status": "completed",
+                    "conclusion": "success",
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/99/reviews").respond(
+        200,
+        json=[
+            {
+                "user": {"login": "reviewer1"},
+                "state": "APPROVED",
+            },
+        ],
+    )
+
+    await stack_list_mod.stack_list(
+        github_server="https://api.github.com/",
+        token="",
+        trunk=("origin", "main"),
+        output_json=True,
+    )
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+
+    entry = output["entries"][0]
+    assert entry["ci_status"] == "passing"
+    assert len(entry["ci_checks"]) == 2
+    assert entry["ci_checks"][0] == {"name": "tests", "status": "success"}
+    assert entry["ci_checks"][1] == {"name": "lint", "status": "success"}
+    assert entry["review_status"] == "approved"
+    assert len(entry["reviews"]) == 1
+    assert entry["reviews"][0] == {"user": "reviewer1", "state": "APPROVED"}
+    assert entry["mergeable"] is True
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_stack_list_shows_ci_and_review_summary(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test that display output includes CI status, review status, and conflict indicator."""
+    git_mock.mock("config", "--get", "mergify-cli.stack-branch-prefix", output="")
+
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="Add feature",
+            message="Message",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/77",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/77").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/77",
+            "number": "77",
+            "title": "Add feature",
+            "head": {
+                "sha": "commit1_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+            "mergeable": False,
+        },
+    )
+    respx_mock.get("/repos/user/repo/commits/commit1_sha/check-runs").respond(
+        200,
+        json={
+            "check_runs": [
+                {
+                    "name": "linters",
+                    "status": "completed",
+                    "conclusion": "success",
+                },
+                {
+                    "name": "tests",
+                    "status": "completed",
+                    "conclusion": "failure",
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/77/reviews").respond(
+        200,
+        json=[
+            {
+                "user": {"login": "alice"},
+                "state": "CHANGES_REQUESTED",
+            },
+        ],
+    )
+
+    await stack_list_mod.stack_list(
+        github_server="https://api.github.com/",
+        token="",
+        trunk=("origin", "main"),
+    )
+
+    captured = capsys.readouterr()
+    assert "failing" in captured.out
+    assert "changes requested" in captured.out
+    assert "conflicting" in captured.out
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_stack_list_verbose_shows_check_names_and_reviewers(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test that verbose mode shows individual check names and reviewer names."""
+    git_mock.mock("config", "--get", "mergify-cli.stack-branch-prefix", output="")
+
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="Add feature",
+            message="Message",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/42",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/42").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/42",
+            "number": "42",
+            "title": "Add feature",
+            "head": {
+                "sha": "commit1_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+            "mergeable": True,
+        },
+    )
+    respx_mock.get("/repos/user/repo/commits/commit1_sha/check-runs").respond(
+        200,
+        json={
+            "check_runs": [
+                {"name": "linters", "status": "completed", "conclusion": "success"},
+                {
+                    "name": "tests (ubuntu)",
+                    "status": "completed",
+                    "conclusion": "failure",
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/42/reviews").respond(
+        200,
+        json=[
+            {"user": {"login": "alice"}, "state": "APPROVED"},
+            {"user": {"login": "bob"}, "state": "CHANGES_REQUESTED"},
+        ],
+    )
+
+    await stack_list_mod.stack_list(
+        github_server="https://api.github.com/",
+        token="",
+        trunk=("origin", "main"),
+        verbose=True,
+    )
+
+    captured = capsys.readouterr()
+    assert "linters" in captured.out
+    assert "tests (ubuntu)" in captured.out
+    assert "alice" in captured.out
+    assert "bob" in captured.out

--- a/mergify_cli/tests/stack/test_open.py
+++ b/mergify_cli/tests/stack/test_open.py
@@ -80,6 +80,7 @@ async def test_stack_open_head(
             "merged_at": None,
             "draft": False,
             "node_id": "",
+            "mergeable": True,
         },
     )
 
@@ -158,6 +159,7 @@ async def test_stack_open_specific_commit(
             "merged_at": None,
             "draft": False,
             "node_id": "",
+            "mergeable": True,
         },
     )
     respx_mock.get("/repos/user/repo/pulls/124").respond(
@@ -174,6 +176,7 @@ async def test_stack_open_specific_commit(
             "merged_at": None,
             "draft": False,
             "node_id": "",
+            "mergeable": True,
         },
     )
 
@@ -393,6 +396,7 @@ async def test_stack_open_interactive_selection(
             "merged_at": None,
             "draft": False,
             "node_id": "",
+            "mergeable": True,
         },
     )
     respx_mock.get("/repos/user/repo/pulls/124").respond(
@@ -409,6 +413,7 @@ async def test_stack_open_interactive_selection(
             "merged_at": None,
             "draft": False,
             "node_id": "",
+            "mergeable": True,
         },
     )
 

--- a/mergify_cli/tests/stack/test_sync.py
+++ b/mergify_cli/tests/stack/test_sync.py
@@ -759,3 +759,330 @@ async def test_smart_rebase_mid_stack_merged(
     assert status.remaining[0].title == "First open"
     assert status.remaining[1].title == "Last open"
     assert git_mock.has_been_called_with("rebase", "-i", "origin/main")
+
+
+# --- stack_sync() integration tests ---
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_sync_up_to_date_after_rebase(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test: no merged commits — rebase onto trunk, report up to date."""
+    git_mock.mock("config", "--get", "mergify-cli.stack-branch-prefix", output="")
+    git_mock.mock("fetch", "origin", "main", output="")
+    git_mock.mock("pull", "--rebase", "origin", "main", output="")
+
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="Open commit",
+            message="Message 1",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/1",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/1",
+            "number": "1",
+            "title": "Open commit",
+            "head": {
+                "sha": "commit1_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+
+    await stack_sync_mod.stack_sync(
+        github_server="https://api.github.com/",
+        token="",
+        trunk=("origin", "main"),
+    )
+
+    captured = capsys.readouterr()
+    assert "up to date" in captured.out
+    assert git_mock.has_been_called_with("fetch", "origin", "main")
+    assert git_mock.has_been_called_with("pull", "--rebase", "origin", "main")
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_sync_drops_merged_and_rebases_in_one_operation(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test: merged commit detected, dropped and rebased in single git rebase -i.
+
+    When sync finds merged commits, it does a single `git rebase -i origin/main`
+    with a drop script — this both removes the merged commit and rebases onto
+    trunk in one operation, avoiding conflicts from trying to reapply a commit
+    whose content was modified on GitHub before merge.
+    """
+    git_mock.mock("config", "--get", "mergify-cli.stack-branch-prefix", output="")
+    git_mock.mock("fetch", "origin", "main", output="")
+    # Single rebase onto origin/main (not fork-point)
+    git_mock.mock("rebase", "-i", "origin/main", output="")
+
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="Modified on GitHub then merged",
+            message="Message 1",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit2_sha",
+            title="Open commit",
+            message="Message 2",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf51",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/1",
+                    },
+                },
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/2",
+                    },
+                },
+            ],
+        },
+    )
+    # commit1: merged (modified on GitHub — would conflict with git pull --rebase)
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/1",
+            "number": "1",
+            "title": "Modified on GitHub then merged",
+            "head": {
+                "sha": "commit1_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "state": "closed",
+            "merged_at": "2024-01-01T00:00:00Z",
+            "merge_commit_sha": "merge_sha_1",
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    # commit2: open
+    respx_mock.get("/repos/user/repo/pulls/2").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/2",
+            "number": "2",
+            "title": "Open commit",
+            "head": {
+                "sha": "commit2_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf51",
+            },
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+
+    await stack_sync_mod.stack_sync(
+        github_server="https://api.github.com/",
+        token="",
+        trunk=("origin", "main"),
+    )
+
+    captured = capsys.readouterr()
+    assert "Modified on GitHub then merged" in captured.out
+    assert "Dropped 1 merged" in captured.out
+    # Should use single rebase -i onto origin/main (not git pull --rebase)
+    assert git_mock.has_been_called_with("rebase", "-i", "origin/main")
+    assert not git_mock.has_been_called_with("pull", "--rebase", "origin", "main")
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_sync_all_merged_suggests_checkout(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test: all commits merged — suggests switching to main."""
+    git_mock.mock("config", "--get", "mergify-cli.stack-branch-prefix", output="")
+    git_mock.mock("fetch", "origin", "main", output="")
+    git_mock.mock("pull", "--rebase", "origin", "main", output="")
+
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="Only commit",
+            message="Message 1",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/1",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/1",
+            "number": "1",
+            "title": "Only commit",
+            "head": {
+                "sha": "commit1_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "state": "closed",
+            "merged_at": "2024-01-01T00:00:00Z",
+            "merge_commit_sha": "merge_sha",
+            "draft": False,
+            "node_id": "",
+        },
+    )
+
+    await stack_sync_mod.stack_sync(
+        github_server="https://api.github.com/",
+        token="",
+        trunk=("origin", "main"),
+    )
+
+    captured = capsys.readouterr()
+    assert "All commits" in captured.out
+    assert "git checkout main" in captured.out
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_sync_dry_run(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test: dry-run shows what would happen without fetching or rebasing."""
+    git_mock.mock("config", "--get", "mergify-cli.stack-branch-prefix", output="")
+
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="Merged commit",
+            message="Message 1",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf80",
+        ),
+    )
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit2_sha",
+            title="Open commit",
+            message="Message 2",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf81",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/1",
+                    },
+                },
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/2",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/1",
+            "number": "1",
+            "title": "Merged commit",
+            "head": {
+                "sha": "commit1_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf80",
+            },
+            "state": "closed",
+            "merged_at": "2024-01-01T00:00:00Z",
+            "merge_commit_sha": "merge_sha_1",
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/2").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/2",
+            "number": "2",
+            "title": "Open commit",
+            "head": {
+                "sha": "commit2_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf81",
+            },
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+
+    await stack_sync_mod.stack_sync(
+        github_server="https://api.github.com/",
+        token="",
+        trunk=("origin", "main"),
+        dry_run=True,
+    )
+
+    captured = capsys.readouterr()
+    assert "Merged commit" in captured.out
+    assert "1 commit(s) would remain" in captured.out
+    # No fetch or rebase in dry-run
+    assert not git_mock.has_been_called_with("fetch", "origin", "main")
+    assert not git_mock.has_been_called_with("pull", "--rebase", "origin", "main")

--- a/mergify_cli/tests/stack/test_sync.py
+++ b/mergify_cli/tests/stack/test_sync.py
@@ -1,0 +1,761 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergify_cli.stack import sync as stack_sync_mod
+from mergify_cli.tests import utils as test_utils
+
+
+if TYPE_CHECKING:
+    import pathlib
+
+    import respx
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Bash not available on Windows")
+def test_write_drop_script_produces_working_script(tmp_path: pathlib.Path) -> None:
+    """Test that the generated drop script correctly modifies a rebase todo file."""
+    merged_shas = {"abc1234567890abcdef1234567890abcdef123456"}
+
+    script_path = stack_sync_mod._write_drop_script(merged_shas)
+    try:
+        # Create a fake rebase todo file
+        todo = tmp_path / "git-rebase-todo"
+        todo.write_text(
+            "pick abc1234 First commit\n"
+            "pick def5678 Second commit\n"
+            "pick ghi9012 Third commit\n",
+        )
+
+        # Run the script
+        subprocess.run(
+            [str(script_path), str(todo)],
+            check=True,
+        )
+
+        result = todo.read_text()
+        assert "drop abc1234 First commit\n" in result
+        assert "pick def5678 Second commit\n" in result
+        assert "pick ghi9012 Third commit\n" in result
+    finally:
+        script_path.unlink(missing_ok=True)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Bash not available on Windows")
+def test_write_drop_script_multiple_shas(tmp_path: pathlib.Path) -> None:
+    """Test drop script with multiple merged commits."""
+    merged_shas = {
+        "abc1234567890abcdef1234567890abcdef123456",
+        "ghi9012567890abcdef1234567890abcdef123456",
+    }
+
+    script_path = stack_sync_mod._write_drop_script(merged_shas)
+    try:
+        todo = tmp_path / "git-rebase-todo"
+        todo.write_text(
+            "pick abc1234 First commit\n"
+            "pick def5678 Second commit\n"
+            "pick ghi9012 Third commit\n",
+        )
+
+        subprocess.run(
+            [str(script_path), str(todo)],
+            check=True,
+        )
+
+        result = todo.read_text()
+        assert "drop abc1234 First commit\n" in result
+        assert "pick def5678 Second commit\n" in result
+        assert "drop ghi9012 Third commit\n" in result
+    finally:
+        script_path.unlink(missing_ok=True)
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_sync_detects_merged_commits(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    """Test that get_sync_status correctly classifies merged vs remaining commits."""
+    git_mock.mock("config", "--get", "mergify-cli.stack-branch-prefix", output="")
+
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="First commit",
+            message="Message commit 1",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit2_sha",
+            title="Second commit",
+            message="Message commit 2",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf51",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/1",
+                    },
+                },
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/2",
+                    },
+                },
+            ],
+        },
+    )
+    # commit1: merged
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/1",
+            "number": "1",
+            "title": "First commit",
+            "head": {
+                "sha": "commit1_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "state": "closed",
+            "merged_at": "2024-01-01T00:00:00Z",
+            "merge_commit_sha": "merge_sha_1",
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    # commit2: open
+    respx_mock.get("/repos/user/repo/pulls/2").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/2",
+            "number": "2",
+            "title": "Second commit",
+            "head": {
+                "sha": "commit2_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf51",
+            },
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+
+    result = await stack_sync_mod.get_sync_status(
+        github_server="https://api.github.com/",
+        token="",
+        trunk=("origin", "main"),
+    )
+
+    assert len(result.merged) == 1
+    assert result.merged[0].title == "First commit"
+    assert result.merged[0].commit_sha == "commit1_sha"
+
+    assert len(result.remaining) == 1
+    assert result.remaining[0].title == "Second commit"
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_sync_up_to_date(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    """Test that get_sync_status reports up_to_date when no commits are merged."""
+    git_mock.mock("config", "--get", "mergify-cli.stack-branch-prefix", output="")
+
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="First commit",
+            message="Message commit 1",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf60",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/1",
+                    },
+                },
+            ],
+        },
+    )
+    # commit1: open (not merged)
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/1",
+            "number": "1",
+            "title": "First commit",
+            "head": {
+                "sha": "commit1_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf60",
+            },
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+
+    result = await stack_sync_mod.get_sync_status(
+        github_server="https://api.github.com/",
+        token="",
+        trunk=("origin", "main"),
+    )
+
+    assert result.up_to_date is True
+    assert len(result.merged) == 0
+    assert len(result.remaining) == 1
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_sync_all_merged(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    """Test that get_sync_status reports all_merged when every commit is merged."""
+    git_mock.mock("config", "--get", "mergify-cli.stack-branch-prefix", output="")
+
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="First commit",
+            message="Message commit 1",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf70",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/1",
+                    },
+                },
+            ],
+        },
+    )
+    # commit1: merged
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/1",
+            "number": "1",
+            "title": "First commit",
+            "head": {
+                "sha": "commit1_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf70",
+            },
+            "state": "closed",
+            "merged_at": "2024-01-01T00:00:00Z",
+            "merge_commit_sha": "merge_sha",
+            "draft": False,
+            "node_id": "",
+        },
+    )
+
+    result = await stack_sync_mod.get_sync_status(
+        github_server="https://api.github.com/",
+        token="",
+        trunk=("origin", "main"),
+    )
+
+    assert result.all_merged is True
+    assert len(result.merged) == 1
+    assert len(result.remaining) == 0
+
+
+# --- smart_rebase() direct tests ---
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_smart_rebase_no_merged_uses_pull_rebase(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    """smart_rebase with no merged commits falls back to git pull --rebase."""
+    git_mock.mock("config", "--get", "mergify-cli.stack-branch-prefix", output="")
+    git_mock.mock("pull", "--rebase", "origin", "main", output="")
+
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="Open commit",
+            message="Message 1",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/1",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/1",
+            "number": "1",
+            "title": "Open commit",
+            "head": {
+                "sha": "commit1_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+
+    status = await stack_sync_mod.smart_rebase(
+        github_server="https://api.github.com/",
+        token="",
+        trunk=("origin", "main"),
+    )
+
+    assert status.up_to_date
+    assert git_mock.has_been_called_with("pull", "--rebase", "origin", "main")
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_smart_rebase_with_merged_uses_rebase_i(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    """smart_rebase with merged commits uses git rebase -i to drop them."""
+    git_mock.mock("config", "--get", "mergify-cli.stack-branch-prefix", output="")
+    git_mock.mock("rebase", "-i", "origin/main", output="")
+
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="Merged commit",
+            message="Message 1",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit2_sha",
+            title="Open commit",
+            message="Message 2",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf51",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/1",
+                    },
+                },
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/2",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/1",
+            "number": "1",
+            "title": "Merged commit",
+            "head": {
+                "sha": "commit1_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "state": "closed",
+            "merged_at": "2024-01-01T00:00:00Z",
+            "merge_commit_sha": "merge_sha_1",
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/2").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/2",
+            "number": "2",
+            "title": "Open commit",
+            "head": {
+                "sha": "commit2_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf51",
+            },
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+
+    status = await stack_sync_mod.smart_rebase(
+        github_server="https://api.github.com/",
+        token="",
+        trunk=("origin", "main"),
+    )
+
+    assert len(status.merged) == 1
+    assert len(status.remaining) == 1
+    assert git_mock.has_been_called_with("rebase", "-i", "origin/main")
+    assert not git_mock.has_been_called_with("pull", "--rebase", "origin", "main")
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_smart_rebase_all_merged_uses_pull_rebase(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    """smart_rebase with all commits merged falls back to git pull --rebase."""
+    git_mock.mock("config", "--get", "mergify-cli.stack-branch-prefix", output="")
+    git_mock.mock("pull", "--rebase", "origin", "main", output="")
+
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="Merged commit",
+            message="Message 1",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/1",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/1",
+            "number": "1",
+            "title": "Merged commit",
+            "head": {
+                "sha": "commit1_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "state": "closed",
+            "merged_at": "2024-01-01T00:00:00Z",
+            "merge_commit_sha": "merge_sha",
+            "draft": False,
+            "node_id": "",
+        },
+    )
+
+    status = await stack_sync_mod.smart_rebase(
+        github_server="https://api.github.com/",
+        token="",
+        trunk=("origin", "main"),
+    )
+
+    assert status.all_merged
+    assert git_mock.has_been_called_with("pull", "--rebase", "origin", "main")
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_smart_rebase_multiple_merged(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    """smart_rebase drops multiple merged commits in one rebase."""
+    git_mock.mock("config", "--get", "mergify-cli.stack-branch-prefix", output="")
+    git_mock.mock("rebase", "-i", "origin/main", output="")
+
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="First merged",
+            message="Message 1",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit2_sha",
+            title="Second merged",
+            message="Message 2",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf51",
+        ),
+    )
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit3_sha",
+            title="Open commit",
+            message="Message 3",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf52",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/1",
+                    },
+                },
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/2",
+                    },
+                },
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/3",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/1",
+            "number": "1",
+            "title": "First merged",
+            "head": {
+                "sha": "commit1_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "state": "closed",
+            "merged_at": "2024-01-01T00:00:00Z",
+            "merge_commit_sha": "merge1",
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/2").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/2",
+            "number": "2",
+            "title": "Second merged",
+            "head": {
+                "sha": "commit2_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf51",
+            },
+            "state": "closed",
+            "merged_at": "2024-01-02T00:00:00Z",
+            "merge_commit_sha": "merge2",
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/3").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/3",
+            "number": "3",
+            "title": "Open commit",
+            "head": {
+                "sha": "commit3_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf52",
+            },
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+
+    status = await stack_sync_mod.smart_rebase(
+        github_server="https://api.github.com/",
+        token="",
+        trunk=("origin", "main"),
+    )
+
+    assert len(status.merged) == 2
+    assert len(status.remaining) == 1
+    assert status.merged[0].title == "First merged"
+    assert status.merged[1].title == "Second merged"
+    assert git_mock.has_been_called_with("rebase", "-i", "origin/main")
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_smart_rebase_mid_stack_merged(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    """smart_rebase handles interleaved merged/open commits (A open, B merged, C open)."""
+    git_mock.mock("config", "--get", "mergify-cli.stack-branch-prefix", output="")
+    git_mock.mock("rebase", "-i", "origin/main", output="")
+
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="First open",
+            message="Message 1",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit2_sha",
+            title="Mid-stack merged",
+            message="Message 2",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf51",
+        ),
+    )
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit3_sha",
+            title="Last open",
+            message="Message 3",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf52",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/1",
+                    },
+                },
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/2",
+                    },
+                },
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/3",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/1",
+            "number": "1",
+            "title": "First open",
+            "head": {
+                "sha": "commit1_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/2").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/2",
+            "number": "2",
+            "title": "Mid-stack merged",
+            "head": {
+                "sha": "commit2_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf51",
+            },
+            "state": "closed",
+            "merged_at": "2024-01-01T00:00:00Z",
+            "merge_commit_sha": "merge_sha",
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/3").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/3",
+            "number": "3",
+            "title": "Last open",
+            "head": {
+                "sha": "commit3_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf52",
+            },
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+
+    status = await stack_sync_mod.smart_rebase(
+        github_server="https://api.github.com/",
+        token="",
+        trunk=("origin", "main"),
+    )
+
+    assert len(status.merged) == 1
+    assert status.merged[0].title == "Mid-stack merged"
+    assert len(status.remaining) == 2
+    assert status.remaining[0].title == "First open"
+    assert status.remaining[1].title == "Last open"
+    assert git_mock.has_been_called_with("rebase", "-i", "origin/main")


### PR DESCRIPTION
Enhances `mergify stack list` to show CI status, review status, and
merge conflict state for each PR in the stack.

- Default: summary line (CI: ✓ passing | Review: ✓ approved)
- --verbose: detailed check names and reviewer names
- --json: full structured data (ci_checks, reviews, mergeable)
- Conflict indicator (✗ conflicting) when PR has merge conflicts

Fetches check-runs and reviews in parallel with bounded concurrency.
Callers like `stack open` skip the extra fetches via include_status=False.

Depends-On: #1107