### PR TITLE
feat: add Buildkite CI provider support

### DIFF
--- a/mergify_cli/ci/detector.py
+++ b/mergify_cli/ci/detector.py
@@ -11,7 +11,7 @@ from mergify_cli import utils
 
 GIT_BRANCH_PREFIXES = ("origin/", "refs/heads/")
 
-CIProviderT = typing.Literal["github_actions", "circleci", "jenkins"]
+CIProviderT = typing.Literal["github_actions", "circleci", "jenkins", "buildkite"]
 
 
 def get_ci_provider() -> CIProviderT | None:
@@ -21,6 +21,8 @@ def get_ci_provider() -> CIProviderT | None:
         return "github_actions"
     if os.getenv("CIRCLECI") == "true":
         return "circleci"
+    if os.getenv("BUILDKITE") == "true":
+        return "buildkite"
     return None
 
 
@@ -30,6 +32,8 @@ def get_pipeline_name() -> str | None:
             return os.getenv("GITHUB_WORKFLOW")
         case "jenkins":
             return os.getenv("JOB_NAME")
+        case "buildkite":
+            return os.getenv("BUILDKITE_PIPELINE_SLUG")
 
     return None
 
@@ -42,6 +46,8 @@ def get_job_name() -> str | None:
             return os.getenv("CIRCLE_JOB")
         case "jenkins":
             return os.getenv("JOB_NAME")
+        case "buildkite":
+            return os.getenv("BUILDKITE_LABEL") or os.getenv("BUILDKITE_STEP_KEY")
         case _:
             return None
 
@@ -77,6 +83,8 @@ def get_head_ref_name() -> str | None:
             return os.getenv("CIRCLE_BRANCH")
         case "jenkins":
             return get_jenkins_head_ref_name()
+        case "buildkite":
+            return os.getenv("BUILDKITE_BRANCH")
         case _:
             return None
 
@@ -127,6 +135,8 @@ async def get_head_sha() -> str | None:
             return await get_circle_ci_head_sha()
         case "jenkins":
             return os.getenv("GIT_COMMIT")
+        case "buildkite":
+            return os.getenv("BUILDKITE_COMMIT")
         case _:
             return None
 
@@ -137,6 +147,8 @@ def get_cicd_pipeline_runner_name() -> str | None:
             return os.getenv("RUNNER_NAME")
         case "jenkins":
             return os.getenv("NODE_NAME")
+        case "buildkite":
+            return os.getenv("BUILDKITE_AGENT_NAME")
         case _:
             return None
 
@@ -151,6 +163,8 @@ def get_cicd_pipeline_run_id() -> int | str | None:
                 return int(os.environ["CIRCLE_WORKFLOW_ID"])
         case "jenkins":
             return os.getenv("BUILD_ID")
+        case "buildkite":
+            return os.getenv("BUILDKITE_BUILD_ID")
 
     return None
 
@@ -160,6 +174,8 @@ def get_cicd_pipeline_run_attempt() -> int | None:
         return int(os.environ["GITHUB_RUN_ATTEMPT"])
     if get_ci_provider() == "circleci" and "CIRCLE_BUILD_NUM" in os.environ:
         return int(os.environ["CIRCLE_BUILD_NUM"])
+    if get_ci_provider() == "buildkite" and "BUILDKITE_RETRY_COUNT" in os.environ:
+        return int(os.environ["BUILDKITE_RETRY_COUNT"])
 
     return None
 
@@ -182,7 +198,7 @@ def _get_github_repository_from_env(env: str) -> str | None:
         r"(https?://[\w.-]+(?::\d+)?/)?(?P<full_name>[\w.-]+/[\w.-]+)/?$",
         repository_url,
     ):
-        return match.group("full_name")
+        return match.group("full_name").removesuffix(".git")
 
     return None
 
@@ -198,6 +214,12 @@ def get_github_pull_request_number() -> int | None:
                 return None
             return event.pull_request.number
 
+        case "buildkite":
+            pr = os.getenv("BUILDKITE_PULL_REQUEST")
+            if pr and pr != "false":
+                return int(pr)
+            return None
+
         case _:
             return None
 
@@ -210,6 +232,8 @@ def get_github_repository() -> str | None:
             return _get_github_repository_from_env("CIRCLE_REPOSITORY_URL")
         case "jenkins":
             return _get_github_repository_from_env("GIT_URL")
+        case "buildkite":
+            return _get_github_repository_from_env("BUILDKITE_REPO")
         case _:
             return None
 

--- a/mergify_cli/ci/git_refs/detector.py
+++ b/mergify_cli/ci/git_refs/detector.py
@@ -29,6 +29,7 @@ ReferencesSource = typing.Literal[
     "github_event_other",
     "github_event_pull_request",
     "github_event_push",
+    "buildkite_pull_request",
 ]
 
 
@@ -85,7 +86,28 @@ def _detect_from_push_event(ev: github_event.GitHubEvent) -> References | None:
     return None
 
 
+def _detect_from_buildkite() -> References | None:
+    """Detect base/head references from Buildkite environment variables."""
+    pr = os.getenv("BUILDKITE_PULL_REQUEST")
+    if pr and pr != "false":
+        base_branch = os.getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
+        commit = os.getenv("BUILDKITE_COMMIT", "HEAD")
+        if base_branch:
+            return References(
+                base_branch,
+                commit,
+                "buildkite_pull_request",
+            )
+    return None
+
+
 def detect() -> References:
+    # Try Buildkite-specific detection first
+    if os.getenv("BUILDKITE") == "true":
+        result = _detect_from_buildkite()
+        if result:
+            return result
+
     try:
         event_name, event = utils.get_github_event()
     except utils.GitHubEventNotFoundError:

--- a/mergify_cli/tests/ci/git_refs/test_git_refs_detector.py
+++ b/mergify_cli/tests/ci/git_refs/test_git_refs_detector.py
@@ -188,3 +188,35 @@ def test_detect_unhandled_event(
     result = detector.detect()
 
     assert result == detector.References(None, "HEAD", "github_event_other")
+
+
+def test_detect_buildkite_pull_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+    monkeypatch.setenv("BUILDKITE", "true")
+    monkeypatch.setenv("BUILDKITE_PULL_REQUEST", "42")
+    monkeypatch.setenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "main")
+    monkeypatch.setenv("BUILDKITE_COMMIT", "abc123")
+
+    result = detector.detect()
+
+    assert result == detector.References(
+        "main",
+        "abc123",
+        "buildkite_pull_request",
+    )
+
+
+def test_detect_buildkite_not_pr_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+    monkeypatch.setenv("BUILDKITE", "true")
+    monkeypatch.setenv("BUILDKITE_PULL_REQUEST", "false")
+
+    result = detector.detect()
+
+    assert result == detector.References("HEAD^", "HEAD", "fallback_last_commit")

--- a/mergify_cli/tests/ci/test_detector.py
+++ b/mergify_cli/tests/ci/test_detector.py
@@ -125,6 +125,7 @@ async def test_get_head_sha_circle_ci(
         ("https://github.com/my-org.name/my-repo.name", "my-org.name/my-repo.name"),
         ("https://git.example.com:8080/owner/repo", "owner/repo"),
         ("https://github.com/owner123/repo456", "owner123/repo456"),
+        ("https://github.com/owner/repo.git", "owner/repo"),
         ("git@github.com:owner/repo.git", "owner/repo"),
         ("git@github.com:owner/repo", "owner/repo"),
         ("git@gitlab.com:owner/repo.git", "owner/repo"),
@@ -272,3 +273,111 @@ def test_get_mergify_config_path_none_when_missing(
 
     result = detector.get_mergify_config_path()
     assert result is None
+
+
+# --- Buildkite provider tests ---
+
+
+@pytest.fixture
+def _buildkite_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set up a minimal Buildkite CI environment."""
+    # Clear other CI providers
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("CIRCLECI", raising=False)
+    monkeypatch.delenv("JENKINS_URL", raising=False)
+    # Set Buildkite
+    monkeypatch.setenv("BUILDKITE", "true")
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+def test_get_ci_provider_buildkite() -> None:
+    assert detector.get_ci_provider() == "buildkite"
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+def test_get_pipeline_name_buildkite(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BUILDKITE_PIPELINE_SLUG", "my-pipeline")
+    assert detector.get_pipeline_name() == "my-pipeline"
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+def test_get_job_name_buildkite_label(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BUILDKITE_LABEL", "Run tests")
+    assert detector.get_job_name() == "Run tests"
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+def test_get_job_name_buildkite_step_key_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("BUILDKITE_LABEL", raising=False)
+    monkeypatch.setenv("BUILDKITE_STEP_KEY", "test-step")
+    assert detector.get_job_name() == "test-step"
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+def test_get_head_ref_name_buildkite(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BUILDKITE_BRANCH", "feature/my-branch")
+    assert detector.get_head_ref_name() == "feature/my-branch"
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+async def test_get_head_sha_buildkite(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BUILDKITE_COMMIT", "abc123def456")
+    assert await detector.get_head_sha() == "abc123def456"
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+def test_get_cicd_pipeline_runner_name_buildkite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUILDKITE_AGENT_NAME", "agent-1")
+    assert detector.get_cicd_pipeline_runner_name() == "agent-1"
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+def test_get_cicd_pipeline_run_id_buildkite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUILDKITE_BUILD_ID", "018f3e2a-1234-5678-9abc-def012345678")
+    assert detector.get_cicd_pipeline_run_id() == "018f3e2a-1234-5678-9abc-def012345678"
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+def test_get_cicd_pipeline_run_attempt_buildkite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUILDKITE_RETRY_COUNT", "2")
+    assert detector.get_cicd_pipeline_run_attempt() == 2
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+def test_get_github_repository_buildkite_ssh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUILDKITE_REPO", "git@github.com:mergifyio/demo.git")
+    assert detector.get_github_repository() == "mergifyio/demo"
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+def test_get_github_repository_buildkite_https(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUILDKITE_REPO", "https://github.com/mergifyio/demo")
+    assert detector.get_github_repository() == "mergifyio/demo"
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+def test_get_github_pull_request_number_buildkite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUILDKITE_PULL_REQUEST", "42")
+    assert detector.get_github_pull_request_number() == 42
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+def test_get_github_pull_request_number_buildkite_not_pr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUILDKITE_PULL_REQUEST", "false")
+    assert detector.get_github_pull_request_number() is None


### PR DESCRIPTION
Detect Buildkite environment and extract:
- Repository (BUILDKITE_REPO, supports SSH and HTTPS URLs)
- Branch (BUILDKITE_BRANCH)
- Commit SHA (BUILDKITE_COMMIT)
- Pull request number (BUILDKITE_PULL_REQUEST)
- Pipeline name (BUILDKITE_PIPELINE_SLUG)
- Job name (BUILDKITE_LABEL / BUILDKITE_STEP_KEY)
- Runner name (BUILDKITE_AGENT_NAME)
- Build ID (BUILDKITE_BUILD_ID)
- Retry count (BUILDKITE_RETRY_COUNT)

For git-refs detection, use BUILDKITE_PULL_REQUEST_BASE_BRANCH
to determine the base ref on PR builds instead of falling back
to HEAD^.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>