### PR TITLE
fix(ci): write empty string to GITHUB_OUTPUT when base is undetected

### DIFF
--- a/mergify_cli/ci/git_refs/detector.py
+++ b/mergify_cli/ci/git_refs/detector.py
@@ -56,7 +56,7 @@ class References:
         if not gha:
             return
         with pathlib.Path(gha).open("a", encoding="utf-8") as fh:
-            fh.write(f"{GITHUB_ACTIONS_BASE_OUTPUT_NAME}={self.base}\n")
+            fh.write(f"{GITHUB_ACTIONS_BASE_OUTPUT_NAME}={self.base or ''}\n")
             fh.write(f"{GITHUB_ACTIONS_HEAD_OUTPUT_NAME}={self.head}\n")
 
     def maybe_write_to_buildkite_metadata(self) -> None:

--- a/mergify_cli/tests/ci/test_cli.py
+++ b/mergify_cli/tests/ci/test_cli.py
@@ -476,6 +476,27 @@ head=xyz987
     assert content == expected
 
 
+def test_git_refs_github_output_empty_base_when_none(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When base can't be detected, GITHUB_OUTPUT gets `base=` (empty), not `base=None`."""
+    event_data: dict[str, object] = {}
+    event_file = tmp_path / "event.json"
+    event_file.write_text(json.dumps(event_data))
+    output_file = tmp_path / "github_output"
+
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "workflow_dispatch")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_file))
+
+    runner = testing.CliRunner()
+    result = runner.invoke(ci_cli.git_refs, [])
+    assert result.exit_code == 0, result.output
+
+    assert output_file.read_text() == "base=\nhead=HEAD\n"
+
+
 def test_git_refs_format_shell(
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Previously `maybe_write_to_github_outputs` emitted the literal string
`base=None` when base was None (e.g. `workflow_dispatch` events), which
leaks Python's `None` representation into workflow output. Coalesce to
an empty string so GitHub Actions steps see `base=` instead — consistent
with the new `--format=shell` behavior.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>