### PR TITLE
feat(stack): add Claude Code plugin for marketplace distribution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "mergify-marketplace",
+  "owner": {
+    "name": "Mergify"
+  },
+  "plugins": [
+    {
+      "name": "mergify",
+      "source": "./",
+      "description": "Stacked PRs, merge queues, and Git workflow automation"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "mergify",
+  "description": "Mergify CLI integration for stacked PRs, merge queues, and Git workflows",
+  "author": {
+    "name": "Mergify"
+  },
+  "keywords": ["git", "pr", "stacked-prs", "merge-queue", "workflow"],
+  "license": "Apache-2.0",
+  "repository": "https://github.com/Mergifyio/mergify-cli"
+}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ mergify ci --help
 mergify freeze --help
 ```
 
+## Claude Code Plugin
+
+Mergify CLI is available as a [Claude Code
+plugin](https://docs.anthropic.com/en/docs/claude-code/plugins), providing AI
+skills for managing stacked PRs and Git workflows.
+
+### Install from the official marketplace
+
+```shell
+claude /plugin install mergify@claude-plugins-official
+```
+
+### Install from this repository
+
+```shell
+claude /plugin marketplace add https://github.com/Mergifyio/mergify-cli
+claude /plugin install mergify
+```
+
 ## Contributing
 
 We welcome and appreciate contributions from the open-source community to make

--- a/mergify_cli/stack/cli.py
+++ b/mergify_cli/stack/cli.py
@@ -174,42 +174,6 @@ def _print_hooks_status(status: dict[str, Any]) -> None:
         needs_setup = True
     console.print()
 
-    # Skill stub section
-    skill_stub = claude_hooks["skill_stub"]
-    console.print("  skill stub (.agents/skills/):")
-    if skill_stub["installed"]:
-        if skill_stub["needs_update"]:
-            console.print(
-                f"    Status: [yellow]needs update[/] ({skill_stub['path']})",
-            )
-            needs_setup = True
-        else:
-            console.print(
-                f"    Status: [green]up to date[/] ({skill_stub['path']})",
-            )
-    else:
-        console.print("    Status: [red]not installed[/]")
-        needs_setup = True
-    console.print()
-
-    # Claude symlink section
-    skill_symlink = claude_hooks["skill_symlink"]
-    console.print("  claude skill symlink:")
-    if skill_symlink["installed"]:
-        if skill_symlink["correct"]:
-            console.print(
-                f"    Status: [green]up to date[/] ({skill_symlink['path']})",
-            )
-        else:
-            console.print(
-                f"    Status: [yellow]needs update[/] ({skill_symlink['path']})",
-            )
-            needs_setup = True
-    else:
-        console.print("    Status: [red]not installed[/]")
-        needs_setup = True
-    console.print()
-
     if needs_setup or needs_force:
         console.print("Run 'mergify stack hooks --setup' to install/upgrade hooks.")
         if needs_force:
@@ -233,16 +197,10 @@ def _print_hooks_status(status: dict[str, Any]) -> None:
     is_flag=True,
     help="Force reinstall wrappers (use with --setup)",
 )
-@click.option(
-    "--global",
-    "global_install",
-    is_flag=True,
-    help="Also install AI skill stub globally (~/.agents/skills/)",
-)
 @utils.run_with_asyncio
-async def hooks(*, do_setup: bool, force: bool, global_install: bool) -> None:
+async def hooks(*, do_setup: bool, force: bool) -> None:
     if do_setup:
-        await stack_setup_mod.stack_setup(force=force, global_install=global_install)
+        await stack_setup_mod.stack_setup(force=force)
     else:
         status = await stack_setup_mod.get_hooks_status()
         _print_hooks_status(status)
@@ -260,19 +218,13 @@ async def hooks(*, do_setup: bool, force: bool, global_install: bool) -> None:
     is_flag=True,
     help="Check status only (use 'stack hooks' instead)",
 )
-@click.option(
-    "--global",
-    "global_install",
-    is_flag=True,
-    help="Also install AI skill stub globally (~/.agents/skills/)",
-)
 @utils.run_with_asyncio
-async def setup(*, force: bool, check: bool, global_install: bool) -> None:
+async def setup(*, force: bool, check: bool) -> None:
     if check:
         status = await stack_setup_mod.get_hooks_status()
         _print_hooks_status(status)
     else:
-        await stack_setup_mod.stack_setup(force=force, global_install=global_install)
+        await stack_setup_mod.stack_setup(force=force)
 
 
 @stack.command(help="Edit the stack history")

--- a/mergify_cli/stack/setup.py
+++ b/mergify_cli/stack/setup.py
@@ -19,7 +19,6 @@ import enum
 import importlib.resources
 import importlib.resources.abc
 import json
-import os
 import pathlib
 import shutil
 from typing import TYPE_CHECKING
@@ -68,151 +67,6 @@ def _get_wrapper_resource(hook_name: str) -> importlib.resources.abc.Traversable
     return importlib.resources.files(__package__).joinpath(
         f"hooks/wrappers/{hook_name}",
     )
-
-
-def _get_global_skill_stub_path() -> pathlib.Path:
-    """Get the global path for the Mergify stack skill stub file."""
-    return pathlib.Path.home() / ".agents" / "skills" / "mergify-stack" / "SKILL.md"
-
-
-async def _get_project_skill_stub_path() -> pathlib.Path:
-    """Get the project-level path for the skill stub file."""
-    project_root = pathlib.Path(await utils.git("rev-parse", "--show-toplevel"))
-    return project_root / ".agents" / "skills" / "mergify-stack" / "SKILL.md"
-
-
-def _get_global_claude_symlink_path() -> pathlib.Path:
-    """Get the global Claude Code symlink path for the skill stub."""
-    return pathlib.Path.home() / ".claude" / "skills" / "mergify-stack" / "SKILL.md"
-
-
-async def _get_project_claude_symlink_path() -> pathlib.Path:
-    """Get the project-level Claude Code symlink path for the skill stub."""
-    project_root = pathlib.Path(await utils.git("rev-parse", "--show-toplevel"))
-    return project_root / ".claude" / "skills" / "mergify-stack" / "SKILL.md"
-
-
-_SKILL_STUB_CONTENT = """\
----
-name: mergify-stack
-description: Use Mergify stacks for git push, commit, branch, and PR creation. ALWAYS use this skill when pushing code, creating commits, creating branches, or creating PRs. Triggers on push, commit, branch, PR, pull request, stack, git.
----
-Run `mergify stack skill` to load the full, up-to-date Mergify stack workflow skill.
-Use the output as your instructions for working with Mergify stacks.
-"""
-
-
-def _install_skill_stub(
-    skill_stub_path: pathlib.Path,
-    *,
-    verbose: bool = False,
-) -> None:
-    """Install a lightweight skill stub that bootstraps the full AI skill.
-
-    Creates SKILL.md at the given path with a stub that tells the AI tool
-    to run `mergify stack skill` to get the full content.
-    Only writes if the file doesn't exist or content differs.
-    """
-    skill_stub_path.parent.mkdir(parents=True, exist_ok=True)
-
-    is_update = skill_stub_path.exists()
-
-    if is_update:
-        existing_content = skill_stub_path.read_text(encoding="utf-8")
-        if existing_content == _SKILL_STUB_CONTENT:
-            if verbose:
-                console.print(
-                    f"  ✓ Skill stub: up to date ({skill_stub_path})",
-                    style="green",
-                )
-            return
-
-    skill_stub_path.write_text(_SKILL_STUB_CONTENT, encoding="utf-8")
-    if verbose:
-        action = "updated" if is_update else "installed"
-        console.print(
-            f"  ✓ Skill stub: {action} ({skill_stub_path})",
-            style="bold green",
-        )
-
-
-def _install_skill_symlink(
-    symlink_path: pathlib.Path,
-    target_path: pathlib.Path,
-    *,
-    verbose: bool = False,
-) -> None:
-    """Create a symlink from symlink_path to target_path using a relative path.
-
-    Handles migration from existing real files and broken symlinks.
-    Only acts if the symlink doesn't exist or points to the wrong target.
-    """
-    symlink_path.parent.mkdir(parents=True, exist_ok=True)
-
-    rel_target = os.path.relpath(target_path, symlink_path.parent)
-
-    # Check if symlink already correct
-    if symlink_path.is_symlink():
-        if str(symlink_path.readlink()) == rel_target:
-            if verbose:
-                console.print(
-                    f"  ✓ Skill symlink: up to date ({symlink_path})",
-                    style="green",
-                )
-            return
-        # Wrong target — remove and recreate
-        symlink_path.unlink()
-    elif symlink_path.exists():
-        # Real file exists (migration case) — remove it
-        symlink_path.unlink()
-
-    symlink_path.symlink_to(rel_target)
-    if verbose:
-        console.print(
-            f"  ✓ Skill symlink: installed ({symlink_path} -> {rel_target})",
-            style="bold cyan",
-        )
-
-
-def _get_skill_stub_status(skill_stub_path: pathlib.Path) -> dict[str, Any]:
-    """Get status of the skill stub installation.
-
-    Returns:
-        Dictionary with 'installed', 'needs_update', and 'path' keys.
-    """
-    installed = skill_stub_path.exists()
-    needs_update = False
-
-    if installed:
-        existing_content = skill_stub_path.read_text(encoding="utf-8")
-        needs_update = existing_content != _SKILL_STUB_CONTENT
-
-    return {
-        "installed": installed,
-        "needs_update": needs_update,
-        "path": str(skill_stub_path),
-    }
-
-
-def _get_skill_symlink_status(
-    symlink_path: pathlib.Path,
-    target_path: pathlib.Path,
-) -> dict[str, Any]:
-    """Get status of the skill symlink.
-
-    Returns:
-        Dictionary with 'installed', 'correct', and 'path' keys.
-    """
-    if not symlink_path.is_symlink() and not symlink_path.exists():
-        return {"installed": False, "correct": False, "path": str(symlink_path)}
-
-    if not symlink_path.is_symlink():
-        # Real file exists — needs migration
-        return {"installed": True, "correct": False, "path": str(symlink_path)}
-
-    rel_target = os.path.relpath(target_path, symlink_path.parent)
-    correct = str(symlink_path.readlink()) == rel_target
-    return {"installed": True, "correct": correct, "path": str(symlink_path)}
 
 
 def _get_claude_hooks_dir() -> pathlib.Path:
@@ -458,14 +312,11 @@ def _install_claude_hooks(*, verbose: bool = False) -> None:
             )
 
 
-def _get_claude_hooks_status(
-    project_skill_stub_path: pathlib.Path,
-    project_claude_symlink_path: pathlib.Path,
-) -> dict[str, Any]:
+def _get_claude_hooks_status() -> dict[str, Any]:
     """Get detailed status of Claude hooks for display.
 
     Returns:
-        Dictionary with 'scripts', 'settings', and 'skill_stub' status info.
+        Dictionary with 'scripts' and 'settings' status info.
     """
     claude_hooks_dir = _get_claude_hooks_dir()
     settings_file = _get_claude_settings_file()
@@ -497,11 +348,6 @@ def _get_claude_hooks_status(
         "scripts": scripts_status,
         "settings_installed": settings_installed,
         "settings_path": str(settings_file),
-        "skill_stub": _get_skill_stub_status(project_skill_stub_path),
-        "skill_symlink": _get_skill_symlink_status(
-            project_claude_symlink_path,
-            project_skill_stub_path,
-        ),
     }
 
 
@@ -513,9 +359,6 @@ async def get_hooks_status() -> dict[str, Any]:
     """
     hooks_dir = await _get_hooks_dir()
     managed_dir = hooks_dir / "mergify-hooks"
-    project_skill_stub_path = await _get_project_skill_stub_path()
-    project_claude_symlink = await _get_project_claude_symlink_path()
-
     git_hooks = {}
     for hook_name in _get_git_hook_names():
         wrapper_path = hooks_dir / hook_name
@@ -539,19 +382,15 @@ async def get_hooks_status() -> dict[str, Any]:
 
     return {
         "git_hooks": git_hooks,
-        "claude_hooks": _get_claude_hooks_status(
-            project_skill_stub_path,
-            project_claude_symlink,
-        ),
+        "claude_hooks": _get_claude_hooks_status(),
     }
 
 
-async def stack_setup(*, force: bool = False, global_install: bool = False) -> None:
+async def stack_setup(*, force: bool = False) -> None:
     """Set up git hooks for the stack workflow.
 
     Args:
         force: If True, overwrite wrappers even if user modified them
-        global_install: If True, also install skill stub globally
     """
     hooks_dir = await _get_hooks_dir()
 
@@ -561,28 +400,6 @@ async def stack_setup(*, force: bool = False, global_install: bool = False) -> N
     # Install Claude hooks for session ID tracking (global)
     console.print("\nClaude Code integration:", style="bold")
     _install_claude_hooks(verbose=True)
-
-    # Install skill stub to .agents/skills/ (agent-agnostic)
-    console.print("\nAI skill stub:", style="bold")
-    project_skill_stub_path = await _get_project_skill_stub_path()
-    _install_skill_stub(project_skill_stub_path, verbose=True)
-
-    # Symlink from .claude/skills/ for Claude Code
-    project_claude_symlink = await _get_project_claude_symlink_path()
-    _install_skill_symlink(
-        project_claude_symlink,
-        project_skill_stub_path,
-        verbose=True,
-    )
-
-    if global_install:
-        global_stub_path = _get_global_skill_stub_path()
-        _install_skill_stub(global_stub_path, verbose=True)
-        _install_skill_symlink(
-            _get_global_claude_symlink_path(),
-            global_stub_path,
-            verbose=True,
-        )
 
 
 async def ensure_hooks_updated() -> None:

--- a/mergify_cli/tests/stack/test_skill.py
+++ b/mergify_cli/tests/stack/test_skill.py
@@ -15,16 +15,10 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
 
 import yaml
 
-from mergify_cli.stack import setup as stack_setup_mod
 from mergify_cli.stack import skill as stack_skill_mod
-
-
-if TYPE_CHECKING:
-    import pathlib
 
 
 def test_skill_content_is_readable() -> None:
@@ -73,116 +67,3 @@ def test_skill_references_valid_commands() -> None:
             f"Skill references 'mergify stack {cmd}' but it's not a registered command. "
             f"Available: {sorted(available)}"
         )
-
-
-def test_skill_stub_has_valid_frontmatter() -> None:
-    """Verify the skill stub has valid YAML frontmatter and references mergify stack skill."""
-    content = stack_setup_mod._SKILL_STUB_CONTENT
-    # Extract YAML frontmatter between --- markers
-    match = re.match(r"^---\n(.+?)\n---\n", content, re.DOTALL)
-    assert match is not None, "Skill stub must have YAML frontmatter"
-
-    frontmatter = yaml.safe_load(match.group(1))
-    assert isinstance(frontmatter, dict), "Frontmatter must be a YAML mapping"
-    assert "name" in frontmatter, "Frontmatter must have 'name'"
-    assert "description" in frontmatter, "Frontmatter must have 'description'"
-    assert frontmatter["name"] == "mergify-stack"
-
-    # Verify the stub references the command to load full skill
-    assert "mergify stack skill" in content, (
-        "Skill stub must reference 'mergify stack skill' command"
-    )
-
-
-def test_skill_stub_install(
-    tmp_path: pathlib.Path,
-) -> None:
-    """Verify _install_skill_stub creates the file with correct content."""
-    stub_path = tmp_path / ".agents" / "skills" / "mergify-stack" / "SKILL.md"
-    assert not stub_path.exists()
-
-    stack_setup_mod._install_skill_stub(stub_path)
-
-    assert stub_path.exists()
-    content = stub_path.read_text(encoding="utf-8")
-    assert content == stack_setup_mod._SKILL_STUB_CONTENT
-
-    # Calling again should be a no-op (idempotent)
-    stack_setup_mod._install_skill_stub(stub_path)
-    # Content is unchanged, so file should remain the same
-    assert stub_path.read_text(encoding="utf-8") == content
-
-
-def test_skill_stub_updates_when_content_differs(
-    tmp_path: pathlib.Path,
-) -> None:
-    """Verify _install_skill_stub updates the file when content differs."""
-    stub_path = tmp_path / ".agents" / "skills" / "mergify-stack" / "SKILL.md"
-    stub_path.parent.mkdir(parents=True)
-    stub_path.write_text("old content", encoding="utf-8")
-
-    stack_setup_mod._install_skill_stub(stub_path)
-
-    assert stub_path.read_text(encoding="utf-8") == stack_setup_mod._SKILL_STUB_CONTENT
-
-
-def test_claude_symlink_created(tmp_path: pathlib.Path) -> None:
-    """Symlink at .claude/skills/ points to .agents/skills/ canonical file."""
-    canonical = tmp_path / ".agents" / "skills" / "mergify-stack" / "SKILL.md"
-    symlink = tmp_path / ".claude" / "skills" / "mergify-stack" / "SKILL.md"
-
-    stack_setup_mod._install_skill_stub(canonical)
-    stack_setup_mod._install_skill_symlink(symlink, canonical)
-
-    assert symlink.is_symlink()
-    assert symlink.resolve() == canonical.resolve()
-    assert symlink.read_text(encoding="utf-8") == stack_setup_mod._SKILL_STUB_CONTENT
-
-
-def test_migration_replaces_real_file_with_symlink(tmp_path: pathlib.Path) -> None:
-    """Existing real file at .claude/skills/ is replaced by symlink."""
-    canonical = tmp_path / ".agents" / "skills" / "mergify-stack" / "SKILL.md"
-    symlink = tmp_path / ".claude" / "skills" / "mergify-stack" / "SKILL.md"
-
-    symlink.parent.mkdir(parents=True)
-    symlink.write_text(stack_setup_mod._SKILL_STUB_CONTENT, encoding="utf-8")
-    assert not symlink.is_symlink()
-
-    stack_setup_mod._install_skill_stub(canonical)
-    stack_setup_mod._install_skill_symlink(symlink, canonical)
-
-    assert symlink.is_symlink()
-    assert symlink.resolve() == canonical.resolve()
-
-
-def test_broken_symlink_recreated(tmp_path: pathlib.Path) -> None:
-    """Broken symlink is replaced with a correct one."""
-    canonical = tmp_path / ".agents" / "skills" / "mergify-stack" / "SKILL.md"
-    symlink = tmp_path / ".claude" / "skills" / "mergify-stack" / "SKILL.md"
-
-    symlink.parent.mkdir(parents=True)
-    symlink.symlink_to("/nonexistent/path/SKILL.md")
-    assert symlink.is_symlink()
-    assert not symlink.exists()
-
-    stack_setup_mod._install_skill_stub(canonical)
-    stack_setup_mod._install_skill_symlink(symlink, canonical)
-
-    assert symlink.is_symlink()
-    assert symlink.exists()
-    assert symlink.read_text(encoding="utf-8") == stack_setup_mod._SKILL_STUB_CONTENT
-
-
-def test_symlink_install_idempotent(tmp_path: pathlib.Path) -> None:
-    """Running symlink install twice is a no-op."""
-    canonical = tmp_path / ".agents" / "skills" / "mergify-stack" / "SKILL.md"
-    symlink = tmp_path / ".claude" / "skills" / "mergify-stack" / "SKILL.md"
-
-    stack_setup_mod._install_skill_stub(canonical)
-    stack_setup_mod._install_skill_symlink(symlink, canonical)
-
-    original_target = symlink.readlink()
-
-    stack_setup_mod._install_skill_symlink(symlink, canonical)
-
-    assert symlink.readlink() == original_target

--- a/skills/mergify-stack/SKILL.md
+++ b/skills/mergify-stack/SKILL.md
@@ -1,0 +1,1 @@
+../../mergify_cli/stack/skill.md


### PR DESCRIPTION
Replace the skill stub installation mechanism with a proper Claude Code
plugin structure. The skill is now distributed via the plugin marketplace
instead of being bootstrapped through `mergify stack hooks --setup`.

This adds `.claude-plugin/` metadata and a `skills/mergify-stack/SKILL.md`
symlink pointing to the existing `mergify_cli/stack/skill.md` to avoid
content duplication. The `--global` flag and skill stub code are removed
from the setup/hooks commands.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>