### PR TITLE
feat(stack): add revision history comments for force-pushed PRs

### DIFF
--- a/mergify_cli/stack/cli.py
+++ b/mergify_cli/stack/cli.py
@@ -341,6 +341,15 @@ async def new(
     is_flag=True,
     help="Only update existing pull requests, do not create new ones",
 )
+@click.option(
+    "--no-revision-history",
+    is_flag=True,
+    flag_value=True,
+    default=lambda: not asyncio.run(utils.get_default_revision_history()),
+    help="Don't post revision history comments on pull requests. "
+    "Default fetched from git config if added with "
+    "`git config --add mergify-cli.stack-revision-history false`",
+)
 @utils.run_with_asyncio
 async def push(
     ctx: click.Context,
@@ -356,6 +365,7 @@ async def push(
     trunk: tuple[str, str],
     branch_prefix: str | None,
     only_update_existing_pulls: bool,
+    no_revision_history: bool,
 ) -> None:
     if setup:
         # backward compat
@@ -378,6 +388,7 @@ async def push(
         keep_pull_request_title_and_body=keep_pull_request_title_and_body,
         only_update_existing_pulls=only_update_existing_pulls,
         author=author,
+        revision_history=not no_revision_history,
     )
 
 

--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import datetime
 import os
 import re
 import sys
@@ -79,6 +80,46 @@ async def push_branches(
             await utils.git("push", "-f", remote, *refspecs)
         finally:
             os.environ.pop("MERGIFY_STACK_PUSH", None)
+
+
+async def _git_patch_id(sha: str) -> str:
+    """Get the patch-id of a commit, stable across rebases."""
+    diff = await utils.git("show", sha)
+    proc = await asyncio.subprocess.create_subprocess_exec(
+        "git",
+        "patch-id",
+        "--stable",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    stdout, _ = await proc.communicate(input=diff.encode())
+    if proc.returncode != 0:
+        raise utils.CommandError(
+            ("git", "patch-id"),
+            proc.returncode,
+            stdout or b"",
+        )
+    # Output format: "<patch-id> <commit-sha>"
+    return stdout.decode().strip().split()[0]
+
+
+async def detect_change_type(old_sha: str, new_sha: str) -> str:
+    """Compare patch-ids to determine if a force-push is rebase-only or content change."""
+    try:
+        old_patch_id = await _git_patch_id(old_sha)
+        new_patch_id = await _git_patch_id(new_sha)
+    except (utils.CommandError, IndexError, UnicodeDecodeError):
+        return "unknown"
+    return "rebase" if old_patch_id == new_patch_id else "content"
+
+
+async def fetch_old_pr_heads(remote: str, pr_numbers: list[int]) -> None:
+    """Fetch current PR head refs so old SHAs are available locally for patch-id comparison."""
+    if not pr_numbers:
+        return
+    refspecs = [f"refs/pull/{n}/head" for n in pr_numbers]
+    await utils.git("fetch", remote, *refspecs)
 
 
 @dataclasses.dataclass
@@ -167,6 +208,7 @@ async def stack_push(
     keep_pull_request_title_and_body: bool = False,
     only_update_existing_pulls: bool = False,
     author: str | None = None,
+    revision_history: bool = True,
 ) -> None:
     os.chdir(await utils.git("rev-parse", "--show-toplevel"))
     dest_branch = await utils.git_get_branch_name()
@@ -297,6 +339,28 @@ async def stack_push(
             console.log("[orange]Finished (dry-run mode) :tada:[/]")
             sys.exit(0)
 
+        if revision_history:
+            # Fetch old PR heads for patch-id comparison before force-pushing
+            updated_pr_numbers = [
+                int(c.pull["number"])
+                for c in planned_changes.locals
+                if c.action == "update" and c.pull is not None
+            ]
+            with console.status("Fetching old PR heads for comparison..."):
+                try:
+                    await fetch_old_pr_heads(remote, updated_pr_numbers)
+                except utils.CommandError:
+                    pass  # Non-fatal: change type will be "unknown"
+
+            # Detect change types before force-push overwrites refs
+            change_types: dict[str, str] = {}
+            for change in planned_changes.locals:
+                if change.action == "update" and change.pull is not None:
+                    change_types[change.id] = await detect_change_type(
+                        change.pull_head_sha,
+                        change.commit_sha,
+                    )
+
         with console.status("Pushing stacked branches..."):
             await push_branches(remote, planned_changes.locals)
 
@@ -338,6 +402,22 @@ async def stack_push(
             await create_or_update_comments(client, user, repo, pulls_to_comment)
 
         console.log("[green]Comments updated")
+
+        if revision_history:
+            updated_changes = [
+                (task.change, change_types.get(task.change.id, "unknown"))
+                for task in tasks
+                if task.change.action == "update" and task.change.pull is not None
+            ]
+            with console.status("Updating revision history..."):
+                await create_or_update_revision_comments(
+                    client,
+                    user,
+                    repo,
+                    github_server,
+                    updated_changes,
+                )
+            console.log("[green]Revision history updated")
 
         with console.status("Deleting unused branches..."):
             if planned_changes.orphans:
@@ -382,6 +462,145 @@ class StackComment:
         return comment["body"].startswith(
             StackComment.STACK_COMMENT_HEADER,
         ) or comment["body"].startswith(StackComment._STACK_COMMENT_OLD_HEADER)
+
+
+@dataclasses.dataclass
+class _RevisionEntry:
+    number: int
+    change_type: str
+    old_sha: str | None  # None for "initial"
+    new_sha: str
+    timestamp: str  # "YYYY-MM-DD HH:MM UTC"
+
+
+@dataclasses.dataclass
+class RevisionHistoryComment:
+    github_server: str
+    user: str
+    repo: str
+    entries: list[_RevisionEntry]
+    _raw_rows: list[str] = dataclasses.field(default_factory=list)
+
+    REVISION_COMMENT_FIRST_LINE: typing.ClassVar[str] = "### Revision history\n"
+
+    @staticmethod
+    def is_revision_comment(comment: github_types.Comment) -> bool:
+        return comment["body"].startswith(
+            RevisionHistoryComment.REVISION_COMMENT_FIRST_LINE,
+        )
+
+    def _compare_url(self, old_sha: str, new_sha: str) -> str:
+        api_url = self.github_server.rstrip("/")
+        if "/api/v3" in api_url:
+            html_url = api_url.replace("/api/v3", "")
+        else:
+            html_url = api_url.replace("api.github.com", "github.com")
+        return f"{html_url}/{self.user}/{self.repo}/compare/{old_sha}...{new_sha}"
+
+    @staticmethod
+    def _format_timestamp(dt: datetime.datetime) -> str:
+        return dt.strftime("%Y-%m-%d %H:%M UTC")
+
+    @classmethod
+    def create_initial(
+        cls,
+        *,
+        github_server: str,
+        user: str,
+        repo: str,
+        old_sha: str,
+        new_sha: str,
+        change_type: str,
+        timestamp: datetime.datetime,
+    ) -> RevisionHistoryComment:
+        ts = cls._format_timestamp(timestamp)
+        entries = [
+            _RevisionEntry(1, "initial", None, old_sha, ts),
+            _RevisionEntry(2, change_type, old_sha, new_sha, ts),
+        ]
+        return cls(
+            github_server=github_server,
+            user=user,
+            repo=repo,
+            entries=entries,
+        )
+
+    def append(
+        self,
+        *,
+        old_sha: str,
+        new_sha: str,
+        change_type: str,
+        timestamp: datetime.datetime,
+    ) -> None:
+        ts = self._format_timestamp(timestamp)
+        next_number = len(self.entries) + 1
+        self.entries.append(
+            _RevisionEntry(next_number, change_type, old_sha, new_sha, ts),
+        )
+
+    def _render_entry(self, entry: _RevisionEntry) -> str:
+        if entry.old_sha is None:
+            changes_cell = f"`{entry.new_sha[:7]}`"
+        else:
+            url = self._compare_url(entry.old_sha, entry.new_sha)
+            changes_cell = f"[`{entry.old_sha[:7]} \u2192 {entry.new_sha[:7]}`]({url})"
+        return f"| {entry.number} | {entry.change_type} | {changes_cell} | {entry.timestamp} |"
+
+    def body(self) -> str:
+        lines = [
+            self.REVISION_COMMENT_FIRST_LINE,
+            "| # | Type | Changes | Date |",
+            "|---|------|---------|------|",
+        ]
+        for i, entry in enumerate(self.entries):
+            if i < len(self._raw_rows):
+                # Preserve original row verbatim from parsed comment
+                lines.append(self._raw_rows[i])
+            else:
+                lines.append(self._render_entry(entry))
+        return "\n".join(lines) + "\n"
+
+    _ROW_RE: typing.ClassVar[re.Pattern[str]] = re.compile(
+        r"^\| (\d+) \| (\w+) \| .+ \| (.+) \|$",
+    )
+
+    @classmethod
+    def parse(
+        cls,
+        body: str,
+        *,
+        github_server: str,
+        user: str,
+        repo: str,
+    ) -> RevisionHistoryComment | None:
+        if not body.startswith(cls.REVISION_COMMENT_FIRST_LINE):
+            return None
+
+        entries: list[_RevisionEntry] = []
+        raw_rows: list[str] = []
+        for line in body.splitlines():
+            m = cls._ROW_RE.match(line)
+            if not m:
+                continue
+            number = int(m.group(1))
+            change_type = m.group(2)
+            timestamp = m.group(3).strip()
+            entries.append(
+                _RevisionEntry(number, change_type, None, "", timestamp),
+            )
+            raw_rows.append(line)
+
+        if not entries:
+            return None
+
+        return cls(
+            github_server=github_server,
+            user=user,
+            repo=repo,
+            entries=entries,
+            _raw_rows=raw_rows,
+        )
 
 
 async def _update_comment_for_pull(
@@ -439,6 +658,113 @@ async def create_or_update_comments(
             )
             for pull in pulls
             if not pull["merged_at"]
+        ),
+    )
+
+
+async def _update_revision_for_pull(
+    client: httpx.AsyncClient,
+    user: str,
+    repo: str,
+    github_server: str,
+    change: changes.LocalChange,
+    change_type: str,
+    timestamp: datetime.datetime,
+    sem: asyncio.Semaphore,
+) -> None:
+    if change.pull is None:
+        return
+
+    pull_number = change.pull["number"]
+    old_sha = change.pull_head_sha
+    new_sha = change.commit_sha
+
+    async with sem:
+        r = await client.get(
+            f"/repos/{user}/{repo}/issues/{pull_number}/comments",
+        )
+        comments = typing.cast("list[github_types.Comment]", r.json())
+
+        for comment in comments:
+            if RevisionHistoryComment.is_revision_comment(comment):
+                parsed = RevisionHistoryComment.parse(
+                    comment["body"],
+                    github_server=github_server,
+                    user=user,
+                    repo=repo,
+                )
+                if parsed is not None:
+                    parsed.append(
+                        old_sha=old_sha,
+                        new_sha=new_sha,
+                        change_type=change_type,
+                        timestamp=timestamp,
+                    )
+                    new_body = parsed.body()
+                    if comment["body"] != new_body:
+                        await client.patch(
+                            comment["url"],
+                            json={"body": new_body},
+                        )
+                    return
+                # Comment header matched but body corrupted — overwrite it
+                revision = RevisionHistoryComment.create_initial(
+                    github_server=github_server,
+                    user=user,
+                    repo=repo,
+                    old_sha=old_sha,
+                    new_sha=new_sha,
+                    change_type=change_type,
+                    timestamp=timestamp,
+                )
+                await client.patch(
+                    comment["url"],
+                    json={"body": revision.body()},
+                )
+                return
+
+        # No existing revision comment — create one
+        revision = RevisionHistoryComment.create_initial(
+            github_server=github_server,
+            user=user,
+            repo=repo,
+            old_sha=old_sha,
+            new_sha=new_sha,
+            change_type=change_type,
+            timestamp=timestamp,
+        )
+        await client.post(
+            f"/repos/{user}/{repo}/issues/{pull_number}/comments",
+            json={"body": revision.body()},
+        )
+
+
+async def create_or_update_revision_comments(
+    client: httpx.AsyncClient,
+    user: str,
+    repo: str,
+    github_server: str,
+    updated_changes: list[tuple[changes.LocalChange, str]],
+) -> None:
+    if not updated_changes:
+        return
+
+    sem = asyncio.Semaphore(MAX_CONCURRENT_API_CALLS)
+    now = datetime.datetime.now(datetime.UTC)
+
+    await asyncio.gather(
+        *(
+            _update_revision_for_pull(
+                client,
+                user,
+                repo,
+                github_server,
+                change,
+                change_type,
+                now,
+                sem,
+            )
+            for change, change_type in updated_changes
         ),
     )
 

--- a/mergify_cli/tests/conftest.py
+++ b/mergify_cli/tests/conftest.py
@@ -90,6 +90,12 @@ def git_mock(
         "mergify-cli.stack-branch-prefix",
         output="",
     )
+    git_mock_object.mock(
+        "config",
+        "--get",
+        "mergify-cli.stack-revision-history",
+        output="",
+    )
 
     with mock.patch("mergify_cli.utils.git", git_mock_object):
         yield git_mock_object

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -14,11 +14,14 @@
 # under the License.
 from __future__ import annotations
 
+import datetime
 import json
 from typing import TYPE_CHECKING
+from unittest import mock
 
 import pytest
 
+from mergify_cli import utils
 from mergify_cli.stack import changes
 from mergify_cli.stack import push
 from mergify_cli.tests import utils as test_utils
@@ -306,16 +309,19 @@ async def test_stack_update_no_rebase(
     patch_comment_mock = respx_mock.patch(
         "/repos/user/repo/issues/comments/456",
     ).respond(200)
+    respx_mock.post("/repos/user/repo/issues/123/comments").respond(200)
+    git_mock.mock("fetch", "origin", "refs/pull/123/head", output="")
 
-    await push.stack_push(
-        github_server="https://api.github.com/",
-        token="",
-        skip_rebase=True,
-        next_only=False,
-        branch_prefix="",
-        dry_run=False,
-        trunk=("origin", "main"),
-    )
+    with mock.patch.object(push, "detect_change_type", return_value="content"):
+        await push.stack_push(
+            github_server="https://api.github.com/",
+            token="",
+            skip_rebase=True,
+            next_only=False,
+            branch_prefix="",
+            dry_run=False,
+            trunk=("origin", "main"),
+        )
     assert not git_mock.has_been_called_with("pull", "--rebase", "origin", "main")
 
     # The pull request is updated
@@ -400,16 +406,19 @@ async def test_stack_update(
         ],
     )
     respx_mock.patch("/repos/user/repo/issues/comments/456").respond(200)
+    respx_mock.post("/repos/user/repo/issues/123/comments").respond(200)
+    git_mock.mock("fetch", "origin", "refs/pull/123/head", output="")
 
-    await push.stack_push(
-        github_server="https://api.github.com/",
-        token="",
-        skip_rebase=False,
-        next_only=False,
-        branch_prefix="",
-        dry_run=False,
-        trunk=("origin", "main"),
-    )
+    with mock.patch.object(push, "detect_change_type", return_value="content"):
+        await push.stack_push(
+            github_server="https://api.github.com/",
+            token="",
+            skip_rebase=False,
+            next_only=False,
+            branch_prefix="",
+            dry_run=False,
+            trunk=("origin", "main"),
+        )
     assert git_mock.has_been_called_with("pull", "--rebase", "origin", "main")
 
     # The pull request is updated
@@ -486,17 +495,20 @@ async def test_stack_update_keep_title_and_body(
         ],
     )
     respx_mock.patch("/repos/user/repo/issues/comments/456").respond(200)
+    respx_mock.post("/repos/user/repo/issues/123/comments").respond(200)
+    git_mock.mock("fetch", "origin", "refs/pull/123/head", output="")
 
-    await push.stack_push(
-        github_server="https://api.github.com/",
-        token="",
-        skip_rebase=False,
-        next_only=False,
-        branch_prefix="",
-        dry_run=False,
-        trunk=("origin", "main"),
-        keep_pull_request_title_and_body=True,
-    )
+    with mock.patch.object(push, "detect_change_type", return_value="content"):
+        await push.stack_push(
+            github_server="https://api.github.com/",
+            token="",
+            skip_rebase=False,
+            next_only=False,
+            branch_prefix="",
+            dry_run=False,
+            trunk=("origin", "main"),
+            keep_pull_request_title_and_body=True,
+        )
 
     # The pull request is updated
     assert len(patch_pull_mock.calls) == 1
@@ -740,3 +752,520 @@ async def test_get_remote_changes_search_query_uses_trailing_slash(
     assert "head:my-stack/" in query, (
         f"Expected 'head:my-stack/' (with trailing slash) in query, got: {query}"
     )
+
+
+@pytest.mark.parametrize(
+    ("config_value", "expected"),
+    [
+        ("true", True),
+        ("false", False),
+        ("", True),  # default when empty
+    ],
+)
+async def test_get_default_revision_history(
+    git_mock: test_utils.GitMock,
+    *,
+    config_value: str,
+    expected: bool,
+) -> None:
+    git_mock.mock(
+        "config",
+        "--get",
+        "mergify-cli.stack-revision-history",
+        output=config_value,
+    )
+    result = await utils.get_default_revision_history()
+    assert result == expected
+
+
+async def test_get_default_revision_history_not_set() -> None:
+    # When config key doesn't exist, git raises an error — default to True
+    with mock.patch.object(
+        utils,
+        "git",
+        side_effect=utils.CommandError(
+            ("config", "--get", "mergify-cli.stack-revision-history"),
+            1,
+            b"",
+        ),
+    ):
+        result = await utils.get_default_revision_history()
+    assert result is True
+
+
+async def test_detect_change_type_content() -> None:
+    with mock.patch.object(push, "_git_patch_id", side_effect=["aaa", "bbb"]):
+        result = await push.detect_change_type("old_sha", "new_sha")
+    assert result == "content"
+
+
+async def test_detect_change_type_rebase() -> None:
+    with mock.patch.object(push, "_git_patch_id", side_effect=["aaa", "aaa"]):
+        result = await push.detect_change_type("old_sha", "new_sha")
+    assert result == "rebase"
+
+
+async def test_detect_change_type_error_falls_back_to_unknown() -> None:
+    with mock.patch.object(
+        push,
+        "_git_patch_id",
+        side_effect=utils.CommandError(("git",), 1, b""),
+    ):
+        result = await push.detect_change_type("old_sha", "new_sha")
+    assert result == "unknown"
+
+
+async def test_fetch_old_pr_heads(
+    git_mock: test_utils.GitMock,
+) -> None:
+    git_mock.mock(
+        "fetch",
+        "origin",
+        "refs/pull/1/head",
+        "refs/pull/2/head",
+        output="",
+    )
+    await push.fetch_old_pr_heads("origin", [1, 2])
+
+
+async def test_fetch_old_pr_heads_empty() -> None:
+    # No PRs to fetch — should not call git fetch at all
+    await push.fetch_old_pr_heads("origin", [])
+
+
+def test_revision_history_comment_first_update() -> None:
+    """First update creates a comment with initial + update rows."""
+    comment = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="abc1234567890abcdef1234567890abcdef123456",
+        new_sha="def5678901234567890abcdef1234567890abcdef",
+        change_type="content",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+    )
+    body = comment.body()
+    assert body.startswith("### Revision history\n")
+    assert "| 1 | initial |" in body
+    assert "`abc1234`" in body
+    assert "| 2 | content |" in body
+    assert (
+        "abc1234567890abcdef1234567890abcdef123456...def5678901234567890abcdef1234567890abcdef"
+        in body
+    )
+    assert "2026-04-14 14:30 UTC" in body
+
+
+def test_revision_history_comment_append() -> None:
+    """Appending adds a new row to existing comment."""
+    comment = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="abc1234567890abcdef1234567890abcdef123456",
+        new_sha="def5678901234567890abcdef1234567890abcdef",
+        change_type="content",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+    )
+    comment.append(
+        old_sha="def5678901234567890abcdef1234567890abcdef",
+        new_sha="789abcdef01234567890abcdef01234567890abcd",
+        change_type="rebase",
+        timestamp=datetime.datetime(2026, 4, 15, 9, 10, tzinfo=datetime.UTC),
+    )
+    body = comment.body()
+    assert "| 3 | rebase |" in body
+    assert (
+        "def5678901234567890abcdef1234567890abcdef...789abcdef01234567890abcdef01234567890abcd"
+        in body
+    )
+    assert "2026-04-15 09:10 UTC" in body
+
+
+def test_revision_history_comment_parse_existing() -> None:
+    """Parse an existing comment body back into a RevisionHistoryComment."""
+    original = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="abc1234567890abcdef1234567890abcdef123456",
+        new_sha="def5678901234567890abcdef1234567890abcdef",
+        change_type="content",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+    )
+    body = original.body()
+
+    parsed = push.RevisionHistoryComment.parse(
+        body,
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+    )
+    assert parsed is not None
+    # Append to the parsed comment
+    parsed.append(
+        old_sha="def5678901234567890abcdef1234567890abcdef",
+        new_sha="789abcdef01234567890abcdef01234567890abcd",
+        change_type="rebase",
+        timestamp=datetime.datetime(2026, 4, 15, 9, 10, tzinfo=datetime.UTC),
+    )
+    new_body = parsed.body()
+    assert "| 3 | rebase |" in new_body
+    # Verify old rows are preserved verbatim (compare links intact)
+    assert (
+        "abc1234567890abcdef1234567890abcdef123456...def5678901234567890abcdef1234567890abcdef"
+        in new_body
+    )
+    assert "| 1 | initial |" in new_body
+    assert "| 2 | content |" in new_body
+
+
+def test_revision_history_comment_parse_returns_none_for_non_matching() -> None:
+    parsed = push.RevisionHistoryComment.parse(
+        "Some other comment",
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+    )
+    assert parsed is None
+
+
+def test_revision_history_is_revision_comment() -> None:
+    assert push.RevisionHistoryComment.is_revision_comment(
+        {"body": "### Revision history\n...", "url": ""},
+    )
+    assert not push.RevisionHistoryComment.is_revision_comment(
+        {"body": "Some other comment", "url": ""},
+    )
+
+
+def test_revision_history_comment_unknown_type() -> None:
+    comment = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="abc1234567890abcdef1234567890abcdef123456",
+        new_sha="def5678901234567890abcdef1234567890abcdef",
+        change_type="unknown",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+    )
+    body = comment.body()
+    assert "| 2 | unknown |" in body
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_create_revision_comment_on_update(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    """When a PR is updated (force-pushed), a revision history comment is created."""
+    git_mock.commit(
+        test_utils.Commit(
+            sha="new_commit_sha",
+            title="Title",
+            message="Message",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize()
+    git_mock.mock(
+        "fetch",
+        "origin",
+        "refs/pull/123/head",
+        output="",
+    )
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/123",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/123").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/123",
+            "number": "123",
+            "title": "Title",
+            "head": {
+                "sha": "old_commit_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "body": "body",
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    respx_mock.patch("/repos/user/repo/pulls/123").respond(200, json={})
+    # Stack comment (existing)
+    respx_mock.get("/repos/user/repo/issues/123/comments").respond(
+        200,
+        json=[
+            {
+                "body": "This pull request is part of a stack:\n...",
+                "url": "https://api.github.com/repos/user/repo/issues/comments/456",
+            },
+        ],
+    )
+    respx_mock.patch("/repos/user/repo/issues/comments/456").respond(200)
+    # Revision comment will be POSTed (no existing one in the comments list)
+    post_revision_mock = respx_mock.post(
+        "/repos/user/repo/issues/123/comments",
+    ).respond(200)
+
+    with mock.patch.object(push, "detect_change_type", return_value="content"):
+        await push.stack_push(
+            github_server="https://api.github.com/",
+            token="",
+            skip_rebase=False,
+            next_only=False,
+            branch_prefix="",
+            dry_run=False,
+            trunk=("origin", "main"),
+        )
+
+    # A revision history comment should have been posted
+    assert post_revision_mock.called
+    # The last POST to comments should be the revision history
+    revision_calls = [
+        call
+        for call in post_revision_mock.calls
+        if json.loads(call.request.content)
+        .get("body", "")
+        .startswith("### Revision history")
+    ]
+    assert len(revision_calls) == 1
+    posted_body = json.loads(revision_calls[0].request.content)["body"]
+    assert "content" in posted_body
+    assert "old_com" in posted_body  # old_commit_sha[:7]
+    assert "new_com" in posted_body  # new_commit_sha[:7]
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_no_revision_comment_on_create(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    """When a PR is created (not updated), no revision history comment is posted."""
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="Title commit 1",
+            message="Message commit 1",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(200, json={"items": []})
+    respx_mock.post("/repos/user/repo/pulls").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/1",
+            "number": "1",
+            "title": "Title commit 1",
+            "head": {"sha": "commit1_sha"},
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    respx_mock.get("/repos/user/repo/issues/1/comments").respond(200, json=[])
+
+    await push.stack_push(
+        github_server="https://api.github.com/",
+        token="",
+        skip_rebase=False,
+        next_only=False,
+        branch_prefix="",
+        dry_run=False,
+        trunk=("origin", "main"),
+    )
+
+    # Verify no revision history comment was posted
+    for call in respx_mock.calls:
+        if call.request.method == "POST" and "/comments" in str(call.request.url):
+            posted = json.loads(call.request.content)
+            assert not posted.get("body", "").startswith("### Revision history")
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_no_revision_history_flag_skips_revision_comments(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    git_mock.commit(
+        test_utils.Commit(
+            sha="new_commit_sha",
+            title="Title",
+            message="Message",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/123",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/123").respond(
+        200,
+        json={
+            "html_url": "",
+            "number": "123",
+            "title": "Title",
+            "head": {
+                "sha": "old_commit_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "body": "body",
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    respx_mock.patch("/repos/user/repo/pulls/123").respond(200, json={})
+    respx_mock.get("/repos/user/repo/issues/123/comments").respond(
+        200,
+        json=[
+            {
+                "body": "This pull request is part of a stack:\n...",
+                "url": "https://api.github.com/repos/user/repo/issues/comments/456",
+            },
+        ],
+    )
+    respx_mock.patch("/repos/user/repo/issues/comments/456").respond(200)
+
+    await push.stack_push(
+        github_server="https://api.github.com/",
+        token="",
+        skip_rebase=False,
+        next_only=False,
+        branch_prefix="",
+        dry_run=False,
+        trunk=("origin", "main"),
+        revision_history=False,
+    )
+
+    # No fetch of PR heads
+    assert not git_mock.has_been_called_with("fetch", "origin", "refs/pull/123/head")
+    # No revision comment posted
+    for call in respx_mock.calls:
+        if call.request.method == "POST" and "/comments" in str(call.request.url):
+            posted = json.loads(call.request.content)
+            assert not posted.get("body", "").startswith("### Revision history")
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_revision_comment_updated_on_second_push(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    """On a second force-push, the existing revision comment is updated, not duplicated."""
+    git_mock.commit(
+        test_utils.Commit(
+            sha="third_sha",
+            title="Title",
+            message="Message",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize()
+    git_mock.mock("fetch", "origin", "refs/pull/123/head", output="")
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/123",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/123").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/123",
+            "number": "123",
+            "title": "Title",
+            "head": {
+                "sha": "second_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "body": "body",
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    respx_mock.patch("/repos/user/repo/pulls/123").respond(200, json={})
+
+    # Existing comments: stack comment + existing revision comment
+    existing_revision_body = (
+        "### Revision history\n"
+        "| # | Type | Changes | Date |\n"
+        "|---|------|---------|------|\n"
+        "| 1 | initial | `first_s` | 2026-04-14 10:00 UTC |\n"
+        "| 2 | content | [`first_s \u2192 second_`](https://github.com/user/repo/compare/first_s...second_) | 2026-04-14 12:00 UTC |\n"
+    )
+    respx_mock.get("/repos/user/repo/issues/123/comments").respond(
+        200,
+        json=[
+            {
+                "body": "This pull request is part of a stack:\n...",
+                "url": "https://api.github.com/repos/user/repo/issues/comments/456",
+            },
+            {
+                "body": existing_revision_body,
+                "url": "https://api.github.com/repos/user/repo/issues/comments/789",
+            },
+        ],
+    )
+    respx_mock.patch("/repos/user/repo/issues/comments/456").respond(200)
+    patch_revision_mock = respx_mock.patch(
+        "/repos/user/repo/issues/comments/789",
+    ).respond(200)
+
+    with mock.patch.object(push, "detect_change_type", return_value="rebase"):
+        await push.stack_push(
+            github_server="https://api.github.com/",
+            token="",
+            skip_rebase=False,
+            next_only=False,
+            branch_prefix="",
+            dry_run=False,
+            trunk=("origin", "main"),
+        )
+
+    # The existing revision comment is PATCHED, not a new one POSTed
+    assert patch_revision_mock.called
+    patched_body = json.loads(patch_revision_mock.calls.last.request.content)["body"]
+    assert "| 3 | rebase |" in patched_body
+    assert "second_" in patched_body  # old sha
+    assert "third_s" in patched_body  # new sha

--- a/mergify_cli/utils.py
+++ b/mergify_cli/utils.py
@@ -158,6 +158,19 @@ async def get_default_create_as_draft() -> bool:
     return result == "true"
 
 
+async def get_default_revision_history() -> bool:
+    try:
+        result = await git(
+            "config",
+            "--get",
+            "mergify-cli.stack-revision-history",
+        )
+    except CommandError:
+        return True
+
+    return result != "false"
+
+
 async def _get_default_remote_branch() -> tuple[str, str]:
     """Detect the default branch from the remote (e.g. origin/main).
 


### PR DESCRIPTION
When `stack push` force-pushes a PR branch, reviewers have no way to see
what changed between the previous and new commits. This adds a "Revision
History" comment on each updated PR showing all push iterations with:

- Compare links (github.com/owner/repo/compare/old...new) so reviewers
  can see exactly what changed
- Change type labels (content vs rebase) using git patch-id to detect
  whether the force-push changed actual code or just rebased
- Timestamps for each push iteration

The feature is enabled by default. Disable per-push with
`--no-revision-history` or globally with:
  git config --global mergify-cli.stack-revision-history false

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>