### PR TITLE
feat(skills): add Depends-On and Merge-After to merge protections skill

### DIFF
--- a/skills/mergify-merge-protections/SKILL.md
+++ b/skills/mergify-merge-protections/SKILL.md
@@ -1,11 +1,97 @@
 ---
-name: mergify-freeze
-description: Use Mergify freeze commands to create, list, update, and delete scheduled freezes that temporarily halt PR merging. ALWAYS use this skill when managing merge freezes, deployment windows, or temporarily blocking merges. Triggers on freeze, scheduled freeze, merge freeze, deployment freeze, halt merges.
+name: mergify-merge-protections
+description: Use Mergify merge protections to control when PRs merge — PR dependencies (Depends-On header), delayed merges (Merge-After header), and scheduled freezes (CLI). ALWAYS use this skill when managing merge freezes, deployment windows, temporarily blocking merges, setting up PR dependencies, blocking a PR on another PR, coordinating cross-repo merges, scheduling a merge for a specific time, or adding Depends-On or Merge-After headers to PRs. Triggers on freeze, scheduled freeze, merge freeze, deployment freeze, halt merges, depends on, dependency, block merge, merge after, merge later, schedule merge, delayed merge, cross-repo, merge protection.
 ---
 
-# Mergify Scheduled Freezes
+# Mergify Merge Protections
 
-## Overview
+Merge protections control when PRs are allowed to merge:
+
+| Protection | Scope | How |
+|------------|-------|-----|
+| **Depends-On** | Per-PR dependency chain | `Depends-On:` header in PR body |
+| **Merge-After** | Per-PR time gate | `Merge-After:` header in PR body |
+| **Scheduled Freezes** | Repository-wide or conditional | CLI commands (`mergify freeze`) |
+
+`Depends-On` and `Merge-After` are built-in — just add the header to the PR description (or commit message body when using `mergify stack push`) and Mergify enforces them automatically, no `.mergify.yml` configuration needed. Freezes are managed via CLI commands.
+
+## Depends-On
+
+Block a PR from merging until one or more other PRs are merged first.
+
+### Syntax
+
+Add one or more `Depends-On:` lines to the PR body:
+
+```
+Depends-On: #123
+Depends-On: https://github.com/org/other-repo/pull/456
+Depends-On: org/other-repo#789
+```
+
+All three formats are supported — use `#NNN` for same-repo, full URL or `org/repo#NNN` for cross-repo.
+
+### Rules
+
+- All referenced PRs must be in repositories with Mergify enabled
+- All referenced PRs must belong to the same GitHub organization
+- Circular dependencies and self-references are silently ignored
+- Multiple `Depends-On:` lines are allowed (one per line)
+
+### With `mergify stack push`
+
+The stack tool **automatically** adds `Depends-On: #NNN` between consecutive PRs in a stack. For dependencies *outside* the stack (cross-repo or unrelated PRs), add the header manually to the **commit message body** — it will be copied to the PR description on push.
+
+### When to suggest
+
+- Feature spanning multiple repos (e.g., API change + client update)
+- Schema migration must merge before application code
+- Shared library update must land before consumers
+
+## Merge-After
+
+Postpone merging until a specified date and time.
+
+### Syntax
+
+Add a `Merge-After:` line to the PR body:
+
+```
+Merge-After: 2025-09-01T09:00:00Z
+```
+
+### Supported timestamp formats (ISO 8601)
+
+```
+Merge-After: 2025-09-01                          # date only (midnight UTC)
+Merge-After: 2025-09-01T09:00:00                 # no timezone (assumed UTC)
+Merge-After: 2025-09-01T09:00:00Z                # explicit UTC
+Merge-After: 2025-09-01T09:00:00+02:00           # with UTC offset
+Merge-After: 2025-09-01T09:00:00[Europe/Paris]   # with IANA timezone
+```
+
+If no timezone is specified, UTC is assumed.
+
+### When to suggest
+
+- Coordinated release: multiple PRs should merge together at a specific time
+- Merge during a maintenance window or off-peak hours
+- Embargo: PR is ready but should not ship before a date
+
+### Combining Depends-On and Merge-After
+
+Both headers can be used together on the same PR:
+
+```
+This PR updates the billing API to support the new pricing model.
+
+Depends-On: org/billing-service#42
+Merge-After: 2025-06-15T10:00:00[US/Eastern]
+```
+
+The PR will not merge until PR #42 in `billing-service` is merged **and** the specified time has passed.
+
+## Scheduled Freezes
 
 Scheduled freezes temporarily halt merging of pull requests matching specific conditions. Use them for deployment windows, incident response, maintenance periods, or any situation where merges should be paused.
 


### PR DESCRIPTION
Rename mergify-freeze skill to mergify-merge-protections and add
documentation for the Depends-On and Merge-After built-in merge
protections. These PR body headers are automatically enforced by
Mergify without any .mergify.yml configuration.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>