### PR TITLE
fix(stack): auto-set upstream when missing instead of crashing

### DIFF
--- a/mergify_cli/tests/test_utils.py
+++ b/mergify_cli/tests/test_utils.py
@@ -50,6 +50,58 @@ async def test_get_trunk() -> None:
     assert await utils.get_trunk() == "origin/main"
 
 
+@pytest.mark.usefixtures("_git_repo")
+async def test_get_trunk_auto_sets_upstream_when_missing() -> None:
+    await utils.git("checkout", "-b", "feature-branch")
+    # No upstream is set for feature-branch; get_trunk should auto-detect
+    # from origin/HEAD and set the upstream
+    original_git = utils.git
+
+    async def patched_git(*args: str) -> str:
+        if args[:2] == ("branch", "feature-branch"):
+            # Simulate successful set-upstream-to without a real remote
+            await original_git(
+                "config",
+                "branch.feature-branch.remote",
+                "origin",
+            )
+            await original_git(
+                "config",
+                "branch.feature-branch.merge",
+                "refs/heads/main",
+            )
+            return ""
+        return await original_git(*args)
+
+    with (
+        mock.patch.object(
+            utils,
+            "_get_default_remote_branch",
+            return_value=("origin", "main"),
+        ),
+        mock.patch.object(utils, "git", side_effect=patched_git),
+    ):
+        result = await utils.get_trunk()
+    assert result == "origin/main"
+    # Verify the upstream was set
+    assert await utils.git_get_target_branch("feature-branch") == "main"
+    assert await utils.git_get_target_remote("feature-branch") == "origin"
+
+
+@pytest.mark.usefixtures("_git_repo")
+async def test_get_trunk_fails_when_no_upstream_and_no_default() -> None:
+    await utils.git("checkout", "-b", "feature-branch")
+    with (
+        mock.patch.object(
+            utils,
+            "_get_default_remote_branch",
+            side_effect=utils.CommandError((), 1, b""),
+        ),
+        pytest.raises(utils.CommandError),
+    ):
+        await utils.get_trunk()
+
+
 @pytest.mark.parametrize(
     ("default_arg_fct", "config_get_result", "expected_default"),
     [

--- a/mergify_cli/utils.py
+++ b/mergify_cli/utils.py
@@ -158,31 +158,67 @@ async def get_default_create_as_draft() -> bool:
     return result == "true"
 
 
+async def _get_default_remote_branch() -> tuple[str, str]:
+    """Detect the default branch from the remote (e.g. origin/main).
+
+    Returns (remote, branch) tuple.
+    """
+    ref = await git("symbolic-ref", "refs/remotes/origin/HEAD")
+    # ref is like "refs/remotes/origin/main"
+    prefix = "refs/remotes/"
+    ref = ref.removeprefix(prefix)
+    remote, _, branch = ref.partition("/")
+    return remote, branch
+
+
 async def get_trunk() -> str:
     try:
         branch_name = await git_get_branch_name()
     except CommandError:
         console.print("error: can't get the current branch", style="red")
         raise
+
+    target_branch = None
+    target_remote = None
     try:
         target_branch = await git_get_target_branch(branch_name)
     except CommandError:
-        # It's possible this has not been set; ignore
-        console.print("error: can't get the remote target branch", style="red")
-        console.print(
-            f"Please set the target branch with `git branch {branch_name} --set-upstream-to=<remote>/<branch>",
-            style="red",
-        )
-        raise
-
+        pass
     try:
         target_remote = await git_get_target_remote(branch_name)
     except CommandError:
-        console.print(
-            f"error: can't get the target remote for branch {branch_name}",
-            style="red",
+        pass
+
+    if target_branch is None or target_remote is None:
+        try:
+            default_remote, default_branch = await _get_default_remote_branch()
+        except CommandError:
+            console.print(
+                f"error: can't detect the remote target branch for {branch_name}",
+                style="red",
+            )
+            console.print(
+                f"Please set it with `git branch {branch_name} --set-upstream-to=<remote>/<branch>`",
+            )
+            raise
+
+        if target_branch is None:
+            target_branch = default_branch
+        if target_remote is None:
+            target_remote = default_remote
+
+        await git(
+            "branch",
+            branch_name,
+            "--set-upstream-to",
+            f"{target_remote}/{target_branch}",
         )
-        raise
+        console.print(
+            f"Upstream not set for {branch_name}, "
+            f"automatically set to {target_remote}/{target_branch}",
+            style="yellow",
+        )
+
     return f"{target_remote}/{target_branch}"
 
 


### PR DESCRIPTION
When a branch has no upstream configured, automatically detect the
default remote branch via `git symbolic-ref` and set the upstream,
instead of showing an unfriendly traceback.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>