### PR TITLE
refactor(ci): use DYMGroup for CI command group

### DIFF
--- a/mergify_cli/ci/cli.py
+++ b/mergify_cli/ci/cli.py
@@ -14,6 +14,7 @@ from mergify_cli.ci.junit_processing import cli as junit_processing_cli
 from mergify_cli.ci.queue import metadata as queue_metadata
 from mergify_cli.ci.scopes import cli as scopes_cli
 from mergify_cli.ci.scopes import exceptions as scopes_exc
+from mergify_cli.dym import DYMGroup
 
 
 class JUnitFile(click.Path):
@@ -55,10 +56,15 @@ def _process_tests_target_branch(
     return value.removeprefix("refs/heads/") if value else value
 
 
-ci = click.Group(
-    "ci",
+@click.group(
+    cls=DYMGroup,
+    invoke_without_command=True,
     help="Mergify's CI related commands",
 )
+@click.pass_context
+def ci(ctx: click.Context) -> None:
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 @ci.command(help="Upload JUnit XML reports", deprecated="Use `junit-process` instead")

--- a/mergify_cli/stack/list.py
+++ b/mergify_cli/stack/list.py
@@ -21,6 +21,8 @@ import json
 import sys
 import typing
 
+import click
+
 from mergify_cli import console
 from mergify_cli import utils
 from mergify_cli.exit_codes import ExitCode
@@ -479,6 +481,6 @@ async def stack_list(
     )
 
     if output_json:
-        console.print(json.dumps(output.to_dict(), indent=2))
+        click.echo(json.dumps(output.to_dict(), indent=2))
     else:
         display_stack_list(output, verbose=verbose)

--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -429,7 +429,7 @@ async def stack_push(
         with console.status("Updating comments..."):
             await create_or_update_comments(client, user, repo, pulls_to_comment)
 
-        console.log("[green]Comments updated")
+        console.log("[green]Comments updated[/]")
 
         if revision_history:
             updated_changes = [
@@ -445,7 +445,7 @@ async def stack_push(
                     github_server,
                     updated_changes,
                 )
-            console.log("[green]Revision history updated")
+            console.log("[green]Revision history updated[/]")
 
         with console.status("Deleting unused branches..."):
             if planned_changes.orphans:


### PR DESCRIPTION
The `ci` group was the only one using plain `click.Group` instead of
`DYMGroup`. Switch to `DYMGroup` with `invoke_without_command=True`
for consistent "did you mean?" suggestions and help display.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

Depends-On: #1191