### PR TITLE
feat(ci): add --scopes-file for plain-text scopes, rename --file to --scopes-json

### DIFF
--- a/mergify_cli/ci/cli.py
+++ b/mergify_cli/ci/cli.py
@@ -338,10 +338,21 @@ def scopes(
 )
 @click.option("--scope", "-s", multiple=True, help="Scope to upload")
 @click.option(
+    "--scopes-json",
+    help="JSON file containing scopes to upload (output of `mergify ci scopes --write`)",
+    type=click.Path(exists=True, dir_okay=False),
+)
+@click.option(
+    "--scopes-file",
+    help="Plain-text file with one scope per line",
+    type=click.Path(exists=True, dir_okay=False),
+)
+@click.option(
     "--file",
     "-f",
-    help="File containing scopes to upload",
-    type=click.Path(exists=True),
+    "file_deprecated",
+    type=click.Path(exists=True, dir_okay=False),
+    hidden=True,
 )
 @utils.run_with_asyncio
 async def scopes_send(
@@ -350,19 +361,40 @@ async def scopes_send(
     repository: str,
     pull_request: int | None,
     scope: tuple[str, ...],
-    file: str | None,
+    scopes_json: str | None,
+    scopes_file: str | None,
+    file_deprecated: str | None,
 ) -> None:
     if pull_request is None:
         click.echo("No pull request number detected, skipping scopes upload.")
         return
 
+    if file_deprecated is not None:
+        click.echo(
+            "Warning: --file is deprecated, use --scopes-json instead.",
+            err=True,
+        )
+        if scopes_json is None:
+            scopes_json = file_deprecated
+
     scopes = list(scope)
-    if file is not None:
+    if scopes_json is not None:
         try:
-            dump = scopes_cli.DetectedScope.load_from_file(file)
+            dump = scopes_cli.DetectedScope.load_from_file(scopes_json)
         except scopes_exc.ScopesError as e:
             raise click.ClickException(str(e)) from e
         scopes.extend(dump.scopes)
+    if scopes_file is not None:
+        scopes.extend(
+            line
+            for line in (
+                raw.strip()
+                for raw in pathlib.Path(scopes_file)
+                .read_text(encoding="utf-8")
+                .splitlines()
+            )
+            if line
+        )
 
     await scopes_cli.send_scopes(
         api_url,

--- a/mergify_cli/tests/ci/test_cli.py
+++ b/mergify_cli/tests/ci/test_cli.py
@@ -320,13 +320,14 @@ def test_scopes_send(
 ) -> None:
     """Test scopes command with all required parameters."""
 
-    # Create config file
-    scopes_file = tmp_path / "scopes.json"
-    scopes_file.write_text(
+    scopes_json = tmp_path / "scopes.json"
+    scopes_json.write_text(
         json.dumps(
             {"base_ref": "base", "head_ref": "head", "scopes": ["backend", "frontend"]},
         ),
     )
+    scopes_file = tmp_path / "scopes.txt"
+    scopes_file.write_text("docs\n\n  infra  \n")
 
     runner = testing.CliRunner()
 
@@ -345,14 +346,62 @@ def test_scopes_send(
             "test-token",
             "--scope",
             "foobar",
-            "--file",
+            "--scopes-json",
+            str(scopes_json),
+            "--scopes-file",
             str(scopes_file),
         ],
     )
 
     assert result.exit_code == 0, result.output
     payload = json.loads(post_mock.calls[0].request.content)
-    assert sorted(payload["scopes"]) == ["backend", "foobar", "frontend"]
+    assert sorted(payload["scopes"]) == [
+        "backend",
+        "docs",
+        "foobar",
+        "frontend",
+        "infra",
+    ]
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+def test_scopes_send_file_deprecated(
+    respx_mock: respx.MockRouter,
+    tmp_path: pathlib.Path,
+) -> None:
+    """`--file` still works but emits a deprecation warning on stderr."""
+
+    scopes_json = tmp_path / "scopes.json"
+    scopes_json.write_text(
+        json.dumps(
+            {"base_ref": "base", "head_ref": "head", "scopes": ["backend"]},
+        ),
+    )
+
+    runner = testing.CliRunner()
+
+    post_mock = respx_mock.post(
+        "https://api.mergify.com/v1/repos/owner/repository/pulls/123/scopes",
+        headers={"Authorization": "Bearer test-token"},
+    ).respond(200)
+    result = runner.invoke(
+        ci_cli.scopes_send,
+        [
+            "--pull-request",
+            "123",
+            "--repository",
+            "owner/repository",
+            "--token",
+            "test-token",
+            "--file",
+            str(scopes_json),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "--file is deprecated" in result.stderr
+    payload = json.loads(post_mock.calls[0].request.content)
+    assert payload["scopes"] == ["backend"]
 
 
 def test_scopes_send_no_pull_request_skips(

--- a/skills/mergify-ci/SKILL.md
+++ b/skills/mergify-ci/SKILL.md
@@ -109,8 +109,11 @@ Sends scopes tied to a pull request to the Mergify API. Used when scopes are det
 # Send specific scopes
 mergify ci scopes-send -s frontend -s backend -p 123
 
-# Send scopes from a file
-mergify ci scopes-send --file scopes.json -p 123
+# Send scopes from a JSON file (produced by `mergify ci scopes --write`)
+mergify ci scopes-send --scopes-json scopes.json -p 123
+
+# Send scopes from a plain-text file (one scope per line)
+mergify ci scopes-send --scopes-file scopes.txt -p 123
 ```
 
 **Key options:**
@@ -118,7 +121,8 @@ mergify ci scopes-send --file scopes.json -p 123
 - `--repository` / `-r` -- Repository full name (auto-detected)
 - `--pull-request` / `-p` -- Pull request number (auto-detected in GitHub Actions)
 - `--scope` / `-s` -- Scope name (repeatable)
-- `--file` / `-f` -- File containing scopes to upload (JSON format from `scopes --write`)
+- `--scopes-json` -- JSON file containing scopes (output of `mergify ci scopes --write`)
+- `--scopes-file` -- Plain-text file with one scope per line
 
 ## Queue Info (`queue-info`)
 


### PR DESCRIPTION
Introduce --scopes-file to read one scope per line (whitespace stripped,
empty lines skipped), and rename the JSON variant to --scopes-json for
clarity. --file remains as a hidden deprecated alias and prints a
stderr warning when used.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>