### PR TITLE
feat(ci): read MQ metadata from git note for GitHub and Buildkite

### DIFF
--- a/mergify_cli/ci/git_refs/detector.py
+++ b/mergify_cli/ci/git_refs/detector.py
@@ -7,6 +7,7 @@ import typing
 
 from mergify_cli import utils
 from mergify_cli.ci.queue import metadata as queue_metadata
+from mergify_cli.ci.queue import notes as queue_notes
 from mergify_cli.ci.scopes import exceptions
 
 
@@ -55,7 +56,17 @@ def _detect_from_pull_request_event(
     if ev.pull_request and ev.pull_request.head:
         head = ev.pull_request.head.sha
 
-    # 0) merge-queue PR override
+    # 0a) Merge-queue info via git note (published by the engine for newer MQs).
+    # Falls back to the PR-body parsing below when the note is absent.
+    if ev.pull_request and ev.pull_request.head and ev.pull_request.head.ref:
+        note = queue_notes.read_mq_info_note(
+            ev.pull_request.head.ref,
+            ev.pull_request.head.sha,
+        )
+        if note is not None:
+            return References(note["checking_base_sha"], head, "merge_queue")
+
+    # 0b) merge-queue PR override
     content = queue_metadata.extract_from_event(ev)
     if content:
         return References(content["checking_base_sha"], head, "merge_queue")
@@ -89,15 +100,27 @@ def _detect_from_push_event(ev: github_event.GitHubEvent) -> References | None:
 def _detect_from_buildkite() -> References | None:
     """Detect base/head references from Buildkite environment variables."""
     pr = os.getenv("BUILDKITE_PULL_REQUEST")
-    if pr and pr != "false":
-        base_branch = os.getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
-        commit = os.getenv("BUILDKITE_COMMIT", "HEAD")
-        if base_branch:
-            return References(
-                base_branch,
-                commit,
-                "buildkite_pull_request",
-            )
+    if not pr or pr == "false":
+        return None
+
+    commit = os.getenv("BUILDKITE_COMMIT", "HEAD")
+    branch = os.getenv("BUILDKITE_BRANCH")
+
+    # Merge-queue info via git note (published by the engine). When present,
+    # overrides the standard PR base branch so scope detection compares
+    # against the MQ checking base rather than the target branch.
+    if branch:
+        note = queue_notes.read_mq_info_note(branch, commit)
+        if note is not None:
+            return References(note["checking_base_sha"], commit, "merge_queue")
+
+    base_branch = os.getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
+    if base_branch:
+        return References(
+            base_branch,
+            commit,
+            "buildkite_pull_request",
+        )
     return None
 
 

--- a/mergify_cli/ci/queue/notes.py
+++ b/mergify_cli/ci/queue/notes.py
@@ -1,0 +1,70 @@
+"""Read a Mergify merge-queue info note from the current git repository.
+
+The engine publishes MQ batch metadata as a git note on the draft branch's head
+commit under `refs/notes/<mq_branch_name>`. Reading it requires only a git
+fetch, no GitHub token — handy for CI providers like Buildkite that don't ship
+the webhook payload to the build.
+
+All errors (missing ref, missing note, bad YAML) are swallowed and reported as
+`None` so callers can fall back to legacy detection paths.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import typing
+
+import yaml
+
+
+if typing.TYPE_CHECKING:
+    from mergify_cli.ci.queue import metadata
+
+
+def read_mq_info_note(
+    branch_name: str,
+    head_sha: str,
+) -> metadata.MergeQueueMetadata | None:
+    notes_ref = f"refs/notes/{branch_name}"
+
+    # The engine force-updates the notes ref on MQ retries (fresh commit, no
+    # parents), so the remote SHA moves non-linearly. A '+' on the refspec is
+    # required to accept the non-fast-forward update locally.
+    try:
+        subprocess.run(  # noqa: S603
+            [
+                "git",
+                "fetch",
+                "--no-tags",
+                "--quiet",
+                "origin",
+                f"+{notes_ref}:{notes_ref}",
+            ],
+            check=True,
+            capture_output=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+    try:
+        content = subprocess.check_output(  # noqa: S603
+            ["git", "notes", f"--ref={branch_name}", "show", head_sha],
+            text=True,
+            encoding="utf-8",
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+    try:
+        data = yaml.safe_load(content)
+    except yaml.YAMLError:
+        return None
+
+    if not isinstance(data, dict) or not isinstance(
+        data.get("checking_base_sha"),
+        str,
+    ):
+        return None
+
+    return typing.cast("metadata.MergeQueueMetadata", data)

--- a/mergify_cli/tests/ci/git_refs/test_git_refs_detector.py
+++ b/mergify_cli/tests/ci/git_refs/test_git_refs_detector.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING
+from unittest import mock
 
 import pytest
 
@@ -220,3 +221,116 @@ def test_detect_buildkite_not_pr_falls_back(
     result = detector.detect()
 
     assert result == detector.References("HEAD^", "HEAD", "fallback_last_commit")
+
+
+def test_detect_buildkite_merge_queue_from_note(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When a git note is present, Buildkite MQ builds report checking_base_sha."""
+    monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+    monkeypatch.setenv("BUILDKITE", "true")
+    monkeypatch.setenv("BUILDKITE_PULL_REQUEST", "99")
+    monkeypatch.setenv("BUILDKITE_BRANCH", "mergify/merge-queue/abc")
+    monkeypatch.setenv("BUILDKITE_COMMIT", "headsha")
+    # Base branch env var is also present; the note must take precedence.
+    monkeypatch.setenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "main")
+
+    with mock.patch(
+        "mergify_cli.ci.queue.notes.read_mq_info_note",
+        return_value={
+            "checking_base_sha": "basesha",
+            "pull_requests": [{"number": 1}],
+            "previous_failed_batches": [],
+        },
+    ) as note_mock:
+        result = detector.detect()
+
+    note_mock.assert_called_once_with("mergify/merge-queue/abc", "headsha")
+    assert result == detector.References("basesha", "headsha", "merge_queue")
+
+
+def test_detect_buildkite_pr_falls_back_when_no_note(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing note means we fall back to the existing base-branch behavior."""
+    monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+    monkeypatch.setenv("BUILDKITE", "true")
+    monkeypatch.setenv("BUILDKITE_PULL_REQUEST", "42")
+    monkeypatch.setenv("BUILDKITE_BRANCH", "feature-branch")
+    monkeypatch.setenv("BUILDKITE_COMMIT", "abc123")
+    monkeypatch.setenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "main")
+
+    with mock.patch(
+        "mergify_cli.ci.queue.notes.read_mq_info_note",
+        return_value=None,
+    ):
+        result = detector.detect()
+
+    assert result == detector.References("main", "abc123", "buildkite_pull_request")
+
+
+def test_detect_gha_merge_queue_from_note(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    """GitHub Actions PR event: the note takes precedence over PR body parsing."""
+    event_data = {
+        "pull_request": {
+            "number": 7,
+            "title": "regular PR title",
+            "head": {"ref": "mergify/merge-queue/abc", "sha": "headsha"},
+            "base": {"sha": "pr-base-sha"},
+        },
+    }
+    event_file = tmp_path / "event.json"
+    event_file.write_text(json.dumps(event_data))
+
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_file))
+
+    with mock.patch(
+        "mergify_cli.ci.queue.notes.read_mq_info_note",
+        return_value={
+            "checking_base_sha": "mq-base-sha",
+            "pull_requests": [{"number": 7}],
+            "previous_failed_batches": [],
+        },
+    ) as note_mock:
+        result = detector.detect()
+
+    note_mock.assert_called_once_with("mergify/merge-queue/abc", "headsha")
+    assert result == detector.References("mq-base-sha", "headsha", "merge_queue")
+
+
+def test_detect_gha_falls_back_to_pr_base_when_no_note(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    """Absent note → current PR-base-SHA path is preserved."""
+    event_data = {
+        "pull_request": {
+            "number": 7,
+            "title": "regular PR title",
+            "head": {"ref": "feature-branch", "sha": "headsha"},
+            "base": {"sha": "pr-base-sha"},
+        },
+    }
+    event_file = tmp_path / "event.json"
+    event_file.write_text(json.dumps(event_data))
+
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_file))
+
+    with mock.patch(
+        "mergify_cli.ci.queue.notes.read_mq_info_note",
+        return_value=None,
+    ):
+        result = detector.detect()
+
+    assert result == detector.References(
+        "pr-base-sha",
+        "headsha",
+        "github_event_pull_request",
+    )

--- a/mergify_cli/tests/ci/queue/test_notes.py
+++ b/mergify_cli/tests/ci/queue/test_notes.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import subprocess
+from unittest import mock
+
+from mergify_cli.ci.queue import notes
+
+
+BRANCH = "mergify/merge-queue/abcdef0123"
+HEAD_SHA = "a" * 40
+BASE_SHA = "b" * 40
+NOTES_REF = f"refs/notes/{BRANCH}"
+
+
+def _completed(returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode)
+
+
+def test_read_returns_metadata_when_note_is_valid_yaml() -> None:
+    note_yaml = f"""\
+scopes:
+  - backend
+pull_requests:
+  - number: 1
+    scopes:
+      - backend
+previous_failed_batches: []
+checking_base_sha: {BASE_SHA}
+"""
+
+    with (
+        mock.patch("subprocess.run", return_value=_completed()) as run_mock,
+        mock.patch(
+            "subprocess.check_output",
+            return_value=note_yaml,
+        ) as check_output_mock,
+    ):
+        result = notes.read_mq_info_note(BRANCH, HEAD_SHA)
+
+    run_mock.assert_called_once()
+    fetch_cmd = run_mock.call_args.args[0]
+    assert fetch_cmd == [
+        "git",
+        "fetch",
+        "--no-tags",
+        "--quiet",
+        "origin",
+        f"+{NOTES_REF}:{NOTES_REF}",
+    ]
+
+    check_output_mock.assert_called_once()
+    show_cmd = check_output_mock.call_args.args[0]
+    assert show_cmd == ["git", "notes", f"--ref={BRANCH}", "show", HEAD_SHA]
+
+    assert result is not None
+    assert result["checking_base_sha"] == BASE_SHA
+    assert result["pull_requests"] == [{"number": 1, "scopes": ["backend"]}]
+    assert result["previous_failed_batches"] == []
+
+
+def test_read_returns_none_when_fetch_fails() -> None:
+    with (
+        mock.patch(
+            "subprocess.run",
+            side_effect=subprocess.CalledProcessError(128, ["git", "fetch"]),
+        ),
+        mock.patch("subprocess.check_output") as check_output_mock,
+    ):
+        result = notes.read_mq_info_note(BRANCH, HEAD_SHA)
+
+    assert result is None
+    check_output_mock.assert_not_called()
+
+
+def test_read_returns_none_when_git_binary_missing() -> None:
+    with mock.patch("subprocess.run", side_effect=FileNotFoundError("no git")):
+        result = notes.read_mq_info_note(BRANCH, HEAD_SHA)
+
+    assert result is None
+
+
+def test_read_returns_none_when_note_show_fails() -> None:
+    with (
+        mock.patch("subprocess.run", return_value=_completed()),
+        mock.patch(
+            "subprocess.check_output",
+            side_effect=subprocess.CalledProcessError(1, ["git", "notes"]),
+        ),
+    ):
+        result = notes.read_mq_info_note(BRANCH, HEAD_SHA)
+
+    assert result is None
+
+
+def test_read_returns_none_when_yaml_is_invalid() -> None:
+    with (
+        mock.patch("subprocess.run", return_value=_completed()),
+        mock.patch("subprocess.check_output", return_value=": not valid yaml:\n  [["),
+    ):
+        result = notes.read_mq_info_note(BRANCH, HEAD_SHA)
+
+    assert result is None
+
+
+def test_read_returns_none_when_yaml_lacks_checking_base_sha() -> None:
+    with (
+        mock.patch("subprocess.run", return_value=_completed()),
+        mock.patch("subprocess.check_output", return_value="pull_requests: []\n"),
+    ):
+        result = notes.read_mq_info_note(BRANCH, HEAD_SHA)
+
+    assert result is None
+
+
+def test_read_returns_none_when_checking_base_sha_is_not_a_string() -> None:
+    with (
+        mock.patch("subprocess.run", return_value=_completed()),
+        mock.patch(
+            "subprocess.check_output",
+            return_value="checking_base_sha: 12345\npull_requests: []\n",
+        ),
+    ):
+        result = notes.read_mq_info_note(BRANCH, HEAD_SHA)
+
+    assert result is None
+
+
+def test_read_returns_none_when_yaml_is_scalar() -> None:
+    with (
+        mock.patch("subprocess.run", return_value=_completed()),
+        mock.patch("subprocess.check_output", return_value="just-a-string\n"),
+    ):
+        result = notes.read_mq_info_note(BRANCH, HEAD_SHA)
+
+    assert result is None


### PR DESCRIPTION
When the engine publishes merge-queue metadata as a git note under
refs/notes/<mq_branch_name>, both the GitHub Actions and Buildkite
detection paths now use the note's checking_base_sha as the scope
comparison base instead of the PR's target branch.

If the note is absent (older engine, non-MQ branch, fetch failure)
detection silently falls back to the existing behavior — PR-body YAML
parsing on GitHub Actions, base-branch env var on Buildkite.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>