### PR TITLE
fix(stack): write JSON output to stdout instead of stderr

### DIFF
--- a/mergify_cli/stack/list.py
+++ b/mergify_cli/stack/list.py
@@ -21,6 +21,8 @@ import json
 import sys
 import typing
 
+import click
+
 from mergify_cli import console
 from mergify_cli import utils
 from mergify_cli.exit_codes import ExitCode
@@ -479,6 +481,6 @@ async def stack_list(
     )
 
     if output_json:
-        console.print(json.dumps(output.to_dict(), indent=2))
+        click.echo(json.dumps(output.to_dict(), indent=2))
     else:
         display_stack_list(output, verbose=verbose)

--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -429,7 +429,7 @@ async def stack_push(
         with console.status("Updating comments..."):
             await create_or_update_comments(client, user, repo, pulls_to_comment)
 
-        console.log("[green]Comments updated")
+        console.log("[green]Comments updated[/]")
 
         if revision_history:
             updated_changes = [
@@ -445,7 +445,7 @@ async def stack_push(
                     github_server,
                     updated_changes,
                 )
-            console.log("[green]Revision history updated")
+            console.log("[green]Revision history updated[/]")
 
         with console.status("Deleting unused branches..."):
             if planned_changes.orphans:


### PR DESCRIPTION
`stack list --json` used `console.print()` which writes to stderr via
Rich. Switch to `click.echo()` so JSON goes to stdout and can be
piped to `jq` or other tools, matching queue and freeze commands.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

Depends-On: #1190