### PR TITLE
feat(errors): add MergifyError exception class with typed exit code

### DIFF
--- a/mergify_cli/tests/test_utils.py
+++ b/mergify_cli/tests/test_utils.py
@@ -23,6 +23,7 @@ import pytest
 
 from mergify_cli import console
 from mergify_cli import utils
+from mergify_cli.exit_codes import ExitCode
 
 
 if TYPE_CHECKING:
@@ -309,3 +310,33 @@ class TestCheckForStatus:
             )
         finally:
             utils.set_debug(debug=False)
+
+
+class TestMergifyError:
+    def test_default_exit_code_is_generic_error(self) -> None:
+        err = utils.MergifyError("boom")
+        assert err.exit_code == int(ExitCode.GENERIC_ERROR)
+        assert err.message == "boom"
+
+    def test_accepts_exit_code_override(self) -> None:
+        err = utils.MergifyError("bad config", exit_code=ExitCode.CONFIGURATION_ERROR)
+        assert err.exit_code == int(ExitCode.CONFIGURATION_ERROR)
+        assert err.message == "bad config"
+
+    def test_is_click_exception(self) -> None:
+        """MergifyError must inherit from click.ClickException so click's
+        standalone-mode handler catches it and exits with exit_code."""
+        import click
+
+        assert issubclass(utils.MergifyError, click.ClickException)
+
+    def test_show_prints_red_error_to_stderr(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        err = utils.MergifyError("nope", exit_code=ExitCode.CONFIGURATION_ERROR)
+        err.show()
+        captured = capsys.readouterr()
+        # rich console writes to stderr by default in our setup;
+        # assert the error message is present (ANSI codes may or may not appear).
+        assert "nope" in captured.err or "nope" in captured.out

--- a/mergify_cli/utils.py
+++ b/mergify_cli/utils.py
@@ -23,12 +23,14 @@ import pathlib
 import typing
 from urllib import parse
 
+import click
 import httpx
 
 from mergify_cli import VERSION
 from mergify_cli import console
 from mergify_cli import console_error
 from mergify_cli.ci import github_event
+from mergify_cli.exit_codes import ExitCode
 
 
 if typing.TYPE_CHECKING:
@@ -91,6 +93,30 @@ class CommandError(Exception):
 
     def __str__(self) -> str:
         return f"failed to run `{' '.join(self.command_args)}`: {self.stdout.decode()}"
+
+
+class MergifyError(click.ClickException):
+    """CLI-level error with a typed exit code.
+
+    Raised from any command path that encounters a semantic failure.
+    Click's standalone-mode handler (used by the real entrypoint and by
+    CliRunner in tests) catches ClickException subclasses, calls
+    ``show()``, then exits with ``self.exit_code``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        exit_code: ExitCode = ExitCode.GENERIC_ERROR,
+    ) -> None:
+        super().__init__(message)
+        # click.ClickException stores exit_code as an int class attribute.
+        # Override per-instance with the typed ExitCode coerced to int.
+        self.exit_code = int(exit_code)
+
+    def show(self, file: typing.IO[str] | None = None) -> None:  # noqa: ARG002
+        console_error(self.message)
 
 
 async def run_command(*args: str) -> str:


### PR DESCRIPTION
Introduces MergifyError(msg, exit_code=...) for semantic CLI failures.
Inherits from click.ClickException so click's standalone-mode handler
catches it automatically and exits with the typed exit_code.
Next commits migrate click.ClickException usages to this new class.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>