### PR TITLE
feat(stack): add optional commit argument to `stack edit`

### DIFF
--- a/mergify_cli/stack/cli.py
+++ b/mergify_cli/stack/cli.py
@@ -198,9 +198,10 @@ async def setup(*, force: bool, check: bool) -> None:
 
 
 @stack.command(help="Edit the stack history")
+@click.argument("commit", required=False, default=None)
 @utils.run_with_asyncio
-async def edit() -> None:
-    await stack_edit_mod.stack_edit()
+async def edit(*, commit: str | None) -> None:
+    await stack_edit_mod.stack_edit(commit_prefix=commit)
 
 
 @stack.command(help="Reorder the stack's commits")

--- a/mergify_cli/stack/edit.py
+++ b/mergify_cli/stack/edit.py
@@ -2,11 +2,50 @@ from __future__ import annotations
 
 import os
 
+from mergify_cli import console
 from mergify_cli import utils
+from mergify_cli.stack.reorder import get_stack_commits
+from mergify_cli.stack.reorder import match_commit
+from mergify_cli.stack.reorder import run_scripted_rebase
 
 
-async def stack_edit() -> None:
+async def stack_edit(commit_prefix: str | None = None) -> None:
     os.chdir(await utils.git("rev-parse", "--show-toplevel"))
     trunk = await utils.get_trunk()
     base = await utils.git("merge-base", trunk, "HEAD")
-    os.execvp("git", ("git", "rebase", "-i", f"{base}^"))  # noqa: S606
+
+    if commit_prefix is None:
+        os.execvp("git", ("git", "rebase", "-i", base))  # noqa: S606
+    else:
+        commits = get_stack_commits(base)
+        if not commits:
+            console.print("No commits in the stack", style="green")
+            return
+
+        sha, subject, _ = match_commit(commit_prefix, commits)
+        console.print(f"Editing commit: {sha[:12]} {subject}")
+        _run_edit_rebase(base, sha)
+        console.print(
+            "Amend the commit, then run: git rebase --continue",
+        )
+
+
+def _run_edit_rebase(base: str, target_sha: str) -> None:
+    """Run ``git rebase -i`` marking *target_sha* as ``edit``."""
+    script_content = (
+        "import sys\n"
+        "target = " + repr(target_sha) + "\n"
+        "todo_path = sys.argv[1]\n"
+        "with open(todo_path) as f:\n"
+        "    lines = f.readlines()\n"
+        "result = []\n"
+        "for line in lines:\n"
+        "    parts = line.split(None, 2)\n"
+        "    if len(parts) >= 2 and parts[0] == 'pick':\n"
+        "        if target.startswith(parts[1]) or parts[1].startswith(target):\n"
+        "            line = 'edit' + line[4:]\n"
+        "    result.append(line)\n"
+        "with open(todo_path, 'w') as f:\n"
+        "    f.writelines(result)\n"
+    )
+    run_scripted_rebase(base, script_content)

--- a/mergify_cli/stack/reorder.py
+++ b/mergify_cli/stack/reorder.py
@@ -92,42 +92,14 @@ def match_commit(
     return matches[0]
 
 
-def run_rebase(base: str, ordered_shas: list[str]) -> None:
-    """Run ``git rebase -i`` with a generated sequence editor script.
+def run_scripted_rebase(base: str, script_content: str) -> None:
+    """Run ``git rebase -i`` with a custom sequence-editor script.
 
-    The temporary Python script rewrites the rebase todo list so that
-    the pick lines appear in the order given by *ordered_shas*.
+    Writes *script_content* to a temporary Python file, sets it as
+    ``GIT_SEQUENCE_EDITOR``, then executes the rebase.  The temp file
+    is cleaned up afterwards regardless of outcome.
     """
-    script_content = (
-        "#!/usr/bin/env python3\n"
-        "import sys\n"
-        "order = " + repr(ordered_shas) + "\n"
-        "todo_path = sys.argv[1]\n"
-        "with open(todo_path) as f:\n"
-        "    lines = f.readlines()\n"
-        "pick_lines = {}\n"
-        "other_lines = []\n"
-        "for line in lines:\n"
-        "    stripped = line.strip()\n"
-        "    if stripped and not stripped.startswith('#'):\n"
-        "        parts = stripped.split(None, 2)\n"
-        "        if len(parts) >= 2:\n"
-        "            pick_lines[parts[1]] = line\n"
-        "        else:\n"
-        "            other_lines.append(line)\n"
-        "    else:\n"
-        "        other_lines.append(line)\n"
-        "reordered = []\n"
-        "for sha in order:\n"
-        "    for key in pick_lines:\n"
-        "        if sha.startswith(key) or key.startswith(sha):\n"
-        "            reordered.append(pick_lines[key])\n"
-        "            break\n"
-        "with open(todo_path, 'w') as f:\n"
-        "    f.writelines(reordered + other_lines)\n"
-    )
-
-    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".py", prefix="mergify_reorder_")
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".py", prefix="mergify_rebase_")
     try:
         with os.fdopen(tmp_fd, "w") as f:
             f.write(script_content)
@@ -159,6 +131,39 @@ def run_rebase(base: str, ordered_shas: list[str]) -> None:
         tmp_file = pathlib.Path(tmp_path)
         if tmp_file.exists():
             tmp_file.unlink()
+
+
+def run_rebase(base: str, ordered_shas: list[str]) -> None:
+    """Run ``git rebase -i`` reordering picks to match *ordered_shas*."""
+    script_content = (
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "order = " + repr(ordered_shas) + "\n"
+        "todo_path = sys.argv[1]\n"
+        "with open(todo_path) as f:\n"
+        "    lines = f.readlines()\n"
+        "pick_lines = {}\n"
+        "other_lines = []\n"
+        "for line in lines:\n"
+        "    stripped = line.strip()\n"
+        "    if stripped and not stripped.startswith('#'):\n"
+        "        parts = stripped.split(None, 2)\n"
+        "        if len(parts) >= 2:\n"
+        "            pick_lines[parts[1]] = line\n"
+        "        else:\n"
+        "            other_lines.append(line)\n"
+        "    else:\n"
+        "        other_lines.append(line)\n"
+        "reordered = []\n"
+        "for sha in order:\n"
+        "    for key in pick_lines:\n"
+        "        if sha.startswith(key) or key.startswith(sha):\n"
+        "            reordered.append(pick_lines[key])\n"
+        "            break\n"
+        "with open(todo_path, 'w') as f:\n"
+        "    f.writelines(reordered + other_lines)\n"
+    )
+    run_scripted_rebase(base, script_content)
 
 
 def display_plan(

--- a/mergify_cli/tests/stack/test_edit.py
+++ b/mergify_cli/tests/stack/test_edit.py
@@ -1,0 +1,202 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergify_cli.stack.edit import stack_edit
+
+
+if TYPE_CHECKING:
+    import pathlib
+
+
+def _run_git(*args: str, cwd: pathlib.Path | None = None) -> str:
+    return subprocess.check_output(
+        ["git", *args],
+        text=True,
+        cwd=cwd,
+    ).strip()
+
+
+def _create_commit(
+    repo: pathlib.Path,
+    filename: str,
+    content: str,
+    message: str,
+) -> tuple[str, str | None]:
+    """Create a commit and return (sha, change_id)."""
+    (repo / filename).write_text(content)
+    _run_git("add", filename, cwd=repo)
+    _run_git("commit", "-m", message, cwd=repo)
+    sha = _run_git("rev-parse", "HEAD", cwd=repo)
+    body = _run_git("log", "-1", "--format=%b", "HEAD", cwd=repo)
+    change_id_match = re.search(r"Change-Id: (I[0-9a-z]{40})", body)
+    return sha, change_id_match.group(1) if change_id_match else None
+
+
+def _setup_tracking(repo: pathlib.Path) -> None:
+    """Create a bare origin and set up tracking for the current branch."""
+    origin_path = repo.parent / f"{repo.name}_origin.git"
+    _run_git("init", "--bare", str(origin_path))
+    _run_git("remote", "add", "origin", str(origin_path), cwd=repo)
+    _run_git("push", "origin", "main", cwd=repo)
+    _run_git("branch", "--set-upstream-to=origin/main", cwd=repo)
+
+
+@pytest.fixture
+def stack_repo(
+    git_repo_with_hooks: pathlib.Path,
+) -> tuple[pathlib.Path, list[tuple[str, str | None]]]:
+    """Create a repo with 3 commits (A, B, C) on a feature branch."""
+    repo = git_repo_with_hooks
+
+    # Create an initial commit on main
+    (repo / "init.txt").write_text("init")
+    _run_git("add", "init.txt", cwd=repo)
+    _run_git("commit", "-m", "Initial commit", cwd=repo)
+
+    _setup_tracking(repo)
+
+    # Create a feature branch
+    _run_git("checkout", "-b", "feature", "main", cwd=repo)
+    _run_git("branch", "--set-upstream-to=origin/main", cwd=repo)
+
+    # Create 3 commits
+    commits = []
+    for label, filename in [("A", "a.txt"), ("B", "b.txt"), ("C", "c.txt")]:
+        sha, cid = _create_commit(repo, filename, f"content {label}", f"Commit {label}")
+        commits.append((sha, cid))
+
+    return repo, commits
+
+
+class TestStackEdit:
+    async def test_edit_stops_at_target_commit(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """Editing a mid-stack commit stops the rebase at that commit."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_b = commits[1][0][:12]
+        await stack_edit(commit_prefix=sha_b)
+
+        # Rebase should have stopped — HEAD is now the target commit
+        head_subject = _run_git("log", "-1", "--format=%s", cwd=repo)
+        assert head_subject == "Commit B"
+
+        # Verify we're mid-rebase
+        rebase_dir = repo / ".git" / "rebase-merge"
+        assert rebase_dir.exists()
+
+        # Clean up the rebase
+        _run_git("rebase", "--abort", cwd=repo)
+
+    async def test_edit_stops_at_first_commit(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """Editing the first commit in the stack works."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_a = commits[0][0][:12]
+        await stack_edit(commit_prefix=sha_a)
+
+        head_subject = _run_git("log", "-1", "--format=%s", cwd=repo)
+        assert head_subject == "Commit A"
+
+        rebase_dir = repo / ".git" / "rebase-merge"
+        assert rebase_dir.exists()
+
+        _run_git("rebase", "--abort", cwd=repo)
+
+    async def test_edit_stops_at_last_commit(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """Editing the last (HEAD) commit in the stack works."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_c = commits[2][0][:12]
+        await stack_edit(commit_prefix=sha_c)
+
+        head_subject = _run_git("log", "-1", "--format=%s", cwd=repo)
+        assert head_subject == "Commit C"
+
+        rebase_dir = repo / ".git" / "rebase-merge"
+        assert rebase_dir.exists()
+
+        _run_git("rebase", "--abort", cwd=repo)
+
+    async def test_edit_by_change_id(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """Editing by Change-Id prefix works."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        cid_b = commits[1][1]
+        assert cid_b is not None
+
+        await stack_edit(commit_prefix=cid_b[:8])
+
+        head_subject = _run_git("log", "-1", "--format=%s", cwd=repo)
+        assert head_subject == "Commit B"
+
+        _run_git("rebase", "--abort", cwd=repo)
+
+    async def test_edit_unknown_prefix_exits(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """Unknown commit prefix causes exit."""
+        repo, _commits = stack_repo
+        os.chdir(repo)
+
+        with pytest.raises(SystemExit) as exc_info:
+            await stack_edit(commit_prefix="deadbeef1234")
+        assert exc_info.value.code == 1
+
+    async def test_edit_empty_stack(
+        self,
+        git_repo_with_hooks: pathlib.Path,
+    ) -> None:
+        """Empty stack prints message and returns."""
+        repo = git_repo_with_hooks
+
+        (repo / "init.txt").write_text("init")
+        _run_git("add", "init.txt", cwd=repo)
+        _run_git("commit", "-m", "Initial commit", cwd=repo)
+
+        _setup_tracking(repo)
+
+        _run_git("checkout", "-b", "feature", "main", cwd=repo)
+        _run_git("branch", "--set-upstream-to=origin/main", cwd=repo)
+
+        os.chdir(repo)
+
+        # Should return without error — no commits to edit
+        await stack_edit(commit_prefix="abc")


### PR DESCRIPTION
Allow `mergify stack edit <commit>` to directly edit a specific commit
in the stack by SHA or Change-Id prefix, without opening the full
interactive rebase editor. Uses GIT_SEQUENCE_EDITOR to mark the
matched commit as `edit` automatically.

When called without arguments, the existing behavior (full interactive
rebase) is preserved.

Extract shared `run_scripted_rebase` helper from `reorder.py` to
avoid duplicating the temp-script + GIT_SEQUENCE_EDITOR plumbing.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>