### PR TITLE
fix(cli): catch CommandError to show clean error instead of traceback

### DIFF
--- a/mergify_cli/cli.py
+++ b/mergify_cli/cli.py
@@ -23,6 +23,7 @@ import click
 import httpx
 
 from mergify_cli import VERSION
+from mergify_cli import console
 from mergify_cli import utils
 from mergify_cli.ci import cli as ci_cli_mod
 from mergify_cli.config import cli as config_cli_mod
@@ -86,3 +87,6 @@ def main() -> None:
         if str(e.request.url).startswith(utils.get_mergify_api_url()):
             raise SystemExit(ExitCode.MERGIFY_API_ERROR) from None
         raise SystemExit(ExitCode.GITHUB_API_ERROR) from None
+    except utils.CommandError as e:
+        console.print(f"error: {e}", style="red")
+        raise SystemExit(ExitCode.GENERIC_ERROR) from None

--- a/mergify_cli/tests/test_cli.py
+++ b/mergify_cli/tests/test_cli.py
@@ -1,8 +1,29 @@
 from __future__ import annotations
 
+from unittest import mock
+
 from click import testing
+import pytest
 
 from mergify_cli import cli as cli_mod
+from mergify_cli import utils
+from mergify_cli.exit_codes import ExitCode
+
+
+def test_cli_command_error_shows_clean_message() -> None:
+    """Test that CommandError produces a clean error message, not a traceback."""
+    error = utils.CommandError(
+        ("git", "pull", "--rebase", "origin", "main"),
+        1,
+        b"CONFLICT (content): Merge conflict in file.txt",
+    )
+    with (
+        mock.patch.object(cli_mod, "cli", side_effect=error),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        cli_mod.main()
+
+    assert exc_info.value.code == ExitCode.GENERIC_ERROR
 
 
 def test_cli_shows_help_by_default() -> None:


### PR DESCRIPTION
When a git command fails (e.g., rebase conflict during `mergify stack
push`), the full Python traceback was displayed. Now CommandError is
caught at the top level in main() and printed as a clean one-line error
message, matching how httpx.HTTPStatusError is already handled.

Uses structured exit codes from the exit code system.