### PR TITLE
feat(stack): add cross-format Change-Id helpers for branch name extraction

### DIFF
--- a/mergify_cli/stack/changes.py
+++ b/mergify_cli/stack/changes.py
@@ -43,11 +43,55 @@ def is_change_id_prefix(prefix: str) -> bool:
     )
 
 
+_CHANGEID_FULL_RE = re.compile(r"^I[0-9a-f]{40}$")
+_SHORT_CHANGEID_RE = re.compile(r"--([0-9a-f]{8})$")
+
+
+def is_change_id(value: str) -> bool:
+    """Return True if *value* is a full 40-hex Change-Id (I-prefixed)."""
+    return bool(_CHANGEID_FULL_RE.match(value))
+
+
 ChangeId = typing.NewType("ChangeId", str)
 RemoteChanges = typing.NewType(
     "RemoteChanges",
     dict[ChangeId, github_types.PullRequest],
 )
+
+
+def extract_changeid_from_branch_segment(segment: str) -> ChangeId | None:
+    """Extract a Change-Id from the last segment of a branch name.
+
+    Supports both old format (full I-prefixed Change-Id) and new
+    format (slug--hex8).
+    """
+    if is_change_id(segment):
+        return ChangeId(segment)
+    match = _SHORT_CHANGEID_RE.search(segment)
+    if match:
+        return ChangeId(match.group(1))
+    return None
+
+
+def pop_remote_change(
+    remote_changes: RemoteChanges,
+    changeid: ChangeId,
+) -> github_types.PullRequest | None:
+    """Pop a remote change by exact or cross-format prefix match.
+
+    Handles matching between full Change-Ids (I-prefixed, 40 hex)
+    and short hex-only IDs (8 hex from new-format branch names).
+    """
+    if changeid in remote_changes:
+        return remote_changes.pop(changeid)
+
+    local_hex = changeid.removeprefix("I")
+    for remote_cid in list(remote_changes):
+        remote_hex = remote_cid.removeprefix("I")
+        if remote_hex.startswith(local_hex) or local_hex.startswith(remote_hex):
+            return remote_changes.pop(remote_cid)
+    return None
+
 
 ActionT = typing.Literal[
     "skip-merged",

--- a/mergify_cli/stack/slug.py
+++ b/mergify_cli/stack/slug.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import re
+
+
+_CONVENTIONAL_COMMIT_RE = re.compile(
+    r"^[a-z]+(?:\([^)]*\))?[!]?:\s*",
+    re.IGNORECASE,
+)
+
+ABBREVIATIONS: dict[str, str] = {
+    "application": "app",
+    "applications": "apps",
+    "authentification": "auth",
+    "authentication": "auth",
+    "authorization": "authz",
+    "command": "cmd",
+    "commands": "cmds",
+    "configuration": "config",
+    "connection": "conn",
+    "connections": "conns",
+    "dependency": "dep",
+    "dependencies": "deps",
+    "description": "desc",
+    "development": "dev",
+    "directory": "dir",
+    "documentation": "docs",
+    "environment": "env",
+    "environments": "envs",
+    "function": "func",
+    "functions": "funcs",
+    "generation": "gen",
+    "implement": "impl",
+    "implementation": "impl",
+    "information": "info",
+    "initialization": "init",
+    "library": "lib",
+    "libraries": "libs",
+    "management": "mgmt",
+    "message": "msg",
+    "messages": "msgs",
+    "middleware": "mw",
+    "notification": "notif",
+    "notifications": "notifs",
+    "number": "num",
+    "package": "pkg",
+    "packages": "pkgs",
+    "parameter": "param",
+    "parameters": "params",
+    "performance": "perf",
+    "production": "prod",
+    "property": "prop",
+    "properties": "props",
+    "reference": "ref",
+    "references": "refs",
+    "repository": "repo",
+    "repositories": "repos",
+    "request": "req",
+    "requests": "reqs",
+    "response": "resp",
+    "responses": "resps",
+    "specification": "spec",
+    "specifications": "specs",
+    "statistics": "stats",
+    "subscription": "sub",
+    "subscriptions": "subs",
+    "synchronization": "sync",
+    "temporary": "tmp",
+    "transaction": "tx",
+    "transactions": "txs",
+    "utilities": "utils",
+    "utility": "util",
+    "validation": "val",
+    "variable": "var",
+    "variables": "vars",
+}
+
+STOP_WORDS: frozenset[str] = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "and",
+        "or",
+        "but",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "of",
+        "with",
+        "by",
+        "from",
+        "is",
+        "are",
+        "this",
+        "that",
+        "it",
+        "its",
+        "into",
+        "as",
+        "so",
+        "be",
+        "was",
+        "were",
+        "not",
+        "no",
+        "has",
+        "have",
+        "had",
+        "will",
+        "would",
+        "can",
+        "could",
+        "should",
+        "do",
+        "does",
+        "did",
+        "just",
+        "also",
+        "when",
+        "where",
+        "how",
+        "if",
+        "then",
+        "than",
+        "more",
+        "some",
+        "all",
+        "each",
+        "every",
+        "any",
+        "both",
+        "about",
+        "between",
+        "through",
+        "during",
+        "before",
+        "after",
+        "up",
+        "out",
+        "new",
+    },
+)
+
+_MAX_SLUG_LENGTH = 50
+_SHORT_HASH_LENGTH = 8
+
+
+def slugify_title(title: str, changeid: str) -> str:
+    """Convert a commit title and Change-Id into a branch-name slug.
+
+    Returns ``{slug}--{hex8}`` where *slug* is derived from *title*
+    and *hex8* is the first 8 hex characters of *changeid* (without
+    the ``I`` prefix).
+    """
+    # 1. Strip conventional commit prefix
+    text = _CONVENTIONAL_COMMIT_RE.sub("", title)
+
+    # 2. Split into words, apply abbreviations, remove stop words
+    # First split on whitespace, then on non-alphanumeric chars within each token
+    words: list[str] = []
+    for token in text.split():
+        # Split token on non-alphanumeric boundaries (e.g. foo_bar -> foo, bar)
+        sub_tokens = re.split(r"[^a-zA-Z0-9]+", token)
+        for sub in sub_tokens:
+            if not sub:
+                continue
+            lower = sub.lower()
+            abbreviated = ABBREVIATIONS.get(lower, lower)
+            if abbreviated and abbreviated not in STOP_WORDS:
+                words.append(abbreviated)
+
+    # 3. Join (all tokens are already alphanumeric) and slugify
+    slug = "-".join(words)
+    slug = re.sub(r"[^a-z0-9-]", "-", slug)
+    slug = re.sub(r"-{2,}", "-", slug)
+    slug = slug.strip("-")
+
+    # 4. Truncate at word boundary
+    if len(slug) > _MAX_SLUG_LENGTH:
+        truncated = slug[:_MAX_SLUG_LENGTH]
+        last_hyphen = truncated.rfind("-")
+        slug = truncated[:last_hyphen] if last_hyphen > 0 else truncated
+    slug = slug.strip("-")
+
+    # 5. Fallback
+    if not slug:
+        slug = "change"
+
+    # 6. Append short Change-Id (strip I prefix)
+    hex_suffix = changeid[1 : 1 + _SHORT_HASH_LENGTH]
+    return f"{slug}--{hex_suffix}"

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -1269,3 +1269,75 @@ async def test_revision_comment_updated_on_second_push(
     assert "| 3 | rebase |" in patched_body
     assert "second_" in patched_body  # old sha
     assert "third_s" in patched_body  # new sha
+
+
+def test_is_change_id_valid() -> None:
+    assert changes.is_change_id("I29617d37762fd69809c255d7e7073cb11f8fbf50") is True
+
+
+def test_is_change_id_invalid() -> None:
+    assert changes.is_change_id("add-auth-model--29617d37") is False
+    assert changes.is_change_id("29617d37") is False
+    assert changes.is_change_id("I2961") is False
+    assert changes.is_change_id("") is False
+
+
+def test_extract_short_changeid_new_format() -> None:
+    assert changes.extract_changeid_from_branch_segment(
+        "add-auth-model--29617d37",
+    ) == changes.ChangeId("29617d37")
+
+
+def test_extract_short_changeid_old_format() -> None:
+    assert changes.extract_changeid_from_branch_segment(
+        "I29617d37762fd69809c255d7e7073cb11f8fbf50",
+    ) == changes.ChangeId("I29617d37762fd69809c255d7e7073cb11f8fbf50")
+
+
+def test_extract_short_changeid_invalid() -> None:
+    assert changes.extract_changeid_from_branch_segment("random-branch") is None
+
+
+def test_pop_remote_change_exact_match() -> None:
+    pull: dict = {"number": 1}
+    remote = changes.RemoteChanges(
+        {
+            changes.ChangeId("I29617d37762fd69809c255d7e7073cb11f8fbf50"): pull,
+        },
+    )
+    result = changes.pop_remote_change(
+        remote,
+        changes.ChangeId("I29617d37762fd69809c255d7e7073cb11f8fbf50"),
+    )
+    assert result is pull
+    assert len(remote) == 0
+
+
+def test_pop_remote_change_short_remote_vs_full_local() -> None:
+    pull: dict = {"number": 1}
+    remote = changes.RemoteChanges(
+        {
+            changes.ChangeId("29617d37"): pull,
+        },
+    )
+    result = changes.pop_remote_change(
+        remote,
+        changes.ChangeId("I29617d37762fd69809c255d7e7073cb11f8fbf50"),
+    )
+    assert result is pull
+    assert len(remote) == 0
+
+
+def test_pop_remote_change_no_match() -> None:
+    pull: dict = {"number": 1}
+    remote = changes.RemoteChanges(
+        {
+            changes.ChangeId("Iaaaaaaaa762fd69809c255d7e7073cb11f8fbf50"): pull,
+        },
+    )
+    result = changes.pop_remote_change(
+        remote,
+        changes.ChangeId("Ibbbbbbbb762fd69809c255d7e7073cb11f8fbf50"),
+    )
+    assert result is None
+    assert len(remote) == 1

--- a/mergify_cli/tests/stack/test_slug.py
+++ b/mergify_cli/tests/stack/test_slug.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import pytest
+
+from mergify_cli.stack.slug import slugify_title
+
+
+@pytest.mark.parametrize(
+    ("title", "change_id", "expected"),
+    [
+        # Basic slugification
+        (
+            "Add user model",
+            "I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            "add-user-model--29617d37",
+        ),
+        # Conventional commit prefix stripped
+        (
+            "feat(stack): improve comment design",
+            "I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            "improve-comment-design--29617d37",
+        ),
+        # Conventional commit without scope
+        (
+            "fix: handle missing change id",
+            "I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            "handle-missing-change-id--29617d37",
+        ),
+        # Stop words removed
+        (
+            "Fix the bug in the parser",
+            "I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            "fix-bug-parser--29617d37",
+        ),
+        # Abbreviations applied
+        (
+            "Add user authentication model",
+            "I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            "add-user-auth-model--29617d37",
+        ),
+        # Multiple abbreviations
+        (
+            "Implement repository synchronization",
+            "I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            "impl-repo-sync--29617d37",
+        ),
+        # Non-ASCII characters replaced
+        (
+            "Fix l'authentification du modèle",
+            "I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            "fix-l-auth-du-mod-le--29617d37",
+        ),
+        # Special characters replaced
+        (
+            "Add foo_bar & baz.qux",
+            "I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            "add-foo-bar-baz-qux--29617d37",
+        ),
+        # Short title
+        (
+            "fix typo",
+            "I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            "fix-typo--29617d37",
+        ),
+        # Fallback: only stop words
+        (
+            "It is the",
+            "I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            "change--29617d37",
+        ),
+        # Fallback: empty after processing
+        (
+            "feat: ",
+            "I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            "change--29617d37",
+        ),
+    ],
+)
+def test_slugify_title(title: str, change_id: str, expected: str) -> None:
+    assert slugify_title(title, change_id) == expected
+
+
+def test_slugify_title_truncation() -> None:
+    long_title = "word " * 20  # 100 chars of words
+    result = slugify_title(long_title, "I29617d37762fd69809c255d7e7073cb11f8fbf50")
+    # Slug part (before --) should be <= 50 chars
+    slug_part = result.rsplit("--", 1)[0]
+    assert len(slug_part) <= 50
+    # Should end with the hex suffix
+    assert result.endswith("--29617d37")
+    # Should not end slug part with a hyphen
+    assert not slug_part.endswith("-")
+
+
+def test_slugify_title_different_change_ids() -> None:
+    title = "Add feature"
+    result1 = slugify_title(title, "Iaaaaaaa0762fd69809c255d7e7073cb11f8fbf50")
+    result2 = slugify_title(title, "Ibbbbbbbb762fd69809c255d7e7073cb11f8fbf50")
+    assert result1 == "add-feature--aaaaaaa0"
+    assert result2 == "add-feature--bbbbbbbb"
+    assert result1 != result2


### PR DESCRIPTION
Add is_change_id(), extract_changeid_from_branch_segment(), and
pop_remote_change() to changes.py to handle both old-format
(I-prefixed 40-hex) and new-format (slug--hex8) branch Change-Ids.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Depends-On: #1171