### PR TITLE
style: use compact Unicode symbols instead of emoji in CLI output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Agent Instructions
+
+## CLI Output Style
+
+Use compact Unicode symbols for terminal output, not emoji. This keeps new and
+updated terminal output consistent and avoids rendering issues across terminals.
+
+**Preferred symbols:**
+- `✓` success, approved, merged
+- `✗` failure, conflict, changes requested
+- `●` active, pending, in progress
+- `○` inactive, skipped, none
+- `—` unknown, not applicable
+
+**Avoid in terminal output:** `✅`, `❌`, `🟢`, `🔴`, `📝`, `⚠️`, `🔄`, `📦`, `🤖`, `🔗`
+and other emoji. They can render at inconsistent widths across terminals and
+break column alignment.
+
+**Exception:** Emoji are acceptable in markdown output destined for GitHub
+(PR comments, CI summaries) where they render consistently.

--- a/mergify_cli/stack/hooks/scripts/pre-push.sh
+++ b/mergify_cli/stack/hooks/scripts/pre-push.sh
@@ -40,7 +40,7 @@ if test "$has_change_id" -eq 0; then
 fi
 
 echo ""
-echo "⚠  This branch is managed by Mergify stacks."
+echo "This branch is managed by Mergify stacks."
 echo "   Use 'mergify stack push' instead of 'git push'."
 echo ""
 echo "   'mergify stack push' will:"


### PR DESCRIPTION
Adds AGENTS.md with CLI output style guideline: prefer compact Unicode
symbols (✓ ✗ ● ○ —) over emoji for consistent terminal rendering.

Replaces all emoji in the stack module (setup.py, pre-push.sh) with
the compact symbols to match the queue module's existing style.


Claude-Session-Id: 2d9f4a52-4a1d-4a50-a459-3b57847dec9f