### PR TITLE
fix(plugin): rename marketplace plugin from mergify to mergify-stack

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "plugins": [
     {
-      "name": "mergify",
+      "name": "mergify-stack",
       "source": "./",
       "description": "Stacked PRs, merge queues, and Git workflow automation"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "mergify",
+  "name": "mergify-stack",
   "description": "Mergify CLI integration for stacked PRs, merge queues, and Git workflows",
   "author": {
     "name": "Mergify"


### PR DESCRIPTION
The Claude Code marketplace plugin name should match the skill name
"mergify-stack" for consistency and discoverability.