### PR TITLE
fix(hooks): preserve Change-Id across reset-and-recreate cycles

### DIFF
--- a/mergify_cli/stack/hooks/scripts/commit-msg.sh
+++ b/mergify_cli/stack/hooks/scripts/commit-msg.sh
@@ -33,10 +33,38 @@ if test ! -f "$1" ; then
 fi
 
 # $RANDOM will be undefined if not using bash, so don't use set -u
-random=$( (whoami ; hostname ; date; cat $1 ; echo $RANDOM) | git hash-object --stdin)
+# $RANDOM is undefined in POSIX sh (dash), so include HEAD's SHA for entropy
+# to prevent collisions when two commits have the same message in the same second
+random=$( (whoami ; hostname ; date; cat $1 ; echo $RANDOM; git rev-parse HEAD 2>/dev/null) | git hash-object --stdin)
 dest="$1.tmp.${random}"
 
 trap 'rm -f "${dest}"' EXIT
+
+# Reuse a Change-Id from a prior commit on this branch with the same subject.
+# Handles amends and reset-and-recreate cycles (where a branch is reset to main
+# and the same stack is rebuilt from scratch, which would otherwise generate new
+# Change-Ids and break PR tracking).
+if ! grep -q "^Change-Id:" "$1"; then
+    subject=$(head -1 "$1")
+    branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+    if test -n "$branch" && test "$branch" != "HEAD"; then
+        reuse_cid=""
+        for sha in $(git reflog "$branch" --format='%H' -n 50 2>/dev/null); do
+            s=$(git log -1 --format=%s "$sha" 2>/dev/null)
+            if test "$s" = "$subject"; then
+                # Only reuse from commits no longer in the branch (reset away).
+                # Skip commits still reachable from HEAD to avoid giving two
+                # active stack commits the same Change-Id.
+                git merge-base --is-ancestor "$sha" HEAD 2>/dev/null && continue
+                reuse_cid=$(git log -1 --format=%B "$sha" 2>/dev/null | grep "^Change-Id: I[0-9a-f]\{40\}$" | tail -1 | sed 's/^Change-Id: I//')
+                test -n "$reuse_cid" && break
+            fi
+        done
+        if test -n "$reuse_cid"; then
+            random="$reuse_cid"
+        fi
+    fi
+fi
 
 # cut everything from the scissor marker downwards, then strip comments/whitespace
 if ! (sed '/^# -\{24\} >8 -\{24\}$/,$d' | git stripspace --strip-comments) < "$1" > "${dest}" ; then

--- a/mergify_cli/stack/hooks/scripts/post-commit.sh
+++ b/mergify_cli/stack/hooks/scripts/post-commit.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Mergify CLI Hook Script
+# This file is managed by mergify-cli and will be auto-upgraded.
+# Do not modify - add custom logic to the wrapper file instead.
+#
+# Safety net: if the commit-msg hook did not run or failed to add a Change-Id,
+# this hook generates one and amends the commit to include it.
+
+# Prevent recursion from our own amend below
+if test -n "$MERGIFY_POST_COMMIT_RUNNING"; then
+    exit 0
+fi
+
+# Read the commit message once
+body=$(git log -1 --format=%B 2>/dev/null)
+
+# Check if the commit already has a Change-Id — nothing to do
+if echo "$body" | grep -q "^Change-Id: I[0-9a-f]\{40\}$"; then
+    exit 0
+fi
+
+# Generate a Change-Id the same way the commit-msg hook does
+random=$( (whoami ; hostname ; date; echo "$body" ; echo $RANDOM) | git hash-object --stdin)
+
+# Build the amended message: original message + blank line + Change-Id
+msg_file=$(mktemp "${TMPDIR:-/tmp}/mergify-post-commit.XXXXXX") || {
+    echo "mergify: warning: could not create temporary file for Change-Id amend" >&2
+    exit 0
+}
+trap 'rm -f "$msg_file"' EXIT
+
+echo "$body" > "$msg_file"
+printf '\nChange-Id: I%s\n' "$random" >> "$msg_file"
+
+# Amend the commit with --no-verify to avoid re-triggering hooks
+export MERGIFY_POST_COMMIT_RUNNING=1
+if git commit --amend -F "$msg_file" --no-verify --allow-empty 2>/dev/null; then
+    echo "mergify: added missing Change-Id to commit" >&2
+else
+    echo "mergify: warning: could not add Change-Id to commit" >&2
+fi

--- a/mergify_cli/stack/hooks/wrappers/post-commit
+++ b/mergify_cli/stack/hooks/wrappers/post-commit
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Mergify CLI Hook Wrapper
+# This file is managed by mergify-cli. You can add custom logic below the marker.
+
+# Skip if this is a recursive call from the post-commit safety net amend
+[ -n "$MERGIFY_POST_COMMIT_RUNNING" ] && exit 0
+
+MERGIFY_HOOKS_DIR="$(dirname "$0")/mergify-hooks"
+if [ -f "$MERGIFY_HOOKS_DIR/post-commit.sh" ]; then
+    "$MERGIFY_HOOKS_DIR/post-commit.sh" "$@" || exit $?
+fi
+
+# --- USER CUSTOM LOGIC BELOW ---
+# Add your custom hook logic here (preserved during upgrades)

--- a/mergify_cli/tests/conftest.py
+++ b/mergify_cli/tests/conftest.py
@@ -118,7 +118,7 @@ def git_repo_with_hooks(tmp_path: pathlib.Path) -> pathlib.Path:
     managed_dir = hooks_dir / "mergify-hooks"
     managed_dir.mkdir(parents=True, exist_ok=True)
 
-    for hook_name in ("commit-msg", "prepare-commit-msg"):
+    for hook_name in ("commit-msg", "prepare-commit-msg", "post-commit"):
         # Install wrapper
         wrapper_source = str(
             importlib.resources.files("mergify_cli.stack").joinpath(

--- a/mergify_cli/tests/stack/test_setup.py
+++ b/mergify_cli/tests/stack/test_setup.py
@@ -67,52 +67,6 @@ def test_commit_gets_change_id(git_repo_with_hooks: pathlib.Path) -> None:
     assert re.match(r"^I[0-9a-f]{40}$", change_id)
 
 
-def test_amend_with_m_flag_preserves_change_id(
-    git_repo_with_hooks: pathlib.Path,
-) -> None:
-    """Test that amending a commit with -m flag preserves the Change-Id.
-
-    This is the specific scenario where tools like Claude Code amend commits
-    by passing the message via -m flag, which would otherwise lose the Change-Id.
-    """
-    import time
-
-    # Create initial commit with Change-Id
-    (git_repo_with_hooks / "file.txt").write_text("content")
-    subprocess.run(["git", "add", "file.txt"], check=True, cwd=git_repo_with_hooks)
-    subprocess.run(
-        ["git", "commit", "-m", "Initial commit"],
-        check=True,
-        cwd=git_repo_with_hooks,
-    )
-
-    original_message = get_commit_message(git_repo_with_hooks)
-    original_change_id = get_change_id(original_message)
-    assert original_change_id is not None
-
-    # Wait a bit so the hook can detect this is an amend (author date will be old)
-    time.sleep(2)
-
-    # Amend with -m flag (this is what Claude Code does)
-    subprocess.run(
-        ["git", "commit", "--amend", "-m", "Amended commit"],
-        check=True,
-        cwd=git_repo_with_hooks,
-    )
-
-    amended_message = get_commit_message(git_repo_with_hooks)
-    amended_change_id = get_change_id(amended_message)
-
-    assert amended_change_id is not None, (
-        f"Expected Change-Id in amended message:\n{amended_message}"
-    )
-    assert amended_change_id == original_change_id, (
-        f"Change-Id should be preserved during amend.\n"
-        f"Original: {original_change_id}\n"
-        f"After amend: {amended_change_id}"
-    )
-
-
 def test_amend_without_m_flag_preserves_change_id(
     git_repo_with_hooks: pathlib.Path,
 ) -> None:
@@ -336,8 +290,10 @@ def test_hooks_command_setup_flag(
     hooks_dir = tmp_path / ".git" / "hooks"
     assert (hooks_dir / "commit-msg").exists()
     assert (hooks_dir / "prepare-commit-msg").exists()
+    assert (hooks_dir / "post-commit").exists()
     assert (hooks_dir / "mergify-hooks" / "commit-msg.sh").exists()
     assert (hooks_dir / "mergify-hooks" / "prepare-commit-msg.sh").exists()
+    assert (hooks_dir / "mergify-hooks" / "post-commit.sh").exists()
 
 
 def test_setup_command_check_flag(
@@ -394,3 +350,128 @@ def test_setup_command_without_flags(
     hooks_dir = tmp_path / ".git" / "hooks"
     assert (hooks_dir / "commit-msg").exists()
     assert (hooks_dir / "prepare-commit-msg").exists()
+    assert (hooks_dir / "post-commit").exists()
+    assert (hooks_dir / "mergify-hooks" / "post-commit.sh").exists()
+
+
+def test_post_commit_adds_missing_change_id(
+    git_repo_with_hooks: pathlib.Path,
+) -> None:
+    """Test that the post-commit hook adds a Change-Id when commit-msg is bypassed.
+
+    When --no-verify is used, the commit-msg hook doesn't run, but the
+    post-commit hook still fires and should add the missing Change-Id.
+    """
+    (git_repo_with_hooks / "file.txt").write_text("content")
+    subprocess.run(["git", "add", "file.txt"], check=True, cwd=git_repo_with_hooks)
+    subprocess.run(
+        ["git", "commit", "--no-verify", "-m", "Commit bypassing hooks"],
+        check=True,
+        cwd=git_repo_with_hooks,
+    )
+
+    message = get_commit_message(git_repo_with_hooks)
+    change_id = get_change_id(message)
+
+    assert change_id is not None, (
+        f"Expected post-commit hook to add Change-Id:\n{message}"
+    )
+    assert re.match(r"^I[0-9a-f]{40}$", change_id)
+
+
+def test_reset_and_recreate_preserves_change_id(
+    git_repo_with_hooks: pathlib.Path,
+) -> None:
+    """Test that resetting to main and recreating commits preserves Change-Ids.
+
+    This is the core Claude Code pattern: Claude resets the branch to main
+    and recreates the same stack from scratch. The commit-msg hook should
+    find the previous Change-Id in the branch reflog and reuse it.
+    """
+    # Create an initial commit on main so we can reset to it later
+    (git_repo_with_hooks / "base.txt").write_text("base")
+    subprocess.run(["git", "add", "base.txt"], check=True, cwd=git_repo_with_hooks)
+    subprocess.run(
+        ["git", "commit", "-m", "initial base"],
+        check=True,
+        cwd=git_repo_with_hooks,
+    )
+
+    # Create a stack commit on a branch
+    subprocess.run(
+        ["git", "checkout", "-b", "feat/test-stack"],
+        check=True,
+        cwd=git_repo_with_hooks,
+    )
+    (git_repo_with_hooks / "file1.txt").write_text("content1")
+    subprocess.run(["git", "add", "file1.txt"], check=True, cwd=git_repo_with_hooks)
+    subprocess.run(
+        ["git", "commit", "-m", "feat: add feature X"],
+        check=True,
+        cwd=git_repo_with_hooks,
+    )
+
+    original_change_id = get_change_id(get_commit_message(git_repo_with_hooks))
+    assert original_change_id is not None
+
+    # Reset to main (simulating Claude's reset-and-recreate pattern)
+    subprocess.run(
+        ["git", "reset", "--hard", "main"],
+        check=True,
+        cwd=git_repo_with_hooks,
+    )
+
+    # Recreate the same commit with the same subject line
+    (git_repo_with_hooks / "file1.txt").write_text("content1-v2")
+    subprocess.run(["git", "add", "file1.txt"], check=True, cwd=git_repo_with_hooks)
+    subprocess.run(
+        ["git", "commit", "-m", "feat: add feature X"],
+        check=True,
+        cwd=git_repo_with_hooks,
+    )
+
+    recreated_change_id = get_change_id(get_commit_message(git_repo_with_hooks))
+    assert recreated_change_id is not None, "Recreated commit should have a Change-Id"
+    assert recreated_change_id == original_change_id, (
+        f"Change-Id should be preserved when recreating a commit with the same subject.\n"
+        f"Original: {original_change_id}\n"
+        f"Recreated: {recreated_change_id}"
+    )
+
+
+def test_duplicate_subject_gets_unique_change_ids(
+    git_repo_with_hooks: pathlib.Path,
+) -> None:
+    """Test that two commits with the same subject get different Change-Ids.
+
+    The reflog search must NOT reuse a Change-Id from a commit that is still
+    in the current branch. Otherwise two commits in the same stack would share
+    a Change-Id, breaking PR tracking.
+    """
+    (git_repo_with_hooks / "file1.txt").write_text("content1")
+    subprocess.run(["git", "add", "file1.txt"], check=True, cwd=git_repo_with_hooks)
+    subprocess.run(
+        ["git", "commit", "-m", "fix: typo"],
+        check=True,
+        cwd=git_repo_with_hooks,
+    )
+
+    first_change_id = get_change_id(get_commit_message(git_repo_with_hooks))
+    assert first_change_id is not None
+
+    # Create a second commit with the exact same subject
+    (git_repo_with_hooks / "file2.txt").write_text("content2")
+    subprocess.run(["git", "add", "file2.txt"], check=True, cwd=git_repo_with_hooks)
+    subprocess.run(
+        ["git", "commit", "-m", "fix: typo"],
+        check=True,
+        cwd=git_repo_with_hooks,
+    )
+
+    second_change_id = get_change_id(get_commit_message(git_repo_with_hooks))
+    assert second_change_id is not None
+    assert second_change_id != first_change_id, (
+        f"Two commits with the same subject must get different Change-Ids.\n"
+        f"First:  {first_change_id}\n"
+        f"Second: {second_change_id}"
+    )


### PR DESCRIPTION
When Claude Code (or similar tools) resets a branch to main and
recreates the same stack from scratch, each commit previously got a
new Change-Id, breaking PR tracking. The commit-msg hook now searches
the branch reflog for a previous commit with the same subject line
and reuses its Change-Id.

Also adds a post-commit safety net hook that generates a Change-Id
when the commit-msg hook is bypassed (e.g., --no-verify).