### PR TITLE
feat(ci): write git-refs and scopes to Buildkite meta-data

### DIFF
--- a/mergify_cli/ci/cli.py
+++ b/mergify_cli/ci/cli.py
@@ -237,6 +237,7 @@ def git_refs() -> None:
     click.echo(f"Base: {ref.base}")
     click.echo(f"Head: {ref.head}")
     ref.maybe_write_to_github_outputs()
+    ref.maybe_write_to_buildkite_metadata()
 
 
 @ci.command(

--- a/mergify_cli/ci/git_refs/detector.py
+++ b/mergify_cli/ci/git_refs/detector.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 import os
 import pathlib
+import subprocess
 import typing
 
 from mergify_cli import utils
@@ -17,6 +18,16 @@ if typing.TYPE_CHECKING:
 
 GITHUB_ACTIONS_BASE_OUTPUT_NAME = "base"
 GITHUB_ACTIONS_HEAD_OUTPUT_NAME = "head"
+
+BUILDKITE_BASE_METADATA_KEY = "mergify-ci.base"
+BUILDKITE_HEAD_METADATA_KEY = "mergify-ci.head"
+BUILDKITE_SOURCE_METADATA_KEY = "mergify-ci.source"
+
+
+def buildkite_meta_data_set(key: str, value: str) -> None:
+    subprocess.check_call(  # noqa: S603
+        ["buildkite-agent", "meta-data", "set", key, value],
+    )
 
 
 class BaseNotFoundError(exceptions.ScopesError):
@@ -47,6 +58,14 @@ class References:
         with pathlib.Path(gha).open("a", encoding="utf-8") as fh:
             fh.write(f"{GITHUB_ACTIONS_BASE_OUTPUT_NAME}={self.base}\n")
             fh.write(f"{GITHUB_ACTIONS_HEAD_OUTPUT_NAME}={self.head}\n")
+
+    def maybe_write_to_buildkite_metadata(self) -> None:
+        if os.getenv("BUILDKITE") != "true":
+            return
+        if self.base is not None:
+            buildkite_meta_data_set(BUILDKITE_BASE_METADATA_KEY, self.base)
+        buildkite_meta_data_set(BUILDKITE_HEAD_METADATA_KEY, self.head)
+        buildkite_meta_data_set(BUILDKITE_SOURCE_METADATA_KEY, self.source)
 
 
 def _detect_from_pull_request_event(

--- a/mergify_cli/ci/scopes/cli.py
+++ b/mergify_cli/ci/scopes/cli.py
@@ -13,6 +13,7 @@ import click
 import pydantic
 
 from mergify_cli import utils
+from mergify_cli.ci.git_refs import detector as git_refs_detector
 from mergify_cli.ci.scopes import changed_files
 from mergify_cli.ci.scopes import config
 from mergify_cli.ci.scopes import exceptions
@@ -21,9 +22,8 @@ from mergify_cli.ci.scopes import exceptions
 if typing.TYPE_CHECKING:
     from collections import abc
 
-    from mergify_cli.ci.git_refs import detector as git_refs_detector
-
 GITHUB_ACTIONS_SCOPES_OUTPUT_NAME = "scopes"
+BUILDKITE_SCOPES_METADATA_KEY = "mergify-ci.scopes"
 
 
 # NOTE: We convert the pattern to a compiled regex using `glob.translate`,
@@ -93,6 +93,19 @@ def maybe_write_github_outputs(
         fh.write(
             f"{GITHUB_ACTIONS_SCOPES_OUTPUT_NAME}<<{delimiter}\n{json.dumps(data)}\n{delimiter}\n",
         )
+
+
+def maybe_write_buildkite_metadata(
+    all_scopes: abc.Iterable[str],
+    scopes_hit: set[str],
+) -> None:
+    if os.getenv("BUILDKITE") != "true":
+        return
+    data = {key: "true" if key in scopes_hit else "false" for key in sorted(all_scopes)}
+    git_refs_detector.buildkite_meta_data_set(
+        BUILDKITE_SCOPES_METADATA_KEY,
+        json.dumps(data),
+    )
 
 
 def _build_scopes_markdown(
@@ -245,6 +258,7 @@ def detect(
         click.echo("No scopes matched.")
 
     maybe_write_github_outputs(all_scopes, scopes_hit)
+    maybe_write_buildkite_metadata(all_scopes, scopes_hit)
     maybe_write_github_step_summary(
         references,
         all_scopes,

--- a/mergify_cli/tests/ci/git_refs/test_git_refs_detector.py
+++ b/mergify_cli/tests/ci/git_refs/test_git_refs_detector.py
@@ -210,6 +210,68 @@ def test_detect_buildkite_pull_request(
     )
 
 
+def test_maybe_write_to_buildkite_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUILDKITE", "true")
+
+    ref = detector.References("abc123", "xyz987", "buildkite_pull_request")
+
+    with mock.patch("subprocess.check_call") as mock_check_call:
+        ref.maybe_write_to_buildkite_metadata()
+
+    assert mock_check_call.call_args_list == [
+        mock.call(["buildkite-agent", "meta-data", "set", "mergify-ci.base", "abc123"]),
+        mock.call(["buildkite-agent", "meta-data", "set", "mergify-ci.head", "xyz987"]),
+        mock.call(
+            [
+                "buildkite-agent",
+                "meta-data",
+                "set",
+                "mergify-ci.source",
+                "buildkite_pull_request",
+            ],
+        ),
+    ]
+
+
+def test_maybe_write_to_buildkite_metadata_no_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUILDKITE", "true")
+
+    ref = detector.References(None, "HEAD", "github_event_other")
+
+    with mock.patch("subprocess.check_call") as mock_check_call:
+        ref.maybe_write_to_buildkite_metadata()
+
+    assert mock_check_call.call_args_list == [
+        mock.call(["buildkite-agent", "meta-data", "set", "mergify-ci.head", "HEAD"]),
+        mock.call(
+            [
+                "buildkite-agent",
+                "meta-data",
+                "set",
+                "mergify-ci.source",
+                "github_event_other",
+            ],
+        ),
+    ]
+
+
+def test_maybe_write_to_buildkite_metadata_not_buildkite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("BUILDKITE", raising=False)
+
+    ref = detector.References("abc123", "xyz987", "manual")
+
+    with mock.patch("subprocess.check_call") as mock_check_call:
+        ref.maybe_write_to_buildkite_metadata()
+
+    mock_check_call.assert_not_called()
+
+
 def test_detect_buildkite_not_pr_falls_back(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/mergify_cli/tests/ci/scopes/test_cli.py
+++ b/mergify_cli/tests/ci/scopes/test_cli.py
@@ -345,6 +345,39 @@ def test_maybe_write_github_outputs_no_env(
     cli.maybe_write_github_outputs(["backend"], {"backend"})
 
 
+def test_maybe_write_buildkite_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUILDKITE", "true")
+
+    with mock.patch("subprocess.check_call") as mock_check_call:
+        cli.maybe_write_buildkite_metadata(
+            ["backend", "frontend", "docs"],
+            {"backend", "docs"},
+        )
+
+    mock_check_call.assert_called_once_with(
+        [
+            "buildkite-agent",
+            "meta-data",
+            "set",
+            "mergify-ci.scopes",
+            '{"backend": "true", "docs": "true", "frontend": "false"}',
+        ],
+    )
+
+
+def test_maybe_write_buildkite_metadata_not_buildkite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("BUILDKITE", raising=False)
+
+    with mock.patch("subprocess.check_call") as mock_check_call:
+        cli.maybe_write_buildkite_metadata(["backend"], {"backend"})
+
+    mock_check_call.assert_not_called()
+
+
 def test_maybe_write_buildkite_annotation_no_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/skills/mergify-ci/SKILL.md
+++ b/skills/mergify-ci/SKILL.md
@@ -67,7 +67,7 @@ mergify ci junit-process \
 
 ## Git References (`git-refs`)
 
-Detects the base and head git references for the current pull request context. Writes results to `GITHUB_OUTPUT` when running in GitHub Actions.
+Detects the base and head git references for the current pull request context. Writes results to `GITHUB_OUTPUT` when running in GitHub Actions, and to Buildkite meta-data (`mergify-ci.base`, `mergify-ci.head`, `mergify-ci.source`) when running in Buildkite.
 
 ```bash
 mergify ci git-refs
@@ -99,7 +99,7 @@ mergify ci scopes --config .mergify.yml --write scopes.json
 - `--head` -- Head git reference (default: HEAD)
 - `--write` / `-w` -- Write detected scopes to a JSON file
 
-The config file defines scopes with file patterns. When files change between base and head, matching scopes are identified and written to `GITHUB_OUTPUT` as a JSON map of scope names to `"true"`/`"false"`.
+The config file defines scopes with file patterns. When files change between base and head, matching scopes are identified and written to `GITHUB_OUTPUT` (on GitHub Actions) or to Buildkite meta-data under `mergify-ci.scopes` (on Buildkite), as a JSON map of scope names to `"true"`/`"false"`.
 
 ## Scopes Send (`scopes-send`)
 


### PR DESCRIPTION
Mirror the GitHub Actions output behavior on Buildkite by publishing
mergify-ci.base, mergify-ci.head, mergify-ci.source and mergify-ci.scopes
via `buildkite-agent meta-data set` when running inside Buildkite.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>