### PR TITLE
refactor(stack): pass LocalChange list to stack comment rendering

### DIFF
--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -627,6 +627,10 @@ class RevisionHistoryComment:
                 lines.append(self._render_entry(entry))
         return "\n".join(lines) + "\n" + self._json_marker(pull_number) + "\n"
 
+    _JSON_MARKER_RE: typing.ClassVar[re.Pattern[str]] = re.compile(
+        r"^<!-- mergify-revision-data: (?P<payload>\{.*\}) -->$",
+    )
+
     _ROW_RE: typing.ClassVar[re.Pattern[str]] = re.compile(
         r"^\| (\d+) \| (\w+) \| .+ \| (.+) \|$",
     )
@@ -645,27 +649,64 @@ class RevisionHistoryComment:
 
         entries: list[_RevisionEntry] = []
         raw_rows: list[str] = []
+        marker_entries: list[typing.Any] | None = None
         for line in body.splitlines():
             m = cls._ROW_RE.match(line)
-            if not m:
+            if m:
+                number = int(m.group(1))
+                change_type = m.group(2)
+                timestamp_str = m.group(3).strip()
+                try:
+                    timestamp = datetime.datetime.strptime(
+                        timestamp_str,
+                        "%Y-%m-%d %H:%M UTC",
+                    ).replace(tzinfo=datetime.UTC)
+                except ValueError:
+                    timestamp = None
+                entries.append(
+                    _RevisionEntry(number, change_type, None, "", timestamp),
+                )
+                raw_rows.append(line)
                 continue
-            number = int(m.group(1))
-            change_type = m.group(2)
-            timestamp_str = m.group(3).strip()
-            try:
-                timestamp = datetime.datetime.strptime(
-                    timestamp_str,
-                    "%Y-%m-%d %H:%M UTC",
-                ).replace(tzinfo=datetime.UTC)
-            except ValueError:
-                timestamp = None
-            entries.append(
-                _RevisionEntry(number, change_type, None, "", timestamp),
-            )
-            raw_rows.append(line)
+            marker_match = cls._JSON_MARKER_RE.match(line)
+            if marker_match:
+                try:
+                    payload = json.loads(marker_match.group("payload"))
+                except json.JSONDecodeError:
+                    continue
+                if (
+                    isinstance(payload, dict)
+                    and payload.get("schema_version") == 1
+                    and isinstance(payload.get("entries"), list)
+                ):
+                    marker_entries = payload["entries"]
 
         if not entries:
             return None
+
+        if marker_entries is not None and len(marker_entries) == len(entries):
+            for entry, data in zip(entries, marker_entries, strict=True):
+                if not isinstance(data, dict):
+                    continue
+                if data.get("number") != entry.number:
+                    continue
+                old_sha = data.get("old_sha")
+                new_sha = data.get("new_sha")
+                timestamp_iso = data.get("timestamp_iso")
+                if isinstance(old_sha, str) or old_sha is None:
+                    entry.old_sha = old_sha
+                if isinstance(new_sha, str):
+                    entry.new_sha = new_sha
+                if isinstance(timestamp_iso, str):
+                    try:
+                        entry.timestamp = datetime.datetime.strptime(
+                            timestamp_iso,
+                            "%Y-%m-%dT%H:%M:%SZ",
+                        ).replace(tzinfo=datetime.UTC)
+                    except ValueError:
+                        pass
+                elif timestamp_iso is None:
+                    entry.timestamp = None
 
         return cls(
             github_server=github_server,

--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -425,12 +425,12 @@ async def stack_push(
                 ),
             )
 
-        pulls_to_comment = [
-            task.change.pull for task in tasks if task.change.pull is not None
+        changes_to_comment = [
+            task.change for task in tasks if task.change.pull is not None
         ]
 
         with console.status("Updating comments..."):
-            await create_or_update_comments(client, user, repo, pulls_to_comment)
+            await create_or_update_comments(client, user, repo, changes_to_comment)
 
         console.log("[green]Comments updated.[/]")
 
@@ -464,7 +464,7 @@ async def stack_push(
 
 @dataclasses.dataclass
 class StackComment:
-    pulls: list[github_types.PullRequest]
+    local_changes: list[changes.LocalChange]
 
     _STACK_COMMENT_OLD_HEADER: typing.ClassVar[str] = (
         "This pull request is part of a stack:\n"
@@ -480,11 +480,16 @@ class StackComment:
         body += "| # | Pull Request | Link | |\n"
         body += "|--:|---|---|---|\n"
 
-        for i, pull in enumerate(self.pulls, 1):
+        row = 0
+        for change in self.local_changes:
+            if change.pull is None:
+                continue
+            row += 1
+            pull = change.pull
             title = pull["title"].replace("|", "\\|")
             link = f"[#{pull['number']}]({pull['html_url']})"
             status = "👈" if pull == current_pull else ""
-            body += f"| {i} | {title} | {link} | {status} |\n"
+            body += f"| {row} | {title} | {link} | {status} |\n"
 
         return body
 
@@ -754,9 +759,10 @@ async def create_or_update_comments(
     client: httpx.AsyncClient,
     user: str,
     repo: str,
-    pulls: list[github_types.PullRequest],
+    local_changes: list[changes.LocalChange],
 ) -> None:
-    stack_comment = StackComment(pulls)
+    stack_comment = StackComment(local_changes)
+    pulls = [c.pull for c in local_changes if c.pull is not None]
     sem = asyncio.Semaphore(MAX_CONCURRENT_API_CALLS)
 
     await asyncio.gather(

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -1714,3 +1714,99 @@ def test_revision_entry_timestamp_iso_returns_none_for_unknown() -> None:
     )
     assert entry.timestamp_iso is None
     assert not entry.timestamp_human
+
+
+def test_revision_history_parse_rehydrates_from_json_marker() -> None:
+    original = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="abc1234567890abcdef1234567890abcdef123456",
+        new_sha="def5678901234567890abcdef1234567890abcdef",
+        change_type="content",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+    )
+    body = original.body(pull_number=7)
+
+    parsed = push.RevisionHistoryComment.parse(
+        body,
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+    )
+    assert parsed is not None
+    assert parsed.entries[0].old_sha is None
+    assert parsed.entries[0].new_sha == "abc1234567890abcdef1234567890abcdef123456"
+    assert parsed.entries[0].timestamp_iso == "2026-04-14T14:30:00Z"
+    assert parsed.entries[1].old_sha == "abc1234567890abcdef1234567890abcdef123456"
+    assert parsed.entries[1].new_sha == "def5678901234567890abcdef1234567890abcdef"
+    assert parsed.entries[1].timestamp_iso == "2026-04-14T14:30:00Z"
+
+
+def test_revision_history_parse_without_json_marker_recovers_timestamp() -> None:
+    """Legacy bodies (no JSON marker) recover timestamp from the rendered row.
+
+    SHAs cannot be recovered from the Markdown row (only short SHAs are
+    rendered), but the human-readable timestamp string is parseable back to
+    a datetime, so timestamp_iso is non-null even without a JSON marker.
+    """
+    legacy_body = (
+        "### Revision history\n"
+        "| # | Type | Changes | Date |\n"
+        "|---|------|---------|------|\n"
+        "| 1 | initial | `abc1234` | 2026-04-14 14:30 UTC |\n"
+        "| 2 | content | [`abc1234 \u2192 def5678`]"
+        "(https://github.com/owner/repo/compare/abc1234...def5678) | 2026-04-14 14:30 UTC |\n"
+    )
+    parsed = push.RevisionHistoryComment.parse(
+        legacy_body,
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+    )
+    assert parsed is not None
+    assert parsed.entries[0].old_sha is None
+    assert not parsed.entries[0].new_sha
+    assert parsed.entries[0].timestamp_iso == "2026-04-14T14:30:00Z"
+    assert parsed.entries[1].old_sha is None
+    assert not parsed.entries[1].new_sha
+    assert parsed.entries[1].timestamp_iso == "2026-04-14T14:30:00Z"
+
+
+def test_revision_history_round_trip_preserves_full_data() -> None:
+    original = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="abc1234567890abcdef1234567890abcdef123456",
+        new_sha="def5678901234567890abcdef1234567890abcdef",
+        change_type="content",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+    )
+    parsed = push.RevisionHistoryComment.parse(
+        original.body(pull_number=1),
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+    )
+    assert parsed is not None
+    parsed.append(
+        old_sha="def5678901234567890abcdef1234567890abcdef",
+        new_sha="789abcdef01234567890abcdef01234567890abcd",
+        change_type="rebase",
+        timestamp=datetime.datetime(2026, 4, 15, 9, 10, tzinfo=datetime.UTC),
+    )
+    new_body = parsed.body(pull_number=1)
+
+    marker_prefix = "<!-- mergify-revision-data: "
+    marker_line = next(
+        line for line in new_body.splitlines() if line.startswith(marker_prefix)
+    )
+    payload = json.loads(marker_line[len(marker_prefix) : -len(" -->")])
+    # Every entry has non-empty SHAs and timestamps (no degradation).
+    assert all(e["new_sha"] for e in payload["entries"])
+    assert all(e["timestamp_iso"] for e in payload["entries"])
+    # Entries 2 and 3 have old_sha set; entry 1 is "initial" with old_sha=None.
+    assert payload["entries"][0]["old_sha"] is None
+    assert payload["entries"][1]["old_sha"] is not None
+    assert payload["entries"][2]["old_sha"] is not None


### PR DESCRIPTION
Replace StackComment.pulls with StackComment.local_changes so the
dataclass holds structured LocalChange data needed for the upcoming
JSON marker (Task 5). The rendered Markdown body is byte-identical.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Depends-On: #1217