### PR TITLE
feat: add structured exit codes for better scripting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,36 @@ npx skills add Mergifyio/mergify-cli
 /plugin install mergify
 ```
 
+## Exit Codes
+
+The CLI uses structured exit codes so scripts can distinguish failure modes
+without parsing stderr:
+
+| Code | Name | Meaning |
+|------|------|---------|
+| 0 | `SUCCESS` | Command completed successfully |
+| 1 | `GENERIC_ERROR` | Unclassified error |
+| 2 | *(Click)* | Invalid usage or bad arguments |
+| 3 | `STACK_NOT_FOUND` | Stack, branch, or commit not found |
+| 4 | `CONFLICT` | Rebase conflict |
+| 5 | `GITHUB_API_ERROR` | GitHub API failure |
+| 6 | `MERGIFY_API_ERROR` | Mergify API failure |
+| 7 | `INVALID_STATE` | Invalid state (e.g. branch targets itself, ambiguous commit) |
+| 8 | `CONFIGURATION_ERROR` | Configuration validation failed |
+
+Example usage in a script:
+
+```bash
+mergify stack push
+case $? in
+  0) echo "Success" ;;
+  3) echo "Not in a stack" ;;
+  4) echo "Rebase conflict — resolve and retry" ;;
+  5) echo "GitHub API error — check auth" ;;
+  *) echo "Failed with code $?" ;;
+esac
+```
+
 ## Contributing
 
 We welcome and appreciate contributions from the open-source community to make

--- a/mergify_cli/ci/cli.py
+++ b/mergify_cli/ci/cli.py
@@ -68,7 +68,7 @@ ci = click.Group(
     help="URL of the Mergify API",
     required=True,
     envvar="MERGIFY_API_URL",
-    default="https://api.mergify.com",
+    default=utils.MERGIFY_API_DEFAULT_URL,
     show_default=True,
 )
 @click.option(
@@ -150,7 +150,7 @@ async def junit_upload(
     help="URL of the Mergify API",
     required=True,
     envvar="MERGIFY_API_URL",
-    default="https://api.mergify.com",
+    default=utils.MERGIFY_API_DEFAULT_URL,
     show_default=True,
 )
 @click.option(
@@ -306,7 +306,7 @@ def scopes(
     help="URL of the Mergify API",
     required=True,
     envvar="MERGIFY_API_URL",
-    default="https://api.mergify.com",
+    default=utils.MERGIFY_API_DEFAULT_URL,
     show_default=True,
 )
 @click.option(

--- a/mergify_cli/ci/junit_processing/cli.py
+++ b/mergify_cli/ci/junit_processing/cli.py
@@ -9,6 +9,7 @@ import opentelemetry.trace
 from mergify_cli.ci.junit_processing import junit
 from mergify_cli.ci.junit_processing import quarantine
 from mergify_cli.ci.junit_processing import upload
+from mergify_cli.exit_codes import ExitCode
 
 
 if typing.TYPE_CHECKING:
@@ -52,14 +53,14 @@ async def process_junit_files(
             f"Failed to parse JUnit XML: {e.details}",
             "Check that your test framework is generating valid JUnit XML output.",
         )
-        sys.exit(1)
+        sys.exit(ExitCode.GENERIC_ERROR)
 
     if not spans:
         _print_early_exit_error(
             "No spans found in the JUnit files",
             "Check that the JUnit XML files are not empty.",
         )
-        sys.exit(1)
+        sys.exit(ExitCode.GENERIC_ERROR)
 
     tests_cases = [
         span
@@ -72,7 +73,7 @@ async def process_junit_files(
             "No test cases found in the JUnit files",
             "Check that your test step ran successfully before this step.",
         )
-        sys.exit(1)
+        sys.exit(ExitCode.GENERIC_ERROR)
 
     nb_failing_spans = len(
         [
@@ -187,9 +188,9 @@ async def process_junit_files(
         click.echo(
             "❌ FAIL — test runner exited with an error but no failures were reported",
         )
-        click.echo("  Exit code: 1")
+        click.echo(f"  Exit code: {int(ExitCode.GENERIC_ERROR)}")
         click.echo(SEPARATOR)
-        sys.exit(1)
+        sys.exit(ExitCode.GENERIC_ERROR)
 
     # ── Verdict ──
     nb_quarantined_failures = len(result.failing_spans) if result is not None else 0

--- a/mergify_cli/cli.py
+++ b/mergify_cli/cli.py
@@ -23,9 +23,11 @@ import click
 import httpx
 
 from mergify_cli import VERSION
+from mergify_cli import utils
 from mergify_cli.ci import cli as ci_cli_mod
 from mergify_cli.config import cli as config_cli_mod
 from mergify_cli.dym import DYMGroup
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.freeze import cli as freeze_cli_mod
 from mergify_cli.queue import cli as queue_cli_mod
 from mergify_cli.stack import cli as stack_cli_mod
@@ -78,6 +80,9 @@ def main() -> None:
 
     try:
         cli()
-    except httpx.HTTPStatusError:
-        # Error details already printed by check_for_status
-        raise SystemExit(1) from None
+    except httpx.HTTPStatusError as e:
+        # Error details already printed by check_for_status.
+        # Distinguish Mergify API from GitHub API using the request base URL.
+        if str(e.request.url).startswith(utils.get_mergify_api_url()):
+            raise SystemExit(ExitCode.MERGIFY_API_ERROR) from None
+        raise SystemExit(ExitCode.GITHUB_API_ERROR) from None

--- a/mergify_cli/config/cli.py
+++ b/mergify_cli/config/cli.py
@@ -16,6 +16,7 @@ from mergify_cli.ci.detector import MERGIFY_CONFIG_PATHS
 from mergify_cli.ci.detector import get_mergify_config_path
 from mergify_cli.config import validate as config_validate
 from mergify_cli.dym import DYMGroup
+from mergify_cli.exit_codes import ExitCode
 
 
 def _resolve_config_path(config_path: str | None) -> str:
@@ -89,7 +90,7 @@ def validate(ctx: click.Context) -> None:
             f"  [red]- {escape(error.path)}: {escape(error.message)}[/]",
         )
 
-    raise SystemExit(1)
+    raise SystemExit(ExitCode.CONFIGURATION_ERROR)
 
 
 _PR_URL_RE = re.compile(
@@ -122,7 +123,7 @@ def _parse_pr_url(url: str) -> tuple[str, int]:
     "-u",
     help="URL of the Mergify API",
     envvar="MERGIFY_API_URL",
-    default="https://api.mergify.com",
+    default=utils.MERGIFY_API_DEFAULT_URL,
     show_default=True,
 )
 @click.pass_context

--- a/mergify_cli/exit_codes.py
+++ b/mergify_cli/exit_codes.py
@@ -1,0 +1,39 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import enum
+
+
+class ExitCode(enum.IntEnum):
+    """Structured exit codes for mergify CLI.
+
+    These exit codes allow scripts and automation to distinguish between
+    different failure modes without parsing stderr.
+
+    Code 2 is reserved for Click's built-in usage errors (BadParameter,
+    UsageError).
+    """
+
+    SUCCESS = 0
+    GENERIC_ERROR = 1
+    # 2 is reserved for Click usage/parameter errors
+    STACK_NOT_FOUND = 3
+    CONFLICT = 4
+    GITHUB_API_ERROR = 5
+    MERGIFY_API_ERROR = 6
+    INVALID_STATE = 7
+    CONFIGURATION_ERROR = 8

--- a/mergify_cli/freeze/cli.py
+++ b/mergify_cli/freeze/cli.py
@@ -137,7 +137,7 @@ def _print_freeze(freeze: freeze_api.ScheduledFreezeResponse) -> None:
     "-u",
     help="URL of the Mergify API",
     envvar="MERGIFY_API_URL",
-    default="https://api.mergify.com",
+    default=utils.MERGIFY_API_DEFAULT_URL,
     show_default=True,
 )
 @click.option(

--- a/mergify_cli/queue/cli.py
+++ b/mergify_cli/queue/cli.py
@@ -10,6 +10,7 @@ from rich.tree import Tree
 from mergify_cli import console
 from mergify_cli import utils
 from mergify_cli.dym import DYMGroup
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.queue import api as queue_api
 
 
@@ -338,7 +339,7 @@ def _add_condition_nodes(
     "-u",
     help="URL of the Mergify API",
     envvar="MERGIFY_API_URL",
-    default="https://api.mergify.com",
+    default=utils.MERGIFY_API_DEFAULT_URL,
     show_default=True,
 )
 @click.option(
@@ -465,7 +466,7 @@ async def pause(ctx: click.Context, *, reason: str, yes_i_am_sure: bool) -> None
                 "[red]Error:[/] refusing to pause without confirmation. "
                 "Pass --yes-i-am-sure to proceed.",
             )
-            raise SystemExit(1)
+            raise SystemExit(ExitCode.INVALID_STATE)
         click.confirm(
             f"You are about to pause the merge queue for {repository}. Proceed?",
             abort=True,
@@ -509,7 +510,7 @@ async def unpause(ctx: click.Context) -> None:
                 "Queue is not currently paused",
                 style="yellow",
             )
-            raise SystemExit(1) from None
+            raise SystemExit(ExitCode.MERGIFY_API_ERROR) from None
         raise
 
     console.print("[green]Queue unpaused successfully.[/]")
@@ -556,7 +557,7 @@ async def show(
                 f"PR #{pr_number} is not in the merge queue",
                 style="yellow",
             )
-            raise SystemExit(1) from None
+            raise SystemExit(ExitCode.MERGIFY_API_ERROR) from None
         raise
 
     if output_json:

--- a/mergify_cli/stack/changes.py
+++ b/mergify_cli/stack/changes.py
@@ -23,6 +23,7 @@ import typing
 from mergify_cli import console
 from mergify_cli import github_types
 from mergify_cli import utils
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack.slug import slugify_title
 
 
@@ -328,7 +329,7 @@ async def get_changes(
                 "Did you run `mergify stack setup` for this repository?",
             )
             # TODO(sileht): we should raise an Exception and exit in main program
-            sys.exit(1)
+            sys.exit(ExitCode.INVALID_STATE)
 
         changeid = ChangeId(changeids[-1])
         pull = pop_remote_change(remaining_remote_changes, changeid)

--- a/mergify_cli/stack/checkout.py
+++ b/mergify_cli/stack/checkout.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from mergify_cli import console
 from mergify_cli import utils
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack import changes
 
 
@@ -81,7 +82,7 @@ async def stack_checkout(
                         "Unexpected stack layout, two root commits found",
                         style="red",
                     )
-                    sys.exit(1)
+                    sys.exit(ExitCode.INVALID_STATE)
                 root_node = node
 
         if root_node is None:

--- a/mergify_cli/stack/list.py
+++ b/mergify_cli/stack/list.py
@@ -23,6 +23,7 @@ import typing
 
 from mergify_cli import console
 from mergify_cli import utils
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack import changes
 from mergify_cli.stack.push import LocalBranchInvalidError
 from mergify_cli.stack.push import check_local_branch
@@ -363,7 +364,7 @@ async def get_stack_list(
         console.print(
             "You should run `mergify stack list` on the branch you created in the first place",
         )
-        sys.exit(1)
+        sys.exit(ExitCode.INVALID_STATE)
 
     remote, base_branch = trunk
 
@@ -380,7 +381,7 @@ async def get_stack_list(
             f"* To rename your local branch: `git branch -M {dest_branch} new-branch-name`",
             style="red",
         )
-        sys.exit(1)
+        sys.exit(ExitCode.INVALID_STATE)
 
     stack_prefix = f"{branch_prefix}/{dest_branch}" if branch_prefix else dest_branch
 
@@ -394,7 +395,7 @@ async def get_stack_list(
             f"Common commit between `{remote}/{base_branch}` and `{dest_branch}` branches not found",
             style="red",
         )
-        sys.exit(1)
+        sys.exit(ExitCode.STACK_NOT_FOUND)
 
     async with utils.get_github_http_client(github_server, token) as client:
         remote_changes = await changes.get_remote_changes(

--- a/mergify_cli/stack/move.py
+++ b/mergify_cli/stack/move.py
@@ -20,6 +20,7 @@ import sys
 
 from mergify_cli import console
 from mergify_cli import utils
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack.reorder import display_plan
 from mergify_cli.stack.reorder import get_stack_commits
 from mergify_cli.stack.reorder import match_commit
@@ -50,21 +51,21 @@ async def stack_move(
                 f"error: '{position}' requires a target commit",
                 style="red",
             )
-            sys.exit(1)
+            sys.exit(ExitCode.INVALID_STATE)
         target = match_commit(target_prefix, commits)
         if commit[0] == target[0]:
             console.print(
                 "error: commit and target are the same",
                 style="red",
             )
-            sys.exit(1)
+            sys.exit(ExitCode.INVALID_STATE)
     elif position in {"first", "last"}:
         if target_prefix is not None:
             console.print(
                 f"error: '{position}' does not accept a target commit",
                 style="red",
             )
-            sys.exit(1)
+            sys.exit(ExitCode.INVALID_STATE)
 
     # Compute new order
     remaining = [c for c in commits if c[0] != commit[0]]

--- a/mergify_cli/stack/new.py
+++ b/mergify_cli/stack/new.py
@@ -19,6 +19,7 @@ import sys
 
 from mergify_cli import console
 from mergify_cli import utils
+from mergify_cli.exit_codes import ExitCode
 
 
 async def stack_new(
@@ -43,7 +44,7 @@ async def stack_new(
                 "[red]Could not determine trunk branch. "
                 "Please set upstream tracking or use --base to specify the base branch.[/]",
             )
-            sys.exit(1)
+            sys.exit(ExitCode.STACK_NOT_FOUND)
         else:
             remote, base_branch = trunk.split("/", maxsplit=1)
     else:
@@ -67,7 +68,7 @@ async def stack_new(
                 await utils.git("branch", "--track", name, base_ref)
         except utils.CommandError as e:
             console.print(f"[red]Failed to create branch '{name}': {e}[/]")
-            sys.exit(1)
+            sys.exit(ExitCode.GENERIC_ERROR)
 
     console.print(f"[green]Created branch '{name}' tracking {base_ref}[/]")
 

--- a/mergify_cli/stack/open.py
+++ b/mergify_cli/stack/open.py
@@ -25,6 +25,7 @@ import questionary
 
 from mergify_cli import console
 from mergify_cli import utils
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack.list import get_stack_list
 
 
@@ -71,7 +72,7 @@ async def stack_open(
 
     if not output.entries:
         console.print("[yellow]No commits in stack[/]")
-        sys.exit(1)
+        sys.exit(ExitCode.STACK_NOT_FOUND)
 
     entry: StackListEntry
 
@@ -96,7 +97,7 @@ async def stack_open(
             commit_sha = await utils.git("rev-parse", commit)
         except utils.CommandError:
             console.print(f"[red]Commit `{commit}` not found[/]")
-            sys.exit(1)
+            sys.exit(ExitCode.STACK_NOT_FOUND)
 
         # Find entry matching the commit SHA
         found_entry = next(
@@ -108,7 +109,7 @@ async def stack_open(
             console.print(
                 f"[red]Commit `{commit}` ({commit_sha[:7]}) not found in stack[/]",
             )
-            sys.exit(1)
+            sys.exit(ExitCode.STACK_NOT_FOUND)
 
         entry = found_entry
 
@@ -117,7 +118,7 @@ async def stack_open(
             f"[yellow]No PR for: {entry.title} ({entry.commit_sha[:7]})[/]",
         )
         console.print("Run `mergify stack push` first.")
-        sys.exit(1)
+        sys.exit(ExitCode.STACK_NOT_FOUND)
 
     console.print(f"Opening PR #{entry.pull_number}: {entry.title}")
     webbrowser.open(entry.pull_url)

--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -25,6 +25,7 @@ import typing
 
 from mergify_cli import console
 from mergify_cli import utils
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack import changes
 
 
@@ -244,7 +245,7 @@ async def stack_push(
         console.log(
             "You should run `mergify stack` on the branch you created in the first place",
         )
-        sys.exit(1)
+        sys.exit(ExitCode.INVALID_STATE)
 
     remote, base_branch = trunk
 
@@ -261,7 +262,7 @@ async def stack_push(
             f"* To rename your local branch: `git branch -M {dest_branch} new-branch-name`",
             style="red",
         )
-        sys.exit(1)
+        sys.exit(ExitCode.INVALID_STATE)
 
     stack_prefix = f"{branch_prefix}/{dest_branch}" if branch_prefix else dest_branch
 
@@ -316,7 +317,7 @@ async def stack_push(
             f"Common commit between `{remote}/{base_branch}` and `{dest_branch}` branches not found",
             style="red",
         )
-        sys.exit(1)
+        sys.exit(ExitCode.STACK_NOT_FOUND)
 
     async with utils.get_github_http_client(github_server, token) as client:
         with console.status("Retrieving latest pushed stacks"):

--- a/mergify_cli/stack/reorder.py
+++ b/mergify_cli/stack/reorder.py
@@ -24,6 +24,7 @@ import tempfile
 
 from mergify_cli import console
 from mergify_cli import utils
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack.changes import CHANGEID_RE
 from mergify_cli.stack.changes import is_change_id_prefix
 
@@ -79,7 +80,7 @@ def match_commit(
             f"error: no commit found matching {field_name} prefix '{prefix}'",
             style="red",
         )
-        sys.exit(1)
+        sys.exit(ExitCode.STACK_NOT_FOUND)
     if len(matches) > 1:
         console.print(
             f"error: ambiguous {field_name} prefix '{prefix}' matches {len(matches)} commits:",
@@ -87,7 +88,7 @@ def match_commit(
         )
         for sha, subject, change_id in matches:
             console.print(f"  {sha[:12]} {subject} ({change_id[:12]})", style="red")
-        sys.exit(1)
+        sys.exit(ExitCode.INVALID_STATE)
 
     return matches[0]
 
@@ -126,7 +127,7 @@ def run_scripted_rebase(base: str, script_content: str) -> None:
             console.print(
                 "Or abort the rebase with: git rebase --abort",
             )
-            sys.exit(1)
+            sys.exit(ExitCode.CONFLICT)
     finally:
         tmp_file = pathlib.Path(tmp_path)
         if tmp_file.exists():
@@ -196,7 +197,7 @@ async def stack_reorder(
             f"error: expected {len(commits)} commits but got {len(commit_prefixes)} prefixes",
             style="red",
         )
-        sys.exit(1)
+        sys.exit(ExitCode.INVALID_STATE)
 
     # Match each prefix to a commit
     matched = [match_commit(p, commits) for p in commit_prefixes]
@@ -211,7 +212,7 @@ async def stack_reorder(
                     f"error: duplicate — prefix '{prefix}' resolves to the same commit as another prefix",
                     style="red",
                 )
-                sys.exit(1)
+                sys.exit(ExitCode.INVALID_STATE)
             seen.add(sha)
 
     # Check if already in order

--- a/mergify_cli/stack/sync.py
+++ b/mergify_cli/stack/sync.py
@@ -24,6 +24,7 @@ import typing
 
 from mergify_cli import console
 from mergify_cli import utils
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack import changes
 from mergify_cli.stack.push import LocalBranchInvalidError
 from mergify_cli.stack.push import check_local_branch
@@ -104,7 +105,7 @@ async def get_sync_status(
         console.print(
             "You should run `mergify stack sync` on the branch you created in the first place",
         )
-        sys.exit(1)
+        sys.exit(ExitCode.INVALID_STATE)
 
     remote, base_branch = trunk
 
@@ -124,7 +125,7 @@ async def get_sync_status(
             f"`git branch -M {dest_branch} new-branch-name`",
             style="red",
         )
-        sys.exit(1)
+        sys.exit(ExitCode.INVALID_STATE)
 
     stack_prefix = f"{branch_prefix}/{dest_branch}" if branch_prefix else dest_branch
 
@@ -138,7 +139,7 @@ async def get_sync_status(
             f"Common commit between `{remote}/{base_branch}` and `{dest_branch}` branches not found",
             style="red",
         )
-        sys.exit(1)
+        sys.exit(ExitCode.STACK_NOT_FOUND)
 
     async with utils.get_github_http_client(github_server, token) as client:
         remote_changes = await changes.get_remote_changes(

--- a/mergify_cli/tests/config/test_validate.py
+++ b/mergify_cli/tests/config/test_validate.py
@@ -12,6 +12,7 @@ from httpx import Response
 import respx
 
 from mergify_cli.config.cli import config
+from mergify_cli.exit_codes import ExitCode
 
 
 _MINIMAL_SCHEMA: dict[str, object] = {
@@ -63,7 +64,7 @@ def test_invalid_config(tmp_path: pathlib.Path) -> None:
             config,
             ["--config-file", config_path, "validate"],
         )
-        assert result.exit_code == 1, result.output
+        assert result.exit_code == ExitCode.CONFIGURATION_ERROR, result.output
         assert "error" in result.output.lower()
 
 

--- a/mergify_cli/tests/queue/test_cli.py
+++ b/mergify_cli/tests/queue/test_cli.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 from httpx import Response
 import respx
 
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.queue.cli import _relative_time
 from mergify_cli.queue.cli import _topological_sort
 from mergify_cli.queue.cli import queue
@@ -467,7 +468,7 @@ class TestPauseCommand:
                 queue,
                 [*BASE_ARGS, "pause", "--reason", "test"],
             )
-        assert result.exit_code == 1
+        assert result.exit_code == ExitCode.INVALID_STATE
         assert "--yes-i-am-sure" in result.output
 
     def test_pause_requires_reason(self) -> None:
@@ -524,5 +525,5 @@ class TestUnpauseCommand:
             )
             runner = CliRunner()
             result = runner.invoke(queue, [*BASE_ARGS, "unpause"])
-        assert result.exit_code == 1
+        assert result.exit_code == ExitCode.MERGIFY_API_ERROR
         assert "not currently paused" in result.output.lower()

--- a/mergify_cli/tests/queue/test_show.py
+++ b/mergify_cli/tests/queue/test_show.py
@@ -9,6 +9,7 @@ from click.testing import CliRunner
 from httpx import Response
 import respx
 
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.queue.cli import queue
 
 
@@ -192,7 +193,7 @@ class TestShowCommand:
                 {"message": "Not Found"},
                 status_code=404,
             )
-        assert result.exit_code == 1
+        assert result.exit_code == ExitCode.MERGIFY_API_ERROR
         assert "not in the merge queue" in result.output
 
     def test_json_output(self) -> None:

--- a/mergify_cli/tests/stack/test_edit.py
+++ b/mergify_cli/tests/stack/test_edit.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack.edit import stack_edit
 
 
@@ -178,7 +179,7 @@ class TestStackEdit:
 
         with pytest.raises(SystemExit) as exc_info:
             await stack_edit(commit_prefix="deadbeef1234")
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == ExitCode.STACK_NOT_FOUND
 
     async def test_edit_empty_stack(
         self,

--- a/mergify_cli/tests/stack/test_list.py
+++ b/mergify_cli/tests/stack/test_list.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack import list as stack_list_mod
 from mergify_cli.tests import utils as test_utils
 
@@ -429,7 +430,7 @@ async def test_stack_list_on_trunk_branch_raises_error(
         output="https://github.com/foo/bar.git",
     )
 
-    with pytest.raises(SystemExit, match="1"):
+    with pytest.raises(SystemExit, match=str(ExitCode.INVALID_STATE)):
         await stack_list_mod.stack_list(
             github_server="https://api.github.com/",
             token="",
@@ -460,7 +461,7 @@ async def test_stack_list_on_generated_branch_raises_error(
         output="stack/author/my-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
     )
 
-    with pytest.raises(SystemExit, match="1"):
+    with pytest.raises(SystemExit, match=str(ExitCode.INVALID_STATE)):
         await stack_list_mod.stack_list(
             github_server="https://api.github.com/",
             token="",
@@ -480,7 +481,7 @@ async def test_stack_list_no_fork_point_raises_error(
     respx_mock.get("/user").respond(200, json={"login": "author"})
     git_mock.mock("merge-base", "--fork-point", "origin/main", output="")
 
-    with pytest.raises(SystemExit, match="1"):
+    with pytest.raises(SystemExit, match=str(ExitCode.STACK_NOT_FOUND)):
         await stack_list_mod.stack_list(
             github_server="https://api.github.com/",
             token="",

--- a/mergify_cli/tests/stack/test_move.py
+++ b/mergify_cli/tests/stack/test_move.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack.move import stack_move
 
 
@@ -231,7 +232,7 @@ class TestStackMove:
 
         with pytest.raises(SystemExit) as exc_info:
             await stack_move(sha_a, "before", sha_a, dry_run=False)
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == ExitCode.INVALID_STATE
 
     async def test_move_target_missing_for_before(
         self,
@@ -245,7 +246,7 @@ class TestStackMove:
 
         with pytest.raises(SystemExit) as exc_info:
             await stack_move(sha_a, "before", None, dry_run=False)
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == ExitCode.INVALID_STATE
 
     async def test_move_target_missing_for_after(
         self,
@@ -259,7 +260,7 @@ class TestStackMove:
 
         with pytest.raises(SystemExit) as exc_info:
             await stack_move(sha_a, "after", None, dry_run=False)
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == ExitCode.INVALID_STATE
 
     async def test_move_target_provided_for_first(
         self,
@@ -274,7 +275,7 @@ class TestStackMove:
 
         with pytest.raises(SystemExit) as exc_info:
             await stack_move(sha_a, "first", sha_b, dry_run=False)
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == ExitCode.INVALID_STATE
 
     async def test_move_target_provided_for_last(
         self,
@@ -289,7 +290,7 @@ class TestStackMove:
 
         with pytest.raises(SystemExit) as exc_info:
             await stack_move(sha_a, "last", sha_b, dry_run=False)
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == ExitCode.INVALID_STATE
 
     async def test_move_with_change_id(
         self,

--- a/mergify_cli/tests/stack/test_new.py
+++ b/mergify_cli/tests/stack/test_new.py
@@ -20,6 +20,7 @@ from unittest import mock
 import pytest
 
 from mergify_cli import utils
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack import new as stack_new_mod
 
 
@@ -181,13 +182,13 @@ class TestStackNew:
                 checkout=True,
             )
 
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == ExitCode.GENERIC_ERROR
         assert git_mock.has_been_called_with("fetch", "origin", "main")
 
     async def test_stack_new_trunk_not_found(
         self,
     ) -> None:
-        """Should exit with code 1 when trunk cannot be determined."""
+        """Should exit with STACK_NOT_FOUND when trunk cannot be determined."""
 
         async def patched_get_trunk() -> str:
             raise utils.CommandError(("config", "--get"), 1, b"")
@@ -202,4 +203,4 @@ class TestStackNew:
                 checkout=True,
             )
 
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == ExitCode.STACK_NOT_FOUND

--- a/mergify_cli/tests/stack/test_open.py
+++ b/mergify_cli/tests/stack/test_open.py
@@ -19,6 +19,7 @@ from unittest import mock
 
 import pytest
 
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack import open as stack_open_mod
 from mergify_cli.tests import utils as test_utils
 
@@ -221,7 +222,7 @@ async def test_stack_open_no_pr(
 
     with (
         mock.patch("webbrowser.open") as mock_open,
-        pytest.raises(SystemExit, match="1"),
+        pytest.raises(SystemExit, match=str(ExitCode.STACK_NOT_FOUND)),
     ):
         await stack_open_mod.stack_open(
             github_server="https://api.github.com/",
@@ -265,7 +266,7 @@ async def test_stack_open_commit_not_in_stack(
     respx_mock.get("/user").respond(200, json={"login": "author"})
     respx_mock.get("/search/issues").respond(200, json={"items": []})
 
-    with pytest.raises(SystemExit, match="1"):
+    with pytest.raises(SystemExit, match=str(ExitCode.STACK_NOT_FOUND)):
         await stack_open_mod.stack_open(
             github_server="https://api.github.com/",
             token="",
@@ -319,7 +320,7 @@ async def test_stack_open_invalid_commit(
 
     with (
         mock.patch("mergify_cli.utils.git", side_effect=git_with_invalid_ref),
-        pytest.raises(SystemExit, match="1"),
+        pytest.raises(SystemExit, match=str(ExitCode.STACK_NOT_FOUND)),
     ):
         await stack_open_mod.stack_open(
             github_server="https://api.github.com/",

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -22,6 +22,7 @@ from unittest import mock
 import pytest
 
 from mergify_cli import utils
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack import changes
 from mergify_cli.stack import push
 from mergify_cli.tests import utils as test_utils
@@ -687,7 +688,7 @@ async def test_stack_on_destination_branch_raises_an_error(
         output="https://github.com/foo/bar.git",
     )
 
-    with pytest.raises(SystemExit, match="1"):
+    with pytest.raises(SystemExit, match=str(ExitCode.INVALID_STATE)):
         await push.stack_push(
             github_server="https://api.github.com/",
             token="",
@@ -707,7 +708,7 @@ async def test_stack_without_common_commit_raises_an_error(
     respx_mock.get("/user").respond(200, json={"login": "author"})
     git_mock.mock("merge-base", "--fork-point", "origin/main", output="")
 
-    with pytest.raises(SystemExit, match="1"):
+    with pytest.raises(SystemExit, match=str(ExitCode.STACK_NOT_FOUND)):
         await push.stack_push(
             github_server="https://api.github.com/",
             token="",

--- a/mergify_cli/tests/stack/test_reorder.py
+++ b/mergify_cli/tests/stack/test_reorder.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack.reorder import get_stack_commits
 from mergify_cli.stack.reorder import match_commit
 from mergify_cli.stack.reorder import stack_reorder
@@ -146,7 +147,7 @@ class TestMatchCommit:
         ]
         with pytest.raises(SystemExit) as exc_info:
             match_commit("zzz", commits)
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == ExitCode.STACK_NOT_FOUND
 
     def test_ambiguous_match_exits(self) -> None:
         commits = [
@@ -155,7 +156,7 @@ class TestMatchCommit:
         ]
         with pytest.raises(SystemExit) as exc_info:
             match_commit("abc123", commits)
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == ExitCode.INVALID_STATE
 
 
 class TestStackReorder:
@@ -254,7 +255,7 @@ class TestStackReorder:
 
         with pytest.raises(SystemExit) as exc_info:
             await stack_reorder([sha_a, sha_b], dry_run=False)
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == ExitCode.INVALID_STATE
 
     async def test_reorder_wrong_count_too_many(
         self,
@@ -273,7 +274,7 @@ class TestStackReorder:
                 [sha_a, sha_b, sha_c, sha_a],
                 dry_run=False,
             )
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == ExitCode.INVALID_STATE
 
     async def test_reorder_unknown_prefix(
         self,
@@ -291,7 +292,7 @@ class TestStackReorder:
                 [sha_a, sha_b, "deadbeef1234"],
                 dry_run=False,
             )
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == ExitCode.STACK_NOT_FOUND
 
     async def test_reorder_ambiguous_prefix(self) -> None:
         """Test match_commit logic with ambiguous prefix."""
@@ -314,7 +315,7 @@ class TestStackReorder:
         ]
         with pytest.raises(SystemExit) as exc_info:
             match_commit("abc123", commits)
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == ExitCode.INVALID_STATE
 
     async def test_reorder_duplicate_prefix(
         self,
@@ -329,7 +330,7 @@ class TestStackReorder:
 
         with pytest.raises(SystemExit) as exc_info:
             await stack_reorder([sha_a, sha_a, sha_b], dry_run=False)
-        assert exc_info.value.code == 1
+        assert exc_info.value.code == ExitCode.INVALID_STATE
 
     async def test_reorder_empty_stack(
         self,

--- a/mergify_cli/tests/test_exit_codes.py
+++ b/mergify_cli/tests/test_exit_codes.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from mergify_cli.exit_codes import ExitCode
+
+
+class TestExitCode:
+    def test_values_are_unique(self) -> None:
+        values = [m.value for m in ExitCode.__members__.values()]
+        assert len(values) == len(set(values))
+
+    def test_success_is_zero(self) -> None:
+        assert int(ExitCode.SUCCESS) == 0
+
+    def test_generic_error_is_one(self) -> None:
+        assert int(ExitCode.GENERIC_ERROR) == 1
+
+    def test_code_2_reserved_for_click(self) -> None:
+        """Code 2 is reserved for Click usage errors and should not be in the enum."""
+        assert 2 not in [e.value for e in ExitCode]
+
+    def test_all_codes_are_small_integers(self) -> None:
+        for code in ExitCode:
+            assert 0 <= code <= 127
+
+    def test_int_compatibility(self) -> None:
+        """ExitCode values work with sys.exit() as plain ints."""
+        assert int(ExitCode.STACK_NOT_FOUND) == 3
+        assert int(ExitCode.CONFLICT) == 4
+        assert int(ExitCode.GITHUB_API_ERROR) == 5
+        assert int(ExitCode.MERGIFY_API_ERROR) == 6
+        assert int(ExitCode.INVALID_STATE) == 7
+        assert int(ExitCode.CONFIGURATION_ERROR) == 8

--- a/mergify_cli/utils.py
+++ b/mergify_cli/utils.py
@@ -48,6 +48,13 @@ def is_debug() -> bool:
     return _DEBUG
 
 
+MERGIFY_API_DEFAULT_URL = "https://api.mergify.com"
+
+
+def get_mergify_api_url() -> str:
+    return os.getenv("MERGIFY_API_URL", MERGIFY_API_DEFAULT_URL)
+
+
 async def check_for_status(response: httpx.Response) -> None:
     if response.status_code < 400:
         return


### PR DESCRIPTION
Replace the binary 0/1 exit code model with 8 distinct exit codes so
scripts and automation can distinguish failure modes without parsing
stderr. Codes: 0 success, 1 generic, 2 reserved (Click), 3 stack not
found, 4 conflict, 5 GitHub API, 6 Mergify API, 7 invalid state,
8 configuration error.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>