### PR TITLE
style: add trailing periods to success messages for consistency

### DIFF
--- a/mergify_cli/stack/move.py
+++ b/mergify_cli/stack/move.py
@@ -102,4 +102,4 @@ async def stack_move(
         return
 
     run_rebase(base, new_shas)
-    console.print("Commit moved successfully", style="green")
+    console.print("Commit moved successfully.", style="green")

--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -364,7 +364,7 @@ async def stack_push(
         )
 
         if dry_run:
-            console.log("[orange]Finished (dry-run mode) :tada:[/]")
+            console.log("[orange]Finished (dry-run mode).[/]")
             sys.exit(0)
 
         if revision_history:
@@ -429,7 +429,7 @@ async def stack_push(
         with console.status("Updating comments..."):
             await create_or_update_comments(client, user, repo, pulls_to_comment)
 
-        console.log("[green]Comments updated[/]")
+        console.log("[green]Comments updated.[/]")
 
         if revision_history:
             updated_changes = [
@@ -445,7 +445,7 @@ async def stack_push(
                     github_server,
                     updated_changes,
                 )
-            console.log("[green]Revision history updated[/]")
+            console.log("[green]Revision history updated.[/]")
 
         with console.status("Deleting unused branches..."):
             if planned_changes.orphans:
@@ -456,7 +456,7 @@ async def stack_push(
                     ),
                 )
 
-        console.log("[green]Finished :tada:[/]")
+        console.log("[green]Finished.[/]")
 
 
 @dataclasses.dataclass

--- a/mergify_cli/stack/reorder.py
+++ b/mergify_cli/stack/reorder.py
@@ -231,4 +231,4 @@ async def stack_reorder(
         return
 
     run_rebase(base, matched_shas)
-    console.print("Stack reordered successfully", style="green")
+    console.print("Stack reordered successfully.", style="green")


### PR DESCRIPTION
Freeze and queue commands used trailing periods on success messages
(e.g., "Freeze deleted successfully.") while stack commands did not.
Standardize on periods everywhere. Also removes :tada: emoji
shortcodes from push output per AGENTS.md guidelines.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>