### PR TITLE
fix(ci): fetch branch refs via refspec so merge-base can resolve them

### DIFF
--- a/mergify_cli/ci/scopes/changed_files.py
+++ b/mergify_cli/ci/scopes/changed_files.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 
@@ -7,6 +8,14 @@ from mergify_cli.ci.scopes import exceptions
 
 
 COMMITS_BATCH_SIZE = 100
+
+# Scoped namespace for refs we fetch ourselves, to avoid clashing with
+# refs/remotes/origin/* (which may not exist or may point elsewhere).
+FETCHED_REF_PREFIX = "refs/mergify-cli/fetched/"
+
+# Only full 40-char SHAs — abbreviated SHAs would false-match branch names
+# like "deadbeef" and cause them to be fetched without a refspec.
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 
 class ChangedFilesError(exceptions.ScopesError):
@@ -17,9 +26,33 @@ def _run(cmd: list[str]) -> str:
     return subprocess.check_output(cmd, text=True, encoding="utf-8").strip()  # noqa: S603
 
 
+def _is_sha(ref: str) -> bool:
+    return bool(_SHA_RE.match(ref))
+
+
+def _is_local_ref(ref: str) -> bool:
+    return ref == "HEAD" or ref.startswith(("HEAD~", "HEAD^"))
+
+
+def _local_ref(ref: str) -> str:
+    if _is_sha(ref) or _is_local_ref(ref):
+        return ref
+    return f"{FETCHED_REF_PREFIX}{ref}"
+
+
+def _fetch_arg(ref: str) -> str | None:
+    if _is_local_ref(ref):
+        return None
+    if _is_sha(ref):
+        return ref
+    # `git fetch origin <branch>` only updates FETCH_HEAD; use an explicit
+    # refspec so the branch becomes a real local ref we can name later.
+    return f"+{ref}:{_local_ref(ref)}"
+
+
 def has_merge_base(base: str, head: str) -> bool:
     try:
-        _run(["git", "merge-base", base, head])
+        _run(["git", "merge-base", "--", base, head])
     except subprocess.CalledProcessError:
         return False
     return True
@@ -29,44 +62,56 @@ def get_commits_count() -> int:
     return int(_run(["git", "rev-list", "--count", "--all"]))
 
 
-def ensure_git_history(base: str, head: str) -> None:
+def _fetch_cmd(depth_flag: str, fetch_args: list[str]) -> list[str]:
+    cmd = ["git", "fetch", "--no-tags", depth_flag, "origin"]
+    if fetch_args:
+        cmd.append("--")
+        cmd.extend(fetch_args)
+    return cmd
+
+
+def ensure_git_history(base: str, head: str) -> tuple[str, str]:
+    if has_merge_base(base, head):
+        return base, head
+
+    fetch_args = [a for a in (_fetch_arg(base), _fetch_arg(head)) if a]
+    local_base = _local_ref(base)
+    local_head = _local_ref(head)
     fetch_depth = COMMITS_BATCH_SIZE
 
-    if not has_merge_base(base, head):
-        _run(
-            [
-                "git",
-                "fetch",
-                "--no-tags",
-                f"--depth={fetch_depth}",
-                "origin",
-                base,
-                head,
-            ],
-        )
+    _run(_fetch_cmd(f"--depth={fetch_depth}", fetch_args))
 
     last_commits_count = get_commits_count()
-    while not has_merge_base(base, head):
+    while not has_merge_base(local_base, local_head):
         fetch_depth = min(fetch_depth * 2, sys.maxsize)
-        _run(["git", "fetch", f"--deepen={fetch_depth}", "origin", base, head])
+        _run(_fetch_cmd(f"--deepen={fetch_depth}", fetch_args))
         commits_count = get_commits_count()
         if commits_count == last_commits_count:
-            if not has_merge_base(base, head):
+            if not has_merge_base(local_base, local_head):
                 msg = f"Cannot find a common ancestor between {base} and {head}"
                 raise ChangedFilesError(msg)
 
             break
         last_commits_count = commits_count
 
+    return local_base, local_head
+
 
 def git_changed_files(base: str, head: str) -> list[str]:
-    ensure_git_history(base, head)
+    local_base, local_head = ensure_git_history(base, head)
     # Committed changes only between base_sha and HEAD.
     # Includes: Added (A), Copied (C), Modified (M), Renamed (R), Type-changed (T), Deleted (D)
     # Excludes: Unmerged (U), Unknown (X), Broken (B)
     try:
         out = _run(
-            ["git", "diff", "--name-only", "--diff-filter=ACMRTD", f"{base}...{head}"],
+            [
+                "git",
+                "diff",
+                "--name-only",
+                "--diff-filter=ACMRTD",
+                f"{local_base}...{local_head}",
+                "--",
+            ],
         )
     except subprocess.CalledProcessError as e:
         msg = f"Command failed: {' '.join(e.cmd)}\n{e}"

--- a/mergify_cli/tests/ci/scopes/test_changed_files.py
+++ b/mergify_cli/tests/ci/scopes/test_changed_files.py
@@ -12,11 +12,16 @@ if TYPE_CHECKING:
 
 
 def test_git_changed_files(mock_subprocess: test_utils.SubprocessMocks) -> None:
-    mock_subprocess.register(["git", "merge-base", "main", "HEAD"])
-    mock_subprocess.register(["git", "rev-list", "--count", "--all"], "100")
-    mock_subprocess.register(["git", "merge-base", "main", "HEAD"])
+    mock_subprocess.register(["git", "merge-base", "--", "main", "HEAD"])
     mock_subprocess.register(
-        ["git", "diff", "--name-only", "--diff-filter=ACMRTD", "main...HEAD"],
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMRTD",
+            "main...HEAD",
+            "--",
+        ],
         "file1.py\nfile2.js\n",
     )
 
@@ -32,32 +37,48 @@ def test_git_changed_files_fetch_alot_of_history(
     head = "9b6d25af10e6285862eb2476106f266d2aa303cf"
 
     mock_subprocess.register(
-        ["git", "merge-base", base, head],
+        ["git", "merge-base", "--", base, head],
         "No such git object",
         1,
     )
     mock_subprocess.register(
-        ["git", "fetch", "--no-tags", "--depth=100", "origin", base, head],
+        ["git", "fetch", "--no-tags", "--depth=100", "origin", "--", base, head],
     )
     mock_subprocess.register(["git", "rev-list", "--count", "--all"], "100")
 
     # Loop until we find it
     for count in (200, 400, 800, 1600):
         mock_subprocess.register(
-            ["git", "merge-base", base, head],
+            ["git", "merge-base", "--", base, head],
             "No such git object",
             1,
         )
         mock_subprocess.register(
-            ["git", "fetch", f"--deepen={count}", "origin", base, head],
+            [
+                "git",
+                "fetch",
+                "--no-tags",
+                f"--deepen={count}",
+                "origin",
+                "--",
+                base,
+                head,
+            ],
         )
         mock_subprocess.register(["git", "rev-list", "--count", "--all"], f"{count}")
 
     # We found it!
-    mock_subprocess.register(["git", "merge-base", base, head])
+    mock_subprocess.register(["git", "merge-base", "--", base, head])
 
     mock_subprocess.register(
-        ["git", "diff", "--name-only", "--diff-filter=ACMRTD", f"{base}...{head}"],
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMRTD",
+            f"{base}...{head}",
+            "--",
+        ],
         "file1.py\nfile2.js\n",
     )
 
@@ -66,12 +87,138 @@ def test_git_changed_files_fetch_alot_of_history(
     assert result == ["file1.py", "file2.js"]
 
 
-def test_git_changed_files_empty(mock_subprocess: test_utils.SubprocessMocks) -> None:
-    mock_subprocess.register(["git", "merge-base", "main", "HEAD"])
-    mock_subprocess.register(["git", "rev-list", "--count", "--all"], "100")
-    mock_subprocess.register(["git", "merge-base", "main", "HEAD"])
+def test_git_changed_files_fetch_branch_name_uses_refspec(
+    mock_subprocess: test_utils.SubprocessMocks,
+) -> None:
+    """A branch name must be fetched via refspec so it becomes a local ref.
+
+    Without a refspec, `git fetch origin <branch>` only updates FETCH_HEAD,
+    and subsequent `git merge-base <branch> ...` fails with
+    "Not a valid object name".
+    """
+    base = "devs/sileht/test-stack/add-random-line-readme-md--861404f9"
+    head = "27adb8407351454f8859bc85ac2709d13fd5e9f9"
+    local_base = f"refs/mergify-cli/fetched/{base}"
+    refspec = f"+{base}:{local_base}"
+
     mock_subprocess.register(
-        ["git", "diff", "--name-only", "--diff-filter=ACMRTD", "main...HEAD"],
+        ["git", "merge-base", "--", base, head],
+        "Not a valid object name",
+        1,
+    )
+    mock_subprocess.register(
+        ["git", "fetch", "--no-tags", "--depth=100", "origin", "--", refspec, head],
+    )
+    mock_subprocess.register(["git", "rev-list", "--count", "--all"], "100")
+    mock_subprocess.register(["git", "merge-base", "--", local_base, head])
+    mock_subprocess.register(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMRTD",
+            f"{local_base}...{head}",
+            "--",
+        ],
+        "file1.py\n",
+    )
+
+    result = changed_files.git_changed_files(base, head)
+
+    assert result == ["file1.py"]
+
+
+def test_git_changed_files_short_hex_branch_name_not_sha(
+    mock_subprocess: test_utils.SubprocessMocks,
+) -> None:
+    """A branch name that happens to be valid hex but shorter than 40 chars
+    must be treated as a branch, not a SHA — otherwise it would be fetched
+    bare and merge-base would fail for the exact bug this module fixes."""
+    base = "deadbeef"
+    head = "9b6d25af10e6285862eb2476106f266d2aa303cf"
+    local_base = f"refs/mergify-cli/fetched/{base}"
+    refspec = f"+{base}:{local_base}"
+
+    mock_subprocess.register(
+        ["git", "merge-base", "--", base, head],
+        "Not a valid object name",
+        1,
+    )
+    mock_subprocess.register(
+        ["git", "fetch", "--no-tags", "--depth=100", "origin", "--", refspec, head],
+    )
+    mock_subprocess.register(["git", "rev-list", "--count", "--all"], "100")
+    mock_subprocess.register(["git", "merge-base", "--", local_base, head])
+    mock_subprocess.register(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMRTD",
+            f"{local_base}...{head}",
+            "--",
+        ],
+        "file.py\n",
+    )
+
+    result = changed_files.git_changed_files(base, head)
+
+    assert result == ["file.py"]
+
+
+def test_git_changed_files_shallow_local_refs_deepen(
+    mock_subprocess: test_utils.SubprocessMocks,
+) -> None:
+    """When both refs are local (e.g. HEAD^/HEAD) and the clone is shallow,
+    deepen via `git fetch --deepen` without refspecs until merge-base works.
+    """
+    mock_subprocess.register(
+        ["git", "merge-base", "--", "HEAD^", "HEAD"],
+        "fatal: bad revision 'HEAD^'",
+        1,
+    )
+    mock_subprocess.register(
+        ["git", "fetch", "--no-tags", "--depth=100", "origin"],
+    )
+    mock_subprocess.register(["git", "rev-list", "--count", "--all"], "50")
+    mock_subprocess.register(
+        ["git", "merge-base", "--", "HEAD^", "HEAD"],
+        "fatal: bad revision 'HEAD^'",
+        1,
+    )
+    mock_subprocess.register(
+        ["git", "fetch", "--no-tags", "--deepen=200", "origin"],
+    )
+    mock_subprocess.register(["git", "rev-list", "--count", "--all"], "100")
+    mock_subprocess.register(["git", "merge-base", "--", "HEAD^", "HEAD"])
+    mock_subprocess.register(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMRTD",
+            "HEAD^...HEAD",
+            "--",
+        ],
+        "file.py\n",
+    )
+
+    result = changed_files.git_changed_files("HEAD^", "HEAD")
+
+    assert result == ["file.py"]
+
+
+def test_git_changed_files_empty(mock_subprocess: test_utils.SubprocessMocks) -> None:
+    mock_subprocess.register(["git", "merge-base", "--", "main", "HEAD"])
+    mock_subprocess.register(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMRTD",
+            "main...HEAD",
+            "--",
+        ],
         "",
     )
 
@@ -81,11 +228,16 @@ def test_git_changed_files_empty(mock_subprocess: test_utils.SubprocessMocks) ->
 
 
 def test_run_command_failure(mock_subprocess: test_utils.SubprocessMocks) -> None:
-    mock_subprocess.register(["git", "merge-base", "main", "HEAD"])
-    mock_subprocess.register(["git", "rev-list", "--count", "--all"], "100")
-    mock_subprocess.register(["git", "merge-base", "main", "HEAD"])
+    mock_subprocess.register(["git", "merge-base", "--", "main", "HEAD"])
     mock_subprocess.register(
-        ["git", "diff", "--name-only", "--diff-filter=ACMRTD", "main...HEAD"],
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMRTD",
+            "main...HEAD",
+            "--",
+        ],
         "No such git object",
         1,
     )


### PR DESCRIPTION
`git fetch origin <branch>` only updates FETCH_HEAD and does not create a
local ref, so subsequent `git merge-base <branch> <sha>` failed with
"Not a valid object name". The fetch loop in ensure_git_history then
kept refetching the same objects until bailing with "Cannot find a
common ancestor".

Fetch branch names via `+<branch>:refs/mergify-cli/fetched/<branch>` so
they become real local refs, and have ensure_git_history return the
local refs to use downstream. SHAs are fetched bare; local refs like
HEAD are not fetched at all.

This will improve the detection for stacked PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>