### PR TITLE
feat(stack): use atomic push with explicit force-with-lease per ref

### DIFF
--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -69,17 +69,29 @@ async def push_branches(
     remote: str,
     local_changes: list[changes.LocalChange],
 ) -> None:
-    refspecs = [
-        f"{c.commit_sha}:refs/heads/{c.dest_branch}"
-        for c in local_changes
-        if c.action in {"create", "update"}
-    ]
-    if refspecs:
-        os.environ["MERGIFY_STACK_PUSH"] = "1"
-        try:
-            await utils.git("push", "-f", remote, *refspecs)
-        finally:
-            os.environ.pop("MERGIFY_STACK_PUSH", None)
+    changes_to_push = [c for c in local_changes if c.action in {"create", "update"}]
+    if not changes_to_push:
+        return
+
+    lease_args: list[str] = []
+    for c in changes_to_push:
+        if c.action == "update":
+            # Explicit lease: reject push if the remote branch has moved
+            # since we last read it via the GitHub API.
+            lease_args.append(
+                f"--force-with-lease=refs/heads/{c.dest_branch}:{c.pull_head_sha}",
+            )
+        else:
+            # New branch — no remote ref expected; force is sufficient.
+            lease_args.append(f"--force-with-lease=refs/heads/{c.dest_branch}:")
+
+    refspecs = [f"{c.commit_sha}:refs/heads/{c.dest_branch}" for c in changes_to_push]
+
+    os.environ["MERGIFY_STACK_PUSH"] = "1"
+    try:
+        await utils.git("push", "--atomic", *lease_args, remote, *refspecs)
+    finally:
+        os.environ.pop("MERGIFY_STACK_PUSH", None)
 
 
 async def _git_patch_id(sha: str) -> str:

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -256,7 +256,11 @@ async def test_stack_update_no_rebase(
             change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
         ),
     )
-    git_mock.finalize()
+    git_mock.finalize(
+        remote_shas={
+            "I29617d37762fd69809c255d7e7073cb11f8fbf50": "previous_commit_sha",
+        },
+    )
 
     # Mock HTTP calls: the stack already exists but it's out of date, it should
     # be updated
@@ -355,7 +359,11 @@ async def test_stack_update(
             change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
         ),
     )
-    git_mock.finalize()
+    git_mock.finalize(
+        remote_shas={
+            "I29617d37762fd69809c255d7e7073cb11f8fbf50": "previous_commit_sha",
+        },
+    )
 
     # Mock HTTP calls: the stack already exists but it's out of date, it should
     # be updated
@@ -445,7 +453,11 @@ async def test_stack_update_keep_title_and_body(
             change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
         ),
     )
-    git_mock.finalize()
+    git_mock.finalize(
+        remote_shas={
+            "I29617d37762fd69809c255d7e7073cb11f8fbf50": "previous_commit_sha",
+        },
+    )
 
     # Mock HTTP calls: the stack already exists but it's out of date, it should
     # be updated
@@ -555,7 +567,8 @@ async def test_stack_dry_run_does_not_rebase(
     # No branches are pushed.
     assert not git_mock.has_been_called_with(
         "push",
-        "-f",
+        "--atomic",
+        "--force-with-lease=refs/heads/current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50:",
         "origin",
         "commit1_sha:refs/heads/current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
     )
@@ -967,7 +980,9 @@ async def test_create_revision_comment_on_update(
             change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
         ),
     )
-    git_mock.finalize()
+    git_mock.finalize(
+        remote_shas={"I29617d37762fd69809c255d7e7073cb11f8fbf50": "old_commit_sha"},
+    )
     git_mock.mock(
         "fetch",
         "origin",
@@ -1113,7 +1128,9 @@ async def test_no_revision_history_flag_skips_revision_comments(
             change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
         ),
     )
-    git_mock.finalize()
+    git_mock.finalize(
+        remote_shas={"I29617d37762fd69809c255d7e7073cb11f8fbf50": "old_commit_sha"},
+    )
 
     respx_mock.get("/user").respond(200, json={"login": "author"})
     respx_mock.get("/search/issues").respond(
@@ -1191,7 +1208,9 @@ async def test_revision_comment_updated_on_second_push(
             change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
         ),
     )
-    git_mock.finalize()
+    git_mock.finalize(
+        remote_shas={"I29617d37762fd69809c255d7e7073cb11f8fbf50": "second_sha"},
+    )
     git_mock.mock("fetch", "origin", "refs/pull/123/head", output="")
 
     respx_mock.get("/user").respond(200, json={"login": "author"})

--- a/mergify_cli/tests/utils.py
+++ b/mergify_cli/tests/utils.py
@@ -69,7 +69,11 @@ class GitMock:
         # Base commit SHA
         self.mock("merge-base", "--fork-point", "origin/main", output="base_commit_sha")
 
-    def finalize(self) -> None:
+    def finalize(
+        self,
+        *,
+        remote_shas: dict[str, str] | None = None,
+    ) -> None:
         # Register batch log mock
         records = []
         for c in self._commits:
@@ -83,13 +87,28 @@ class GitMock:
             output="\x1e".join(records) + "\x1e" if records else "",
         )
 
-        # Register batch push mock
-        refspecs = [
-            f"{c['sha']}:refs/heads/current-branch/{c['change_id']}"
-            for c in self._commits
-        ]
-        if refspecs:
-            self.mock("push", "-f", "origin", *refspecs, output="")
+        # Register batch push mock with explicit per-ref leases
+        if not self._commits:
+            return
+
+        lease_args: list[str] = []
+        refspecs: list[str] = []
+        for c in self._commits:
+            branch = f"current-branch/{c['change_id']}"
+            expected_sha = (remote_shas or {}).get(c["change_id"], "")
+            lease_args.append(
+                f"--force-with-lease=refs/heads/{branch}:{expected_sha}",
+            )
+            refspecs.append(f"{c['sha']}:refs/heads/{branch}")
+
+        self.mock(
+            "push",
+            "--atomic",
+            *lease_args,
+            "origin",
+            *refspecs,
+            output="",
+        )
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Replace `git push -f` with `git push --atomic` and per-ref
`--force-with-lease=ref:expected_sha` so that either all stack branches
update or none do.

For updated branches, the lease uses the SHA from the GitHub API
response, so the push is rejected if the remote branch moved since we
last read it — even without a prior `git fetch` of those refs.

For new branches, an empty expected value allows the create while still
participating in the atomic transaction.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>