### PR TITLE
feat(stack): generate slug-based branch names for new PRs

### DIFF
--- a/mergify_cli/stack/changes.py
+++ b/mergify_cli/stack/changes.py
@@ -23,6 +23,7 @@ import typing
 from mergify_cli import console
 from mergify_cli import github_types
 from mergify_cli import utils
+from mergify_cli.stack.slug import slugify_title
 
 
 if typing.TYPE_CHECKING:
@@ -330,7 +331,7 @@ async def get_changes(
             sys.exit(1)
 
         changeid = ChangeId(changeids[-1])
-        pull = remaining_remote_changes.pop(changeid, None)
+        pull = pop_remote_change(remaining_remote_changes, changeid)
 
         action: ActionT
         if next_only and idx > 0:
@@ -344,6 +345,12 @@ async def get_changes(
         else:
             action = "update"
 
+        if pull is not None:
+            dest_branch = pull["head"]["ref"]
+        else:
+            slug = slugify_title(title, changeid)
+            dest_branch = f"{stack_prefix}/{slug}"
+
         changes.locals.append(
             LocalChange(
                 changeid,
@@ -352,7 +359,7 @@ async def get_changes(
                 title,
                 message,
                 changes.locals[-1].dest_branch if changes.locals else base_branch,
-                f"{stack_prefix}/{changeid}",
+                dest_branch,
                 action,
             ),
         )

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -139,7 +139,7 @@ async def test_stack_create(
     # First pull request is created
     assert len(post_pull1_mock.calls) == 1
     assert json.loads(post_pull1_mock.calls.last.request.content) == {
-        "head": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        "head": "current-branch/title-commit-1--29617d37",
         "base": "main",
         "title": "Title commit 1",
         "body": "Message commit 1",
@@ -149,8 +149,8 @@ async def test_stack_create(
     # Second pull request is created
     assert len(post_pull2_mock.calls) == 1
     assert json.loads(post_pull2_mock.calls.last.request.content) == {
-        "head": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf51",
-        "base": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        "head": "current-branch/title-commit-2--29617d37",
+        "base": "current-branch/title-commit-1--29617d37",
         "title": "Title commit 2",
         "body": "Message commit 2\n\nDepends-On: #1",
         "draft": False,
@@ -234,7 +234,7 @@ async def test_stack_create_single_pull(
     # Pull request is created without stack comment
     assert len(post_pull_mock.calls) == 1
     assert json.loads(post_pull_mock.calls.last.request.content) == {
-        "head": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        "head": "current-branch/title-commit-1--29617d37",
         "base": "main",
         "title": "Title commit 1",
         "body": "Message commit 1",
@@ -254,6 +254,7 @@ async def test_stack_update_no_rebase(
             title="Title",
             message="Message",
             change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            head_ref="current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
         ),
     )
     git_mock.finalize()
@@ -353,6 +354,7 @@ async def test_stack_update(
             title="Title",
             message="Message",
             change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            head_ref="current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
         ),
     )
     git_mock.finalize()
@@ -443,6 +445,7 @@ async def test_stack_update_keep_title_and_body(
             title="New Title that should be ignored",
             message="New Message that should be ignored",
             change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            head_ref="current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
         ),
     )
     git_mock.finalize()
@@ -557,7 +560,7 @@ async def test_stack_dry_run_does_not_rebase(
         "push",
         "-f",
         "origin",
-        "commit1_sha:refs/heads/current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        "commit1_sha:refs/heads/current-branch/title-commit-1--29617d37",
     )
 
 

--- a/mergify_cli/tests/utils.py
+++ b/mergify_cli/tests/utils.py
@@ -24,11 +24,15 @@ if typing.TYPE_CHECKING:
     from collections import abc
 
 
-class Commit(typing.TypedDict):
+class _CommitRequired(typing.TypedDict):
     sha: str
     title: str
     message: str
     change_id: str
+
+
+class Commit(_CommitRequired, total=False):
+    head_ref: str  # existing PR branch ref; overrides slug-based refspec in finalize()
 
 
 @dataclasses.dataclass
@@ -84,8 +88,12 @@ class GitMock:
         )
 
         # Register batch push mock
+        from mergify_cli.stack.slug import slugify_title
+
         refspecs = [
-            f"{c['sha']}:refs/heads/current-branch/{c['change_id']}"
+            f"{c['sha']}:refs/heads/{c['head_ref']}"
+            if "head_ref" in c
+            else f"{c['sha']}:refs/heads/current-branch/{slugify_title(c['title'], c['change_id'])}"
             for c in self._commits
         ]
         if refspecs:


### PR DESCRIPTION
New PRs use slugified branch names (e.g. title-commit-1--29617d37)
while updates to existing PRs reuse the existing branch ref as-is.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Depends-On: #1173