### PR TITLE
refactor: add console_error() for consistent error message formatting

### DIFF
--- a/mergify_cli/__init__.py
+++ b/mergify_cli/__init__.py
@@ -17,3 +17,4 @@ from __future__ import annotations
 
 from mergify_cli._globals import VERSION as VERSION
 from mergify_cli._globals import console as console
+from mergify_cli._globals import console_error as console_error

--- a/mergify_cli/_globals.py
+++ b/mergify_cli/_globals.py
@@ -23,3 +23,8 @@ import rich.console
 console = rich.console.Console(log_path=False, log_time=False)
 
 VERSION = importlib.metadata.version("mergify-cli")
+
+
+def console_error(message: str) -> None:
+    """Print a consistently formatted error message."""
+    console.print(f"error: {message}", style="red", markup=False)

--- a/mergify_cli/config/cli.py
+++ b/mergify_cli/config/cli.py
@@ -11,6 +11,7 @@ from rich.markup import escape
 import yaml
 
 from mergify_cli import console
+from mergify_cli import console_error
 from mergify_cli import utils
 from mergify_cli.ci.detector import MERGIFY_CONFIG_PATHS
 from mergify_cli.ci.detector import get_mergify_config_path
@@ -82,12 +83,14 @@ def validate(ctx: click.Context) -> None:
         console.print(f"[green]Configuration file '{escaped_path}' is valid.[/]")
         return
 
-    console.print(
-        f"[red]Configuration file '{escaped_path}' has {len(result.errors)} error(s):[/]",
+    console_error(
+        f"configuration file '{config_path}' has {len(result.errors)} error(s):",
     )
     for error in result.errors:
         console.print(
-            f"  [red]- {escape(error.path)}: {escape(error.message)}[/]",
+            f"  - {error.path}: {error.message}",
+            style="red",
+            markup=False,
         )
 
     raise SystemExit(ExitCode.CONFIGURATION_ERROR)

--- a/mergify_cli/queue/cli.py
+++ b/mergify_cli/queue/cli.py
@@ -8,6 +8,7 @@ from rich.text import Text
 from rich.tree import Tree
 
 from mergify_cli import console
+from mergify_cli import console_error
 from mergify_cli import utils
 from mergify_cli.dym import DYMGroup
 from mergify_cli.exit_codes import ExitCode
@@ -462,8 +463,8 @@ async def pause(ctx: click.Context, *, reason: str, yes_i_am_sure: bool) -> None
         import os
 
         if not os.isatty(0):
-            console.print(
-                "[red]Error:[/] refusing to pause without confirmation. "
+            console_error(
+                "refusing to pause without confirmation. "
                 "Pass --yes-i-am-sure to proceed.",
             )
             raise SystemExit(ExitCode.INVALID_STATE)

--- a/mergify_cli/stack/changes.py
+++ b/mergify_cli/stack/changes.py
@@ -21,6 +21,7 @@ import sys
 import typing
 
 from mergify_cli import console
+from mergify_cli import console_error
 from mergify_cli import github_types
 from mergify_cli import utils
 from mergify_cli.exit_codes import ExitCode
@@ -321,9 +322,8 @@ async def get_changes(
     for idx, (commit, title, message) in enumerate(commit_infos):
         changeids = CHANGEID_RE.findall(message)
         if not changeids:
-            console.print(
+            console_error(
                 f"`Change-Id:` line is missing on commit {commit}",
-                style="red",
             )
             console.print(
                 "Did you run `mergify stack setup` for this repository?",

--- a/mergify_cli/stack/checkout.py
+++ b/mergify_cli/stack/checkout.py
@@ -5,6 +5,7 @@ import sys
 from typing import TYPE_CHECKING
 
 from mergify_cli import console
+from mergify_cli import console_error
 from mergify_cli import utils
 from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack import changes
@@ -78,9 +79,8 @@ async def stack_checkout(
 
             if not node.pull["base"]["ref"].startswith(stack_branch):
                 if root_node is not None:
-                    console.print(
-                        "Unexpected stack layout, two root commits found",
-                        style="red",
+                    console_error(
+                        "unexpected stack layout, two root commits found",
                     )
                     sys.exit(ExitCode.INVALID_STATE)
                 root_node = node

--- a/mergify_cli/stack/cli.py
+++ b/mergify_cli/stack/cli.py
@@ -8,6 +8,7 @@ from urllib import parse
 import click
 
 from mergify_cli import console
+from mergify_cli import console_error
 from mergify_cli import utils
 from mergify_cli.dym import DYMGroup
 from mergify_cli.stack import checkout as stack_checkout_mod
@@ -58,8 +59,8 @@ async def get_default_token() -> str:
         try:
             token = await utils.run_command("gh", "auth", "token")
         except utils.CommandError:
-            console.print(
-                "error: please make sure that gh client is installed and you are authenticated, or set the "
+            console_error(
+                "please make sure that gh client is installed and you are authenticated, or set the "
                 "'GITHUB_TOKEN' environment variable",
             )
     if utils.is_debug():

--- a/mergify_cli/stack/list.py
+++ b/mergify_cli/stack/list.py
@@ -24,6 +24,7 @@ import typing
 import click
 
 from mergify_cli import console
+from mergify_cli import console_error
 from mergify_cli import utils
 from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack import changes
@@ -362,7 +363,7 @@ async def get_stack_list(
     try:
         check_local_branch(branch_name=dest_branch, branch_prefix=branch_prefix)
     except LocalBranchInvalidError as e:
-        console.print(f"[red] {e.message} [/]")
+        console_error(e.message)
         console.print(
             "You should run `mergify stack list` on the branch you created in the first place",
         )
@@ -376,12 +377,14 @@ async def get_stack_list(
 
     if base_branch == dest_branch:
         remote_url = await utils.git("remote", "get-url", remote)
+        console_error(
+            f"your local branch `{dest_branch}` targets itself: "
+            f"`{remote}/{base_branch}` (at {remote_url}@{base_branch})",
+        )
         console.print(
-            f"Your local branch `{dest_branch}` targets itself: `{remote}/{base_branch}` (at {remote_url}@{base_branch}).\n"
-            f"You should either fix the target branch or rename your local branch.\n\n"
-            f"* To fix the target branch: `git branch {dest_branch} --set-upstream-to={remote}/main>\n",
+            "You should either fix the target branch or rename your local branch.\n\n"
+            f"* To fix the target branch: `git branch {dest_branch} --set-upstream-to={remote}/<target-branch>`\n"
             f"* To rename your local branch: `git branch -M {dest_branch} new-branch-name`",
-            style="red",
         )
         sys.exit(ExitCode.INVALID_STATE)
 
@@ -393,9 +396,8 @@ async def get_stack_list(
         f"{remote}/{base_branch}",
     )
     if not base_commit_sha:
-        console.print(
-            f"Common commit between `{remote}/{base_branch}` and `{dest_branch}` branches not found",
-            style="red",
+        console_error(
+            f"common commit between `{remote}/{base_branch}` and `{dest_branch}` branches not found",
         )
         sys.exit(ExitCode.STACK_NOT_FOUND)
 

--- a/mergify_cli/stack/move.py
+++ b/mergify_cli/stack/move.py
@@ -19,6 +19,7 @@ import os
 import sys
 
 from mergify_cli import console
+from mergify_cli import console_error
 from mergify_cli import utils
 from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack.reorder import display_plan
@@ -47,24 +48,15 @@ async def stack_move(
 
     if position in {"before", "after"}:
         if target_prefix is None:
-            console.print(
-                f"error: '{position}' requires a target commit",
-                style="red",
-            )
+            console_error(f"'{position}' requires a target commit")
             sys.exit(ExitCode.INVALID_STATE)
         target = match_commit(target_prefix, commits)
         if commit[0] == target[0]:
-            console.print(
-                "error: commit and target are the same",
-                style="red",
-            )
+            console_error("commit and target are the same")
             sys.exit(ExitCode.INVALID_STATE)
     elif position in {"first", "last"}:
         if target_prefix is not None:
-            console.print(
-                f"error: '{position}' does not accept a target commit",
-                style="red",
-            )
+            console_error(f"'{position}' does not accept a target commit")
             sys.exit(ExitCode.INVALID_STATE)
 
     # Compute new order

--- a/mergify_cli/stack/move.py
+++ b/mergify_cli/stack/move.py
@@ -102,4 +102,4 @@ async def stack_move(
         return
 
     run_rebase(base, new_shas)
-    console.print("Commit moved successfully", style="green")
+    console.print("Commit moved successfully.", style="green")

--- a/mergify_cli/stack/new.py
+++ b/mergify_cli/stack/new.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import sys
 
 from mergify_cli import console
+from mergify_cli import console_error
 from mergify_cli import utils
 from mergify_cli.exit_codes import ExitCode
 
@@ -40,9 +41,9 @@ async def stack_new(
         try:
             trunk = await utils.get_trunk()
         except utils.CommandError:
-            console.print(
-                "[red]Could not determine trunk branch. "
-                "Please set upstream tracking or use --base to specify the base branch.[/]",
+            console_error(
+                "could not determine trunk branch. "
+                "Please set upstream tracking or use --base to specify the base branch.",
             )
             sys.exit(ExitCode.STACK_NOT_FOUND)
         else:
@@ -55,7 +56,7 @@ async def stack_new(
         try:
             await utils.git("fetch", remote, base_branch)
         except utils.CommandError as e:
-            console.print(f"[red]Failed to fetch from {remote}: {e}[/]")
+            console_error(f"failed to fetch from {remote}: {e}")
             raise
 
     # Create the branch from the fetched base
@@ -67,7 +68,7 @@ async def stack_new(
             else:
                 await utils.git("branch", "--track", name, base_ref)
         except utils.CommandError as e:
-            console.print(f"[red]Failed to create branch '{name}': {e}[/]")
+            console_error(f"failed to create branch '{name}': {e}")
             sys.exit(ExitCode.GENERIC_ERROR)
 
     console.print(f"[green]Created branch '{name}' tracking {base_ref}[/]")

--- a/mergify_cli/stack/open.py
+++ b/mergify_cli/stack/open.py
@@ -24,6 +24,7 @@ import webbrowser
 import questionary
 
 from mergify_cli import console
+from mergify_cli import console_error
 from mergify_cli import utils
 from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack.list import get_stack_list
@@ -96,7 +97,7 @@ async def stack_open(
         try:
             commit_sha = await utils.git("rev-parse", commit)
         except utils.CommandError:
-            console.print(f"[red]Commit `{commit}` not found[/]")
+            console_error(f"commit `{commit}` not found")
             sys.exit(ExitCode.STACK_NOT_FOUND)
 
         # Find entry matching the commit SHA
@@ -106,8 +107,8 @@ async def stack_open(
         )
 
         if found_entry is None:
-            console.print(
-                f"[red]Commit `{commit}` ({commit_sha[:7]}) not found in stack[/]",
+            console_error(
+                f"commit `{commit}` ({commit_sha[:7]}) not found in stack",
             )
             sys.exit(ExitCode.STACK_NOT_FOUND)
 

--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -364,7 +364,7 @@ async def stack_push(
         )
 
         if dry_run:
-            console.log("[orange]Finished (dry-run mode) :tada:[/]")
+            console.log("[orange]Finished (dry-run mode).[/]")
             sys.exit(0)
 
         if revision_history:
@@ -429,7 +429,7 @@ async def stack_push(
         with console.status("Updating comments..."):
             await create_or_update_comments(client, user, repo, pulls_to_comment)
 
-        console.log("[green]Comments updated[/]")
+        console.log("[green]Comments updated.[/]")
 
         if revision_history:
             updated_changes = [
@@ -445,7 +445,7 @@ async def stack_push(
                     github_server,
                     updated_changes,
                 )
-            console.log("[green]Revision history updated[/]")
+            console.log("[green]Revision history updated.[/]")
 
         with console.status("Deleting unused branches..."):
             if planned_changes.orphans:
@@ -456,7 +456,7 @@ async def stack_push(
                     ),
                 )
 
-        console.log("[green]Finished :tada:[/]")
+        console.log("[green]Finished.[/]")
 
 
 @dataclasses.dataclass

--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -24,6 +24,7 @@ import sys
 import typing
 
 from mergify_cli import console
+from mergify_cli import console_error
 from mergify_cli import utils
 from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack import changes
@@ -252,8 +253,8 @@ async def stack_push(
     try:
         check_local_branch(branch_name=dest_branch, branch_prefix=branch_prefix)
     except LocalBranchInvalidError as e:
-        console.log(f"[red] {e.message} [/]")
-        console.log(
+        console_error(e.message)
+        console.print(
             "You should run `mergify stack` on the branch you created in the first place",
         )
         sys.exit(ExitCode.INVALID_STATE)
@@ -266,12 +267,14 @@ async def stack_push(
 
     if base_branch == dest_branch:
         remote_url = await utils.git("remote", "get-url", remote)
+        console_error(
+            f"your local branch `{dest_branch}` targets itself: "
+            f"`{remote}/{base_branch}` (at {remote_url}@{base_branch})",
+        )
         console.print(
-            f"Your local branch `{dest_branch}` targets itself: `{remote}/{base_branch}` (at {remote_url}@{base_branch}).\n"
             f"You should either fix the target branch or rename your local branch.\n\n"
-            f"* To fix the target branch: `git branch {dest_branch} --set-upstream-to={remote}/{base_branch}`\n",
+            f"* To fix the target branch: `git branch {dest_branch} --set-upstream-to={remote}/{base_branch}`\n"
             f"* To rename your local branch: `git branch -M {dest_branch} new-branch-name`",
-            style="red",
         )
         sys.exit(ExitCode.INVALID_STATE)
 
@@ -324,9 +327,8 @@ async def stack_push(
         f"{remote}/{base_branch}",
     )
     if not base_commit_sha:
-        console.log(
-            f"Common commit between `{remote}/{base_branch}` and `{dest_branch}` branches not found",
-            style="red",
+        console_error(
+            f"common commit between `{remote}/{base_branch}` and `{dest_branch}` branches not found",
         )
         sys.exit(ExitCode.STACK_NOT_FOUND)
 

--- a/mergify_cli/stack/reorder.py
+++ b/mergify_cli/stack/reorder.py
@@ -23,6 +23,7 @@ import sys
 import tempfile
 
 from mergify_cli import console
+from mergify_cli import console_error
 from mergify_cli import utils
 from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack.changes import CHANGEID_RE
@@ -76,15 +77,11 @@ def match_commit(
         field_name = "SHA"
 
     if len(matches) == 0:
-        console.print(
-            f"error: no commit found matching {field_name} prefix '{prefix}'",
-            style="red",
-        )
+        console_error(f"no commit found matching {field_name} prefix '{prefix}'")
         sys.exit(ExitCode.STACK_NOT_FOUND)
     if len(matches) > 1:
-        console.print(
-            f"error: ambiguous {field_name} prefix '{prefix}' matches {len(matches)} commits:",
-            style="red",
+        console_error(
+            f"ambiguous {field_name} prefix '{prefix}' matches {len(matches)} commits:",
         )
         for sha, subject, change_id in matches:
             console.print(f"  {sha[:12]} {subject} ({change_id[:12]})", style="red")
@@ -117,10 +114,7 @@ def run_scripted_rebase(base: str, script_content: str) -> None:
         )
 
         if result.returncode != 0:
-            console.print(
-                "error: rebase failed — there may be conflicts",
-                style="red",
-            )
+            console_error("rebase failed — there may be conflicts")
             console.print(
                 "Resolve conflicts then run: git rebase --continue",
             )
@@ -193,9 +187,8 @@ async def stack_reorder(
         return
 
     if len(commit_prefixes) != len(commits):
-        console.print(
-            f"error: expected {len(commits)} commits but got {len(commit_prefixes)} prefixes",
-            style="red",
+        console_error(
+            f"expected {len(commits)} commits but got {len(commit_prefixes)} prefixes",
         )
         sys.exit(ExitCode.INVALID_STATE)
 
@@ -208,9 +201,8 @@ async def stack_reorder(
         seen: set[str] = set()
         for prefix, sha in zip(commit_prefixes, matched_shas, strict=True):
             if sha in seen:
-                console.print(
-                    f"error: duplicate — prefix '{prefix}' resolves to the same commit as another prefix",
-                    style="red",
+                console_error(
+                    f"duplicate — prefix '{prefix}' resolves to the same commit as another prefix",
                 )
                 sys.exit(ExitCode.INVALID_STATE)
             seen.add(sha)

--- a/mergify_cli/stack/reorder.py
+++ b/mergify_cli/stack/reorder.py
@@ -231,4 +231,4 @@ async def stack_reorder(
         return
 
     run_rebase(base, matched_shas)
-    console.print("Stack reordered successfully", style="green")
+    console.print("Stack reordered successfully.", style="green")

--- a/mergify_cli/stack/sync.py
+++ b/mergify_cli/stack/sync.py
@@ -23,6 +23,7 @@ import tempfile
 import typing
 
 from mergify_cli import console
+from mergify_cli import console_error
 from mergify_cli import utils
 from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack import changes
@@ -101,7 +102,7 @@ async def get_sync_status(
     try:
         check_local_branch(branch_name=dest_branch, branch_prefix=branch_prefix)
     except LocalBranchInvalidError as e:
-        console.print(f"[red] {e.message} [/]")
+        console_error(e.message)
         console.print(
             "You should run `mergify stack sync` on the branch you created in the first place",
         )
@@ -115,15 +116,16 @@ async def get_sync_status(
 
     if base_branch == dest_branch:
         remote_url = await utils.git("remote", "get-url", remote)
+        console_error(
+            f"your local branch `{dest_branch}` targets itself: "
+            f"`{remote}/{base_branch}` (at {remote_url}@{base_branch})",
+        )
         console.print(
-            f"Your local branch `{dest_branch}` targets itself: "
-            f"`{remote}/{base_branch}` (at {remote_url}@{base_branch}).\n"
             "You should either fix the target branch or rename your local branch.\n\n"
             f"* To fix the target branch: "
             f"`git branch {dest_branch} --set-upstream-to={remote}/{base_branch}`\n"
             f"* To rename your local branch: "
             f"`git branch -M {dest_branch} new-branch-name`",
-            style="red",
         )
         sys.exit(ExitCode.INVALID_STATE)
 
@@ -135,9 +137,8 @@ async def get_sync_status(
         f"{remote}/{base_branch}",
     )
     if not base_commit_sha:
-        console.print(
-            f"Common commit between `{remote}/{base_branch}` and `{dest_branch}` branches not found",
-            style="red",
+        console_error(
+            f"common commit between `{remote}/{base_branch}` and `{dest_branch}` branches not found",
         )
         sys.exit(ExitCode.STACK_NOT_FOUND)
 

--- a/mergify_cli/tests/test_utils.py
+++ b/mergify_cli/tests/test_utils.py
@@ -238,6 +238,7 @@ class TestCheckForStatus:
         mock_print.assert_any_call(
             "error: API error (HTTP 404): Not Found",
             style="red",
+            markup=False,
         )
         mock_print.assert_any_call(
             "url: https://api.mergify.com/v1/repos/jd/home/scheduled_freeze",
@@ -260,6 +261,7 @@ class TestCheckForStatus:
         mock_print.assert_any_call(
             "error: API error (HTTP 500): Internal Server Error",
             style="red",
+            markup=False,
         )
 
     async def test_error_hides_request_data_by_default(self) -> None:

--- a/mergify_cli/utils.py
+++ b/mergify_cli/utils.py
@@ -27,6 +27,7 @@ import httpx
 
 from mergify_cli import VERSION
 from mergify_cli import console
+from mergify_cli import console_error
 from mergify_cli.ci import github_event
 
 
@@ -69,10 +70,7 @@ async def check_for_status(response: httpx.Response) -> None:
     except ValueError:
         pass
 
-    console.print(
-        f"error: API error (HTTP {response.status_code}): {detail}",
-        style="red",
-    )
+    console_error(f"API error (HTTP {response.status_code}): {detail}")
     console.print(f"url: {response.request.url}", style="red")
 
     if is_debug():
@@ -195,7 +193,7 @@ async def get_trunk() -> str:
     try:
         branch_name = await git_get_branch_name()
     except CommandError:
-        console.print("error: can't get the current branch", style="red")
+        console_error("can't get the current branch")
         raise
 
     target_branch = None
@@ -213,9 +211,8 @@ async def get_trunk() -> str:
         try:
             default_remote, default_branch = await _get_default_remote_branch()
         except CommandError:
-            console.print(
-                f"error: can't detect the remote target branch for {branch_name}",
-                style="red",
+            console_error(
+                f"can't detect the remote target branch for {branch_name}",
             )
             console.print(
                 f"Please set it with `git branch {branch_name} --set-upstream-to=<remote>/<branch>`",
@@ -386,10 +383,9 @@ async def get_default_token() -> str | None:
         try:
             token = await run_command("gh", "auth", "token")
         except CommandError:
-            console.print(
-                "error: please set the 'MERGIFY_TOKEN' or 'GITHUB_TOKEN' environment variable, "
+            console_error(
+                "please set the 'MERGIFY_TOKEN' or 'GITHUB_TOKEN' environment variable, "
                 "or make sure that gh client is installed and you are authenticated",
-                style="red",
             )
             return None
     return token


### PR DESCRIPTION
Introduces `console_error(message)` in `_globals.py` which prints
`error: {message}` in red. Replaces five different error formatting
patterns across the codebase:
- `console.print("error: ...", style="red")`
- `console.print("[red]Error:[/] ...")`
- `console.print(f"[red]...[/]")`
- `console.log(f"[red] ... [/]")`
- `console.print(f"...", style="red")` (with inline "error:" prefix)

All user-facing error messages now go through one function.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

Depends-On: #1193