### PR TITLE
feat(plugin): list all skills in marketplace and rename plugin to mergify

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,18 +1,36 @@
 {
-  "name": "mergify-marketplace",
+  "name": "mergify",
   "owner": {
     "name": "Mergify"
+  },
+  "metadata": {
+    "description": "Mergify CLI skills for stacked PRs, merge queues, CI insights, scheduled freezes, and configuration management"
   },
   "plugins": [
     {
       "name": "mergify-stack",
       "source": "./",
-      "description": "Stacked PRs, merge queues, and Git workflow automation"
+      "description": "Stacked PRs and Git workflow automation"
     },
     {
       "name": "mergify-merge-queue",
       "source": "./",
       "description": "Monitor, inspect, pause, and manage the Mergify merge queue"
+    },
+    {
+      "name": "mergify-ci",
+      "source": "./",
+      "description": "CI insights: JUnit test results, git refs detection, scopes, and merge queue metadata"
+    },
+    {
+      "name": "mergify-config",
+      "source": "./",
+      "description": "Validate and simulate Mergify configuration files"
+    },
+    {
+      "name": "mergify-freeze",
+      "source": "./",
+      "description": "Create and manage scheduled merge freezes"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,10 +1,24 @@
 {
-  "name": "mergify-stack",
-  "description": "Mergify CLI integration for stacked PRs, merge queues, and Git workflows",
+  "name": "mergify",
+  "description": "Mergify CLI integration for stacked PRs, merge queues, CI insights, scheduled freezes, and configuration management",
   "author": {
     "name": "Mergify"
   },
-  "keywords": ["git", "pr", "stacked-prs", "push", "commit", "branch", "rebase", "checkout", "workflow"],
+  "keywords": [
+    "git",
+    "pr",
+    "stacked-prs",
+    "merge-queue",
+    "ci",
+    "freeze",
+    "config",
+    "push",
+    "commit",
+    "branch",
+    "rebase",
+    "checkout",
+    "workflow"
+  ],
   "license": "Apache-2.0",
   "repository": "https://github.com/Mergifyio/mergify-cli"
 }


### PR DESCRIPTION
Add the 3 missing skills (mergify-ci, mergify-config, mergify-freeze)
to marketplace.json so all 5 skills are properly listed for discovery.

Rename the plugin from "mergify-stack" to "mergify" since it now covers
the full CLI, matching the README's `/plugin install mergify` command.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>