### PR TITLE
ci: bump timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
         run: uv run --locked poe linters
 
   test:
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2025, macos-15]


### PR DESCRIPTION
Windows takes more than 5 minutes to run the tests.