### PR TITLE
chore: update skill trigger keywords for stack and queue skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "Mergify"
   },
-  "keywords": ["git", "pr", "stacked-prs", "merge-queue", "workflow"],
+  "keywords": ["git", "pr", "stacked-prs", "push", "commit", "branch", "rebase", "checkout", "workflow"],
   "license": "Apache-2.0",
   "repository": "https://github.com/Mergifyio/mergify-cli"
 }

--- a/mergify_cli/queue/skill.md
+++ b/mergify_cli/queue/skill.md
@@ -1,6 +1,6 @@
 ---
 name: mergify-merge-queue
-description: Use Mergify merge queue to monitor, inspect, pause, and manage the merge queue. ALWAYS use this skill when checking queue status, investigating PR merge state, pausing/unpausing the queue, or debugging merge failures. Triggers on merge queue, queue status, queue pause, merge, CI checks.
+description: Use Mergify merge queue to monitor, inspect, pause, and manage the merge queue. ALWAYS use this skill when checking queue status, investigating PR merge state, pausing/unpausing the queue, or debugging merge failures. Triggers on merge queue, queue status, queue pause, queue show, pause, unpause, frozen, bisecting, batch, CI checks.
 ---
 
 # Mergify Merge Queue

--- a/skills/mergify-stack/SKILL.md
+++ b/skills/mergify-stack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mergify-stack
-description: Use Mergify stacks for git push, commit, branch, and PR creation. ALWAYS use this skill when pushing code, creating commits, creating branches, or creating PRs. Triggers on push, commit, branch, PR, pull request, stack, git.
+description: Use Mergify stacks for git push, commit, branch, and PR creation. ALWAYS use this skill when pushing code, creating commits, creating branches, or creating PRs. Triggers on push, commit, branch, PR, pull request, stack, stacked, git, rebase, checkout, reorder, move, sync, amend.
 ---
 
 # Mergify Stack Workflow


### PR DESCRIPTION
Align keywords across plugin.json, stack SKILL.md, and queue skill.md:
- Stack skill: add triggers for rebase, checkout, reorder, move, sync, amend
- Queue skill: replace generic "merge" with queue-specific terms (pause,
  unpause, frozen, bisecting, batch)
- Plugin keywords: remove merge-queue (belongs to queue skill), add push,
  commit, branch, rebase, checkout

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>