### PR TITLE
fix(stack): move PR link to separate column in stack comment table

### DIFF
--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -446,14 +446,14 @@ class StackComment:
     def body(self, current_pull: github_types.PullRequest) -> str:
         body = self.STACK_COMMENT_HEADER
         body += "\n"
-        body += "| # | Pull Request | |\n"
-        body += "|--:|---|---|\n"
+        body += "| # | Pull Request | Link | |\n"
+        body += "|--:|---|---|---|\n"
 
         for i, pull in enumerate(self.pulls, 1):
             title = pull["title"].replace("|", "\\|")
-            entry = f"{title} ([#{pull['number']}]({pull['html_url']}))"
+            link = f"[#{pull['number']}]({pull['html_url']})"
             status = "👈" if pull == current_pull else ""
-            body += f"| {i} | {entry} | {status} |\n"
+            body += f"| {i} | {title} | {link} | {status} |\n"
 
         return body
 

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -160,10 +160,10 @@ async def test_stack_create(
     assert len(post_comment1_mock.calls) == 1
     expected_body = """This pull request is part of a [Mergify stack](https://docs.mergify.com/stacks/):
 
-| # | Pull Request | |
-|--:|---|---|
-| 1 | Title commit 1 ([#1](https://github.com/repo/user/pull/1)) | 👈 |
-| 2 | Title commit 2 ([#2](https://github.com/repo/user/pull/2)) |  |
+| # | Pull Request | Link | |
+|--:|---|---|---|
+| 1 | Title commit 1 | [#1](https://github.com/repo/user/pull/1) | 👈 |
+| 2 | Title commit 2 | [#2](https://github.com/repo/user/pull/2) |  |
 """
     assert json.loads(post_comment1_mock.calls.last.request.content) == {
         "body": expected_body,
@@ -173,10 +173,10 @@ async def test_stack_create(
     assert len(post_comment2_mock.calls) == 1
     expected_body = """This pull request is part of a [Mergify stack](https://docs.mergify.com/stacks/):
 
-| # | Pull Request | |
-|--:|---|---|
-| 1 | Title commit 1 ([#1](https://github.com/repo/user/pull/1)) |  |
-| 2 | Title commit 2 ([#2](https://github.com/repo/user/pull/2)) | 👈 |
+| # | Pull Request | Link | |
+|--:|---|---|---|
+| 1 | Title commit 1 | [#1](https://github.com/repo/user/pull/1) |  |
+| 2 | Title commit 2 | [#2](https://github.com/repo/user/pull/2) | 👈 |
 """
     assert json.loads(post_comment2_mock.calls.last.request.content) == {
         "body": expected_body,


### PR DESCRIPTION
The PR number with URL was embedded in the title column, making it
misaligned when titles had different lengths. Moving it to its own
"Link" column ensures all PR numbers are vertically aligned.