### PR TITLE
fix(plugin): consolidate marketplace to single mergify plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,29 +8,9 @@
   },
   "plugins": [
     {
-      "name": "mergify-stack",
+      "name": "mergify",
       "source": "./",
-      "description": "Stacked PRs and Git workflow automation"
-    },
-    {
-      "name": "mergify-merge-queue",
-      "source": "./",
-      "description": "Monitor, inspect, pause, and manage the Mergify merge queue"
-    },
-    {
-      "name": "mergify-ci",
-      "source": "./",
-      "description": "CI insights: JUnit test results, git refs detection, scopes, and merge queue metadata"
-    },
-    {
-      "name": "mergify-config",
-      "source": "./",
-      "description": "Validate and simulate Mergify configuration files"
-    },
-    {
-      "name": "mergify-freeze",
-      "source": "./",
-      "description": "Create and manage scheduled merge freezes"
+      "description": "Mergify CLI integration for stacked PRs, merge queues, CI insights, scheduled freezes, and configuration management"
     }
   ]
 }


### PR DESCRIPTION
The marketplace.json listed 5 separate plugins (mergify-stack,
mergify-merge-queue, mergify-ci, mergify-config, mergify-freeze) all
with source "./", which conflicts with the single "mergify" plugin
defined in plugin.json. Per the marketplace docs, each plugin entry
with source "./" would need its own .claude-plugin/plugin.json at that
path.

Additionally, one entry was stale (mergify-freeze) — the actual skill
is mergify-merge-protections.

Consolidate to a single "mergify" plugin entry that matches plugin.json
and the runtime behavior (skills already load as mergify:mergify-stack,
mergify:mergify-ci, etc.).