### PR TITLE
feat(stack): embed JSON payload in revision history comments

### DIFF
--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import datetime
+import json
 import os
 import re
 import sys
@@ -500,7 +501,19 @@ class _RevisionEntry:
     change_type: str
     old_sha: str | None  # None for "initial"
     new_sha: str
-    timestamp: str  # "YYYY-MM-DD HH:MM UTC"
+    timestamp: datetime.datetime | None
+
+    @property
+    def timestamp_human(self) -> str:
+        if self.timestamp is None:
+            return ""
+        return self.timestamp.strftime("%Y-%m-%d %H:%M UTC")
+
+    @property
+    def timestamp_iso(self) -> str | None:
+        if self.timestamp is None:
+            return None
+        return self.timestamp.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 @dataclasses.dataclass
@@ -527,10 +540,6 @@ class RevisionHistoryComment:
             html_url = api_url.replace("api.github.com", "github.com")
         return f"{html_url}/{self.user}/{self.repo}/compare/{old_sha}...{new_sha}"
 
-    @staticmethod
-    def _format_timestamp(dt: datetime.datetime) -> str:
-        return dt.strftime("%Y-%m-%d %H:%M UTC")
-
     @classmethod
     def create_initial(
         cls,
@@ -543,10 +552,9 @@ class RevisionHistoryComment:
         change_type: str,
         timestamp: datetime.datetime,
     ) -> RevisionHistoryComment:
-        ts = cls._format_timestamp(timestamp)
         entries = [
-            _RevisionEntry(1, "initial", None, old_sha, ts),
-            _RevisionEntry(2, change_type, old_sha, new_sha, ts),
+            _RevisionEntry(1, "initial", None, old_sha, timestamp),
+            _RevisionEntry(2, change_type, old_sha, new_sha, timestamp),
         ]
         return cls(
             github_server=github_server,
@@ -563,10 +571,9 @@ class RevisionHistoryComment:
         change_type: str,
         timestamp: datetime.datetime,
     ) -> None:
-        ts = self._format_timestamp(timestamp)
         next_number = len(self.entries) + 1
         self.entries.append(
-            _RevisionEntry(next_number, change_type, old_sha, new_sha, ts),
+            _RevisionEntry(next_number, change_type, old_sha, new_sha, timestamp),
         )
 
     def _render_entry(self, entry: _RevisionEntry) -> str:
@@ -575,9 +582,38 @@ class RevisionHistoryComment:
         else:
             url = self._compare_url(entry.old_sha, entry.new_sha)
             changes_cell = f"[`{entry.old_sha[:7]} \u2192 {entry.new_sha[:7]}`]({url})"
-        return f"| {entry.number} | {entry.change_type} | {changes_cell} | {entry.timestamp} |"
+        return (
+            f"| {entry.number} | {entry.change_type} | {changes_cell} "
+            f"| {entry.timestamp_human} |"
+        )
 
-    def body(self) -> str:
+    def _json_marker(self, pull_number: int) -> str:
+        payload = {
+            "schema_version": 1,
+            "pull_number": pull_number,
+            "entries": [
+                {
+                    "number": e.number,
+                    "change_type": e.change_type,
+                    "old_sha": e.old_sha,
+                    "new_sha": e.new_sha,
+                    "timestamp_iso": e.timestamp_iso,
+                    "compare_url": (
+                        None
+                        if e.old_sha is None
+                        else self._compare_url(e.old_sha, e.new_sha)
+                    ),
+                }
+                for e in self.entries
+            ],
+        }
+        return (
+            "<!-- mergify-revision-data: "
+            + json.dumps(payload, separators=(",", ":"))
+            + " -->"
+        )
+
+    def body(self, pull_number: int) -> str:
         lines = [
             self.REVISION_COMMENT_FIRST_LINE,
             "| # | Type | Changes | Date |",
@@ -589,7 +625,7 @@ class RevisionHistoryComment:
                 lines.append(self._raw_rows[i])
             else:
                 lines.append(self._render_entry(entry))
-        return "\n".join(lines) + "\n"
+        return "\n".join(lines) + "\n" + self._json_marker(pull_number) + "\n"
 
     _ROW_RE: typing.ClassVar[re.Pattern[str]] = re.compile(
         r"^\| (\d+) \| (\w+) \| .+ \| (.+) \|$",
@@ -615,7 +651,14 @@ class RevisionHistoryComment:
                 continue
             number = int(m.group(1))
             change_type = m.group(2)
-            timestamp = m.group(3).strip()
+            timestamp_str = m.group(3).strip()
+            try:
+                timestamp = datetime.datetime.strptime(
+                    timestamp_str,
+                    "%Y-%m-%d %H:%M UTC",
+                ).replace(tzinfo=datetime.UTC)
+            except ValueError:
+                timestamp = None
             entries.append(
                 _RevisionEntry(number, change_type, None, "", timestamp),
             )
@@ -705,7 +748,7 @@ async def _update_revision_for_pull(
     if change.pull is None:
         return
 
-    pull_number = change.pull["number"]
+    pull_number = int(change.pull["number"])
     old_sha = change.pull_head_sha
     new_sha = change.commit_sha
 
@@ -730,7 +773,7 @@ async def _update_revision_for_pull(
                         change_type=change_type,
                         timestamp=timestamp,
                     )
-                    new_body = parsed.body()
+                    new_body = parsed.body(pull_number)
                     if comment["body"] != new_body:
                         await client.patch(
                             comment["url"],
@@ -749,7 +792,7 @@ async def _update_revision_for_pull(
                 )
                 await client.patch(
                     comment["url"],
-                    json={"body": revision.body()},
+                    json={"body": revision.body(pull_number)},
                 )
                 return
 
@@ -765,7 +808,7 @@ async def _update_revision_for_pull(
         )
         await client.post(
             f"/repos/{user}/{repo}/issues/{pull_number}/comments",
-            json={"body": revision.body()},
+            json={"body": revision.body(pull_number)},
         )
 
 

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -951,7 +951,7 @@ def test_revision_history_comment_first_update() -> None:
         change_type="content",
         timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
     )
-    body = comment.body()
+    body = comment.body(pull_number=1)
     assert body.startswith("### Revision history\n")
     assert "| 1 | initial |" in body
     assert "`abc1234`" in body
@@ -980,7 +980,7 @@ def test_revision_history_comment_append() -> None:
         change_type="rebase",
         timestamp=datetime.datetime(2026, 4, 15, 9, 10, tzinfo=datetime.UTC),
     )
-    body = comment.body()
+    body = comment.body(pull_number=1)
     assert "| 3 | rebase |" in body
     assert (
         "def5678901234567890abcdef1234567890abcdef...789abcdef01234567890abcdef01234567890abcd"
@@ -1000,7 +1000,7 @@ def test_revision_history_comment_parse_existing() -> None:
         change_type="content",
         timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
     )
-    body = original.body()
+    body = original.body(pull_number=1)
 
     parsed = push.RevisionHistoryComment.parse(
         body,
@@ -1016,7 +1016,7 @@ def test_revision_history_comment_parse_existing() -> None:
         change_type="rebase",
         timestamp=datetime.datetime(2026, 4, 15, 9, 10, tzinfo=datetime.UTC),
     )
-    new_body = parsed.body()
+    new_body = parsed.body(pull_number=1)
     assert "| 3 | rebase |" in new_body
     # Verify old rows are preserved verbatim (compare links intact)
     assert (
@@ -1046,6 +1046,39 @@ def test_revision_history_is_revision_comment() -> None:
     )
 
 
+def test_revision_history_initial_populates_timestamp_iso() -> None:
+    comment = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="abc1234567890abcdef1234567890abcdef123456",
+        new_sha="def5678901234567890abcdef1234567890abcdef",
+        change_type="content",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+    )
+    assert comment.entries[0].timestamp_iso == "2026-04-14T14:30:00Z"
+    assert comment.entries[1].timestamp_iso == "2026-04-14T14:30:00Z"
+
+
+def test_revision_history_append_populates_timestamp_iso() -> None:
+    comment = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="abc1234567890abcdef1234567890abcdef123456",
+        new_sha="def5678901234567890abcdef1234567890abcdef",
+        change_type="content",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+    )
+    comment.append(
+        old_sha="def5678901234567890abcdef1234567890abcdef",
+        new_sha="789abcdef01234567890abcdef01234567890abcd",
+        change_type="rebase",
+        timestamp=datetime.datetime(2026, 4, 15, 9, 10, 45, tzinfo=datetime.UTC),
+    )
+    assert comment.entries[2].timestamp_iso == "2026-04-15T09:10:45Z"
+
+
 def test_revision_history_comment_unknown_type() -> None:
     comment = push.RevisionHistoryComment.create_initial(
         github_server="https://api.github.com",
@@ -1056,8 +1089,78 @@ def test_revision_history_comment_unknown_type() -> None:
         change_type="unknown",
         timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
     )
-    body = comment.body()
+    body = comment.body(pull_number=1)
     assert "| 2 | unknown |" in body
+
+
+def test_revision_history_body_contains_json_marker() -> None:
+    comment = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="abc1234567890abcdef1234567890abcdef123456",
+        new_sha="def5678901234567890abcdef1234567890abcdef",
+        change_type="content",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+    )
+    body = comment.body(pull_number=42)
+
+    marker_prefix = "<!-- mergify-revision-data: "
+    marker_lines = [
+        line for line in body.splitlines() if line.startswith(marker_prefix)
+    ]
+    assert len(marker_lines) == 1
+    assert marker_lines[0].endswith(" -->")
+
+    payload_str = marker_lines[0][len(marker_prefix) : -len(" -->")]
+    payload = json.loads(payload_str)
+
+    assert payload == {
+        "schema_version": 1,
+        "pull_number": 42,
+        "entries": [
+            {
+                "number": 1,
+                "change_type": "initial",
+                "old_sha": None,
+                "new_sha": "abc1234567890abcdef1234567890abcdef123456",
+                "timestamp_iso": "2026-04-14T14:30:00Z",
+                "compare_url": None,
+            },
+            {
+                "number": 2,
+                "change_type": "content",
+                "old_sha": "abc1234567890abcdef1234567890abcdef123456",
+                "new_sha": "def5678901234567890abcdef1234567890abcdef",
+                "timestamp_iso": "2026-04-14T14:30:00Z",
+                "compare_url": (
+                    "https://github.com/owner/repo/compare/"
+                    "abc1234567890abcdef1234567890abcdef123456..."
+                    "def5678901234567890abcdef1234567890abcdef"
+                ),
+            },
+        ],
+    }
+
+
+def test_revision_history_body_json_marker_is_single_line_compact() -> None:
+    comment = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="abc1234567890abcdef1234567890abcdef123456",
+        new_sha="def5678901234567890abcdef1234567890abcdef",
+        change_type="rebase",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+    )
+    body = comment.body(pull_number=7)
+    marker_prefix = "<!-- mergify-revision-data: "
+    marker_line = next(
+        line for line in body.splitlines() if line.startswith(marker_prefix)
+    )
+    # Compact form: no spaces after separators.
+    assert '", ' not in marker_line
+    assert '": ' not in marker_line
 
 
 @pytest.mark.respx(base_url="https://api.github.com/")
@@ -1586,3 +1689,28 @@ async def test_get_remote_changes_old_format_branch(
     assert len(result) == 1
     cid = changes.ChangeId("I29617d37762fd69809c255d7e7073cb11f8fbf50")
     assert cid in result
+
+
+def test_revision_entry_timestamp_iso_normalises_to_utc() -> None:
+    tz_ist = datetime.timezone(datetime.timedelta(hours=5, minutes=30))
+    dt = datetime.datetime(2026, 4, 14, 20, 0, 0, tzinfo=tz_ist)  # 14:30:00 UTC
+    entry = push._RevisionEntry(
+        number=1,
+        change_type="content",
+        old_sha=None,
+        new_sha="abc",
+        timestamp=dt,
+    )
+    assert entry.timestamp_iso == "2026-04-14T14:30:00Z"
+
+
+def test_revision_entry_timestamp_iso_returns_none_for_unknown() -> None:
+    entry = push._RevisionEntry(
+        number=1,
+        change_type="content",
+        old_sha=None,
+        new_sha="abc",
+        timestamp=None,
+    )
+    assert entry.timestamp_iso is None
+    assert not entry.timestamp_human


### PR DESCRIPTION
Append a `<!-- mergify-revision-data: … -->` line to every revision
history comment body, carrying schema_version, pull_number, and
per-entry metadata (number, change_type, old_sha, new_sha,
timestamp_iso, compare_url). Thread pull_number through
RevisionHistoryComment.body() and _update_revision_for_pull.

Also introduces the _RevisionEntry.timestamp_iso field and
_format_timestamp_iso helper that the marker relies on.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>