### PR TITLE
fix(stack): close unclosed Rich markup tags in push output

### DIFF
--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -429,7 +429,7 @@ async def stack_push(
         with console.status("Updating comments..."):
             await create_or_update_comments(client, user, repo, pulls_to_comment)
 
-        console.log("[green]Comments updated")
+        console.log("[green]Comments updated[/]")
 
         if revision_history:
             updated_changes = [
@@ -445,7 +445,7 @@ async def stack_push(
                     github_server,
                     updated_changes,
                 )
-            console.log("[green]Revision history updated")
+            console.log("[green]Revision history updated[/]")
 
         with console.status("Deleting unused branches..."):
             if planned_changes.orphans:


### PR DESCRIPTION
Lines 416 and 432 had `[green]` without a closing `[/]`, causing
subsequent text on those log lines to inherit green styling.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>