### PR TITLE
fix(ci): skip scopes upload when no pull request number is detected

### DIFF
--- a/mergify_cli/ci/cli.py
+++ b/mergify_cli/ci/cli.py
@@ -335,7 +335,6 @@ def scopes(
     help="pull_request number",
     type=int,
     default=detector.get_github_pull_request_number,
-    required=True,
 )
 @click.option("--scope", "-s", multiple=True, help="Scope to upload")
 @click.option(
@@ -349,10 +348,14 @@ async def scopes_send(
     api_url: str,
     token: str,
     repository: str,
-    pull_request: int,
+    pull_request: int | None,
     scope: tuple[str, ...],
     file: str | None,
 ) -> None:
+    if pull_request is None:
+        click.echo("No pull request number detected, skipping scopes upload.")
+        return
+
     scopes = list(scope)
     if file is not None:
         try:

--- a/mergify_cli/tests/ci/test_cli.py
+++ b/mergify_cli/tests/ci/test_cli.py
@@ -355,6 +355,31 @@ def test_scopes_send(
     assert sorted(payload["scopes"]) == ["backend", "foobar", "frontend"]
 
 
+def test_scopes_send_no_pull_request_skips(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no pull request number is detected, scopes-send should skip gracefully."""
+    monkeypatch.delenv("BUILDKITE_PULL_REQUEST", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+
+    runner = testing.CliRunner()
+    result = runner.invoke(
+        ci_cli.scopes_send,
+        [
+            "--repository",
+            "owner/repository",
+            "--token",
+            "test-token",
+            "--scope",
+            "backend",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "No pull request number detected, skipping scopes upload." in result.output
+
+
 def test_scopes_empty_mergify_config_env_uses_autodetection(
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
When `get_github_pull_request_number()` returns None (e.g. on a push
event or a CI provider that doesn't expose a PR number), the
`scopes-send` command now prints a message and exits cleanly instead
of sending a request to `/pulls/None/scopes` which returns HTTP 403.