### PR TITLE
feat(ci): add --format={text,shell,json} to `ci git-refs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ mergify stack checkout my-feature    # Checkout an existing stack from GitHub
 mergify ci junit-process results.xml # Upload test results + quarantine
 mergify ci scopes                    # Detect impacted scopes
 mergify ci git-refs                  # Detect base/head refs
+mergify ci git-refs --format=shell   # Emit MERGIFY_GIT_REFS_* vars for `eval`
+mergify ci git-refs --format=json    # Emit single-line JSON for jq
 
 # Merge queue
 mergify queue status                 # View queue state

--- a/mergify_cli/ci/cli.py
+++ b/mergify_cli/ci/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import pathlib
+import shlex
 import uuid
 
 import click
@@ -232,10 +233,33 @@ async def junit_process(
     help="""Give the base/head git references of the pull request""",
     short_help="""Give the base/head git references of the pull request""",
 )
-def git_refs() -> None:
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "shell", "json"]),
+    default="text",
+    show_default=True,
+    help=(
+        "Output format. 'text' is human-readable. "
+        "'shell' emits MERGIFY_GIT_REFS_{BASE,HEAD,SOURCE}=... lines for `eval`. "
+        "'json' emits a single-line JSON object."
+    ),
+)
+def git_refs(output_format: str) -> None:
     ref = git_refs_detector.detect()
-    click.echo(f"Base: {ref.base}")
-    click.echo(f"Head: {ref.head}")
+
+    if output_format == "shell":
+        click.echo(f"MERGIFY_GIT_REFS_BASE={shlex.quote(ref.base or '')}")
+        click.echo(f"MERGIFY_GIT_REFS_HEAD={shlex.quote(ref.head)}")
+        click.echo(f"MERGIFY_GIT_REFS_SOURCE={shlex.quote(ref.source)}")
+    elif output_format == "json":
+        click.echo(
+            json.dumps({"base": ref.base, "head": ref.head, "source": ref.source}),
+        )
+    else:
+        click.echo(f"Base: {ref.base}")
+        click.echo(f"Head: {ref.head}")
+
     ref.maybe_write_to_github_outputs()
 
 

--- a/mergify_cli/tests/ci/test_cli.py
+++ b/mergify_cli/tests/ci/test_cli.py
@@ -416,12 +416,100 @@ def test_git_refs(
     runner = testing.CliRunner()
     result = runner.invoke(ci_cli.git_refs, [])
     assert result.exit_code == 0, result.output
+    assert result.output == "Base: abc123\nHead: xyz987\n"
 
     content = output_file.read_text()
     expected = """base=abc123
 head=xyz987
 """
     assert content == expected
+
+
+def test_git_refs_format_shell(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_data = {"before": "abc123", "after": "xyz987"}
+    event_file = tmp_path / "event.json"
+    event_file.write_text(json.dumps(event_data))
+
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_file))
+
+    runner = testing.CliRunner()
+    result = runner.invoke(ci_cli.git_refs, ["--format", "shell"])
+    assert result.exit_code == 0, result.output
+    assert result.output == (
+        "MERGIFY_GIT_REFS_BASE=abc123\n"
+        "MERGIFY_GIT_REFS_HEAD=xyz987\n"
+        "MERGIFY_GIT_REFS_SOURCE=github_event_push\n"
+    )
+
+
+def test_git_refs_format_shell_quotes_special_chars(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Values containing shell-special chars must be properly quoted so `eval` is safe."""
+    event_data = {
+        "repository": {"default_branch": "weird branch $name"},
+    }
+    event_file = tmp_path / "event.json"
+    event_file.write_text(json.dumps(event_data))
+
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_file))
+
+    runner = testing.CliRunner()
+    result = runner.invoke(ci_cli.git_refs, ["--format", "shell"])
+    assert result.exit_code == 0, result.output
+    # space and `$` both trigger shlex.quote to wrap the value in single quotes
+    assert "MERGIFY_GIT_REFS_BASE='weird branch $name'\n" in result.output
+
+
+def test_git_refs_format_shell_empty_base(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When base is None, shell format emits an empty quoted string."""
+    event_data: dict[str, object] = {}
+    event_file = tmp_path / "event.json"
+    event_file.write_text(json.dumps(event_data))
+
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "workflow_dispatch")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_file))
+
+    runner = testing.CliRunner()
+    result = runner.invoke(ci_cli.git_refs, ["--format", "shell"])
+    assert result.exit_code == 0, result.output
+    assert "MERGIFY_GIT_REFS_BASE=''\n" in result.output
+    assert "MERGIFY_GIT_REFS_HEAD=HEAD\n" in result.output
+    assert "MERGIFY_GIT_REFS_SOURCE=github_event_other\n" in result.output
+
+
+def test_git_refs_format_json(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_data = {"before": "abc123", "after": "xyz987"}
+    event_file = tmp_path / "event.json"
+    event_file.write_text(json.dumps(event_data))
+
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_file))
+
+    runner = testing.CliRunner()
+    result = runner.invoke(ci_cli.git_refs, ["--format", "json"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {
+        "base": "abc123",
+        "head": "xyz987",
+        "source": "github_event_push",
+    }
 
 
 def test_queue_info(

--- a/skills/mergify-ci/SKILL.md
+++ b/skills/mergify-ci/SKILL.md
@@ -76,6 +76,22 @@ mergify ci git-refs
 # Head: def5678
 ```
 
+**Output formats (`--format`):**
+- `text` (default) — human-readable `Base:` / `Head:` lines
+- `shell` — `MERGIFY_GIT_REFS_{BASE,HEAD,SOURCE}=...` lines suitable for `eval`, with POSIX-safe shell quoting. When base can't be detected, `MERGIFY_GIT_REFS_BASE=''`.
+- `json` — single-line JSON object with `base`, `head`, `source` keys. `base` may be `null` when it can't be detected (e.g., `workflow_dispatch` events); use `jq -r '.base // ""'` to coalesce to empty string.
+
+```bash
+# Consume values in a shell script without parsing:
+eval "$(mergify ci git-refs --format=shell)"
+nx show projects --affected \
+  --base="$MERGIFY_GIT_REFS_BASE" \
+  --head="$MERGIFY_GIT_REFS_HEAD"
+
+# Or with jq:
+BASE=$(mergify ci git-refs --format=json | jq -r '.base // ""')
+```
+
 Sources detected (in priority order): merge queue context, GitHub pull request event, GitHub push event, fallback to last commit.
 
 ## Scopes (`scopes`)


### PR DESCRIPTION
Lets users consume detected refs in scripts without awk-parsing. Shell
format emits MERGIFY_GIT_REFS_{BASE,HEAD,SOURCE}=... lines suitable for
`eval`, with shlex-quoted values; json emits a single-line object.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>