### PR TITLE
feat(freeze): auto-detect system timezone for freeze create

### DIFF
--- a/mergify_cli/freeze/cli.py
+++ b/mergify_cli/freeze/cli.py
@@ -191,8 +191,8 @@ async def list_cmd(ctx: click.Context, *, output_json: bool) -> None:
 @click.option("--reason", required=True, help="Reason for the freeze")
 @click.option(
     "--timezone",
-    required=True,
-    help="IANA timezone name (e.g. Europe/Paris, US/Eastern)",
+    default=None,
+    help="IANA timezone name (e.g. Europe/Paris, US/Eastern). Defaults to system timezone.",
 )
 @click.option(
     "--condition",
@@ -226,12 +226,23 @@ async def create(
     ctx: click.Context,
     *,
     reason: str,
-    timezone: str,
+    timezone: str | None,
     conditions: tuple[str, ...],
     start: datetime.datetime | None,
     end: datetime.datetime | None,
     excludes: tuple[str, ...],
 ) -> None:
+    if timezone is None:
+        from tzlocal import get_localzone_name
+
+        try:
+            timezone = typing.cast("str | None", get_localzone_name())
+        except Exception:
+            timezone = None
+        if not timezone:
+            msg = "Could not detect system timezone. Please specify --timezone explicitly."
+            raise click.UsageError(msg)
+
     async with utils.get_mergify_http_client(
         ctx.obj["api_url"],
         ctx.obj["token"],

--- a/mergify_cli/tests/freeze/test_cli.py
+++ b/mergify_cli/tests/freeze/test_cli.py
@@ -147,6 +147,78 @@ def test_create_minimal() -> None:
         assert body["end"] is None
 
 
+def test_create_auto_detects_timezone(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("tzlocal.get_localzone_name", lambda: "America/New_York")
+
+    with respx.mock(base_url="https://api.mergify.com") as mock:
+        mock.post("/v1/repos/owner/repo/scheduled_freeze").mock(
+            return_value=Response(
+                201,
+                json={**FAKE_FREEZE, "timezone": "America/New_York"},
+            ),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            freeze,
+            [
+                *BASE_ARGS,
+                "create",
+                "--reason",
+                "Release prep",
+                "-c",
+                "base=main",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Freeze created successfully" in result.output
+
+        request = mock.calls.last.request
+        body = json.loads(request.content)
+        assert body["timezone"] == "America/New_York"
+
+
+def test_create_fails_when_timezone_not_detected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("tzlocal.get_localzone_name", lambda: None)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        freeze,
+        [
+            *BASE_ARGS,
+            "create",
+            "--reason",
+            "Release prep",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "Could not detect system timezone" in result.output
+
+
+def test_create_fails_when_timezone_detection_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise() -> str:
+        raise RuntimeError("no timezone found")
+
+    monkeypatch.setattr("tzlocal.get_localzone_name", _raise)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        freeze,
+        [
+            *BASE_ARGS,
+            "create",
+            "--reason",
+            "Release prep",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "Could not detect system timezone" in result.output
+
+
 def test_create_with_all_options() -> None:
     with respx.mock(base_url="https://api.mergify.com") as mock:
         mock.post("/v1/repos/owner/repo/scheduled_freeze").mock(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pyyaml==6.0.3",
     "pydantic==2.13.0",
     "questionary>=2.0.0",
+    "tzlocal==5.3.1",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -292,6 +292,7 @@ dependencies = [
     { name = "questionary" },
     { name = "rich" },
     { name = "tenacity" },
+    { name = "tzlocal" },
 ]
 
 [package.dev-dependencies]
@@ -324,6 +325,7 @@ requires-dist = [
     { name = "questionary", specifier = ">=2.0.0" },
     { name = "rich", specifier = "==15.0.0" },
     { name = "tenacity", specifier = "==9.1.4" },
+    { name = "tzlocal", specifier = "==5.3.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -935,6 +937,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The --timezone flag on `freeze create` is no longer required. When
omitted, the CLI detects the system IANA timezone via tzlocal. Users
can still override it explicitly with --timezone.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>