### PR TITLE
feat(ci): post scopes summary as Buildkite annotation

### DIFF
--- a/mergify_cli/ci/scopes/cli.py
+++ b/mergify_cli/ci/scopes/cli.py
@@ -5,6 +5,7 @@ import json
 import os
 import pathlib
 import re
+import subprocess
 import typing
 import uuid
 
@@ -94,15 +95,11 @@ def maybe_write_github_outputs(
         )
 
 
-def maybe_write_github_step_summary(
+def _build_scopes_markdown(
     references: git_refs_detector.References,
     all_scopes: abc.Iterable[str],
     scopes_hit: set[str],
-) -> None:
-    gha = os.environ.get("GITHUB_STEP_SUMMARY")
-    if not gha:
-        return
-    # Build a pretty Markdown table with emojis
+) -> str:
     markdown = "## Mergify CI Scope Matching Results"
     if references.base is not None:
         markdown += f" for `{references.base[:7]}...{references.head[:7]}` (source: `{references.source}`)"
@@ -111,9 +108,66 @@ def maybe_write_github_step_summary(
     for scope in sorted(all_scopes):
         emoji = "✅" if scope in scopes_hit else "❌"
         markdown += f"| `{scope}` | {emoji} |\n"
+    return markdown
 
+
+def maybe_write_github_step_summary(
+    references: git_refs_detector.References,
+    all_scopes: abc.Iterable[str],
+    scopes_hit: set[str],
+) -> None:
+    gha = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not gha:
+        return
+    markdown = _build_scopes_markdown(references, all_scopes, scopes_hit)
     with pathlib.Path(gha).open("a", encoding="utf-8") as fh:
         fh.write(markdown)
+
+
+BUILDKITE_ANNOTATION_CONTEXT = "mergify-ci-scopes"
+
+
+def maybe_write_buildkite_annotation(
+    references: git_refs_detector.References,
+    all_scopes: abc.Iterable[str],
+    scopes_hit: set[str],
+) -> None:
+    if os.environ.get("BUILDKITE") != "true":
+        return
+
+    markdown = _build_scopes_markdown(references, all_scopes, scopes_hit)
+
+    # One annotation scoped to the current job (shown in the job card), and one
+    # at build scope (shown on the build page). Same context in each scope makes
+    # repeated runs update in place rather than duplicate.
+    for scope_label, extra_args in (("job", ["--scope=job"]), ("build", [])):
+        cmd = [
+            "buildkite-agent",
+            "annotate",
+            "--style",
+            "info",
+            "--context",
+            BUILDKITE_ANNOTATION_CONTEXT,
+            *extra_args,
+        ]
+        try:
+            subprocess.run(  # noqa: S603
+                cmd,
+                input=markdown,
+                text=True,
+                check=True,
+                capture_output=True,
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            detail = (
+                exc.stderr.strip()
+                if isinstance(exc, subprocess.CalledProcessError) and exc.stderr
+                else str(exc)
+            )
+            click.echo(
+                f"warning: failed to write Buildkite annotation ({scope_label} scope): {detail}",
+                err=True,
+            )
 
 
 class InvalidDetectedScopeError(exceptions.ScopesError):
@@ -192,6 +246,11 @@ def detect(
 
     maybe_write_github_outputs(all_scopes, scopes_hit)
     maybe_write_github_step_summary(
+        references,
+        all_scopes,
+        scopes_hit,
+    )
+    maybe_write_buildkite_annotation(
         references,
         all_scopes,
         scopes_hit,

--- a/mergify_cli/tests/ci/scopes/test_cli.py
+++ b/mergify_cli/tests/ci/scopes/test_cli.py
@@ -345,6 +345,134 @@ def test_maybe_write_github_outputs_no_env(
     cli.maybe_write_github_outputs(["backend"], {"backend"})
 
 
+def test_maybe_write_buildkite_annotation_no_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("BUILDKITE", raising=False)
+
+    with mock.patch("subprocess.run") as mock_run:
+        cli.maybe_write_buildkite_annotation(
+            git_refs_detector.References("old", "new", "github_event_pull_request"),
+            ["backend"],
+            {"backend"},
+        )
+
+    mock_run.assert_not_called()
+
+
+def test_maybe_write_buildkite_annotation_runs_both_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUILDKITE", "true")
+
+    with mock.patch("subprocess.run") as mock_run:
+        cli.maybe_write_buildkite_annotation(
+            git_refs_detector.References(
+                "da26838azertyuiopqsdfghjkxcvbn",
+                "HEAD",
+                "github_event_pull_request",
+            ),
+            ["backend", "frontend", "docs"],
+            {"backend", "docs"},
+        )
+
+    expected_markdown = """## Mergify CI Scope Matching Results for `da26838...HEAD` (source: `github_event_pull_request`)
+
+| 🎯 Scope | ✅ Match |
+|:--|:--|
+| `backend` | ✅ |
+| `docs` | ✅ |
+| `frontend` | ❌ |
+"""
+
+    assert mock_run.call_count == 2
+
+    job_call, build_call = mock_run.call_args_list
+    assert job_call.args[0] == [
+        "buildkite-agent",
+        "annotate",
+        "--style",
+        "info",
+        "--context",
+        "mergify-ci-scopes",
+        "--scope=job",
+    ]
+    assert job_call.kwargs["input"] == expected_markdown
+    assert job_call.kwargs["check"] is True
+    assert job_call.kwargs["text"] is True
+
+    assert build_call.args[0] == [
+        "buildkite-agent",
+        "annotate",
+        "--style",
+        "info",
+        "--context",
+        "mergify-ci-scopes",
+    ]
+    assert build_call.kwargs["input"] == expected_markdown
+
+
+def test_maybe_write_buildkite_annotation_warns_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import subprocess
+
+    monkeypatch.setenv("BUILDKITE", "true")
+
+    def boom(
+        cmd: list[str],
+        **_: object,
+    ) -> None:
+        raise subprocess.CalledProcessError(
+            returncode=1,
+            cmd=cmd,
+            stderr="buildkite-agent: boom\n",
+        )
+
+    with mock.patch("subprocess.run", side_effect=boom):
+        # Must not raise
+        cli.maybe_write_buildkite_annotation(
+            git_refs_detector.References("old", "new", "github_event_pull_request"),
+            ["backend"],
+            {"backend"},
+        )
+
+    captured = capsys.readouterr()
+    assert (
+        "warning: failed to write Buildkite annotation (job scope): buildkite-agent: boom"
+        in captured.err
+    )
+    assert (
+        "warning: failed to write Buildkite annotation (build scope): buildkite-agent: boom"
+        in captured.err
+    )
+
+
+def test_maybe_write_buildkite_annotation_warns_on_missing_binary(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("BUILDKITE", "true")
+
+    with mock.patch("subprocess.run", side_effect=FileNotFoundError("no such binary")):
+        cli.maybe_write_buildkite_annotation(
+            git_refs_detector.References("old", "new", "github_event_pull_request"),
+            ["backend"],
+            {"backend"},
+        )
+
+    captured = capsys.readouterr()
+    assert (
+        "warning: failed to write Buildkite annotation (job scope): no such binary"
+        in captured.err
+    )
+    assert (
+        "warning: failed to write Buildkite annotation (build scope): no such binary"
+        in captured.err
+    )
+
+
 @mock.patch("mergify_cli.ci.scopes.changed_files.git_changed_files")
 @mock.patch("mergify_cli.ci.scopes.cli.maybe_write_github_outputs")
 def test_detect_with_matches(


### PR DESCRIPTION
Mirrors the existing GitHub step summary for Buildkite, attaching the
scope-matching table both to the current job (--scope=job) and at the
build level via `buildkite-agent annotate`. Subprocess failures emit a
warning to stderr without failing the detect flow.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>