### PR TITLE
feat(stack): support --no-verify in `mergify stack push` to skip pre-push hooks

### DIFF
--- a/mergify_cli/stack/cli.py
+++ b/mergify_cli/stack/cli.py
@@ -350,6 +350,12 @@ async def new(
     "Default fetched from git config if added with "
     "`git config --add mergify-cli.stack-revision-history false`",
 )
+@click.option(
+    "--no-verify",
+    is_flag=True,
+    default=False,
+    help="Skip pre-push git hooks",
+)
 @utils.run_with_asyncio
 async def push(
     ctx: click.Context,
@@ -366,6 +372,7 @@ async def push(
     branch_prefix: str | None,
     only_update_existing_pulls: bool,
     no_revision_history: bool,
+    no_verify: bool,
 ) -> None:
     if setup:
         # backward compat
@@ -389,6 +396,7 @@ async def push(
         only_update_existing_pulls=only_update_existing_pulls,
         author=author,
         revision_history=not no_revision_history,
+        no_verify=no_verify,
     )
 
 

--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -72,6 +72,8 @@ def format_pull_description(
 async def push_branches(
     remote: str,
     local_changes: list[changes.LocalChange],
+    *,
+    no_verify: bool = False,
 ) -> None:
     changes_to_push = [c for c in local_changes if c.action in {"create", "update"}]
     if not changes_to_push:
@@ -91,9 +93,17 @@ async def push_branches(
 
     refspecs = [f"{c.commit_sha}:refs/heads/{c.dest_branch}" for c in changes_to_push]
 
+    no_verify_args = ("--no-verify",) if no_verify else ()
     os.environ["MERGIFY_STACK_PUSH"] = "1"
     try:
-        await utils.git("push", "--atomic", *lease_args, remote, *refspecs)
+        await utils.git(
+            "push",
+            "--atomic",
+            *no_verify_args,
+            *lease_args,
+            remote,
+            *refspecs,
+        )
     finally:
         os.environ.pop("MERGIFY_STACK_PUSH", None)
 
@@ -225,6 +235,7 @@ async def stack_push(
     only_update_existing_pulls: bool = False,
     author: str | None = None,
     revision_history: bool = True,
+    no_verify: bool = False,
 ) -> None:
     os.chdir(await utils.git("rev-parse", "--show-toplevel"))
     dest_branch = await utils.git_get_branch_name()
@@ -378,7 +389,7 @@ async def stack_push(
                     )
 
         with console.status("Pushing stacked branches..."):
-            await push_branches(remote, planned_changes.locals)
+            await push_branches(remote, planned_changes.locals, no_verify=no_verify)
 
         console.log("Updating and/or creating stacked pull requests:", style="green")
 

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -61,6 +61,94 @@ def test_check_local_branch_invalid() -> None:
 
 
 @pytest.mark.respx(base_url="https://api.github.com/")
+async def test_stack_push_forwards_no_verify(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="Title commit 1",
+            message="Message commit 1",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize(no_verify=True)
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(200, json={"items": []})
+    respx_mock.post("/repos/user/repo/pulls").respond(
+        200,
+        json={
+            "html_url": "https://github.com/repo/user/pull/1",
+            "number": "1",
+            "title": "Title commit 1",
+            "head": {"sha": "commit1_sha"},
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    respx_mock.get("/repos/user/repo/issues/1/comments").respond(200, json=[])
+
+    await push.stack_push(
+        github_server="https://api.github.com/",
+        token="",
+        skip_rebase=False,
+        next_only=False,
+        branch_prefix="",
+        dry_run=False,
+        trunk=("origin", "main"),
+        no_verify=True,
+    )
+
+    assert git_mock.has_been_called_with(
+        "push",
+        "--atomic",
+        "--no-verify",
+        "--force-with-lease=refs/heads/current-branch/title-commit-1--29617d37:",
+        "origin",
+        "commit1_sha:refs/heads/current-branch/title-commit-1--29617d37",
+    )
+
+
+async def test_push_branches_no_verify(git_mock: test_utils.GitMock) -> None:
+    local_changes = [
+        changes.LocalChange(
+            id=changes.ChangeId("I29617d37762fd69809c255d7e7073cb11f8fbf50"),
+            pull=None,
+            commit_sha="commit1_sha",
+            title="Title",
+            message="Message",
+            base_branch="main",
+            dest_branch="stack/title--29617d37",
+            action="create",
+        ),
+    ]
+    git_mock.mock(
+        "push",
+        "--atomic",
+        "--no-verify",
+        "--force-with-lease=refs/heads/stack/title--29617d37:",
+        "origin",
+        "commit1_sha:refs/heads/stack/title--29617d37",
+        output="",
+    )
+
+    await push.push_branches("origin", local_changes, no_verify=True)
+
+    assert git_mock.has_been_called_with(
+        "push",
+        "--atomic",
+        "--no-verify",
+        "--force-with-lease=refs/heads/stack/title--29617d37:",
+        "origin",
+        "commit1_sha:refs/heads/stack/title--29617d37",
+    )
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
 async def test_stack_create(
     git_mock: test_utils.GitMock,
     respx_mock: respx.MockRouter,

--- a/mergify_cli/tests/utils.py
+++ b/mergify_cli/tests/utils.py
@@ -77,6 +77,7 @@ class GitMock:
         self,
         *,
         remote_shas: dict[str, str] | None = None,
+        no_verify: bool = False,
     ) -> None:
         # Register batch log mock
         records = []
@@ -110,9 +111,12 @@ class GitMock:
             )
             refspecs.append(f"{c['sha']}:refs/heads/{branch}")
 
+        no_verify_args: tuple[str, ...] = ("--no-verify",) if no_verify else ()
+
         self.mock(
             "push",
             "--atomic",
+            *no_verify_args,
             *lease_args,
             "origin",
             *refspecs,


### PR DESCRIPTION
Allow users to bypass pre-push git hooks when pushing stacked branches,
useful when hooks are slow, flaky, or irrelevant for stack operations.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>