### PR TITLE
refactor(config): replace ClickException with typed MergifyError

### DIFF
--- a/mergify_cli/config/cli.py
+++ b/mergify_cli/config/cli.py
@@ -27,11 +27,11 @@ def _resolve_config_path(config_path: str | None) -> str:
     if config_path is None:
         locations = ", ".join(MERGIFY_CONFIG_PATHS)
         msg = f"Mergify configuration file not found. Looked in: {locations}"
-        raise click.ClickException(msg)
+        raise utils.MergifyError(msg, exit_code=ExitCode.CONFIGURATION_ERROR)
 
     if not pathlib.Path(config_path).is_file():
         msg = f"Configuration file not found: {config_path}"
-        raise click.ClickException(msg)
+        raise utils.MergifyError(msg, exit_code=ExitCode.CONFIGURATION_ERROR)
 
     return config_path
 
@@ -64,18 +64,30 @@ def validate(ctx: click.Context) -> None:
     try:
         config_data = config_validate.load_yaml(config_path)
     except yaml.YAMLError as e:
-        raise click.ClickException(f"Invalid YAML in {config_path}: {e}") from e
+        raise utils.MergifyError(
+            f"Invalid YAML in {config_path}: {e}",
+            exit_code=ExitCode.CONFIGURATION_ERROR,
+        ) from e
     except (TypeError, OSError) as e:
-        raise click.ClickException(str(e)) from e
+        raise utils.MergifyError(
+            str(e),
+            exit_code=ExitCode.CONFIGURATION_ERROR,
+        ) from e
 
     try:
         with httpx.Client(timeout=30) as client:
             schema = config_validate.fetch_schema(client)
         result = config_validate.validate_config(config_data, schema)
     except httpx.HTTPError as e:
-        raise click.ClickException(f"Failed to fetch validation schema: {e}") from e
+        raise utils.MergifyError(
+            f"Failed to fetch validation schema: {e}",
+            exit_code=ExitCode.MERGIFY_API_ERROR,
+        ) from e
     except (ValueError, TypeError) as e:
-        raise click.ClickException(f"Failed to parse validation schema: {e}") from e
+        raise utils.MergifyError(
+            f"Failed to parse validation schema: {e}",
+            exit_code=ExitCode.GENERIC_ERROR,
+        ) from e
 
     escaped_path = escape(config_path)
 
@@ -93,7 +105,10 @@ def validate(ctx: click.Context) -> None:
             markup=False,
         )
 
-    raise SystemExit(ExitCode.CONFIGURATION_ERROR)
+    raise utils.MergifyError(
+        "configuration validation failed",
+        exit_code=ExitCode.CONFIGURATION_ERROR,
+    )
 
 
 _PR_URL_RE = re.compile(
@@ -105,7 +120,7 @@ def _parse_pr_url(url: str) -> tuple[str, int]:
     m = _PR_URL_RE.match(url)
     if not m:
         msg = f"Invalid pull request URL: {url}"
-        raise click.ClickException(msg)
+        raise click.BadParameter(msg)
     return f"{m.group('owner')}/{m.group('repo')}", int(m.group("number"))
 
 

--- a/mergify_cli/tests/config/test_validate.py
+++ b/mergify_cli/tests/config/test_validate.py
@@ -3,16 +3,20 @@ from __future__ import annotations
 import typing
 from unittest import mock
 
-
-if typing.TYPE_CHECKING:
-    import pathlib
-
+from click import testing
 from click.testing import CliRunner
 from httpx import Response
 import respx
 
+from mergify_cli import cli as cli_mod
 from mergify_cli.config.cli import config
 from mergify_cli.exit_codes import ExitCode
+
+
+if typing.TYPE_CHECKING:
+    import pathlib
+
+    import pytest
 
 
 _MINIMAL_SCHEMA: dict[str, object] = {
@@ -237,3 +241,44 @@ def test_simulate_config_not_found() -> None:
     )
     assert result.exit_code != 0
     assert "not found" in result.output.lower()
+
+
+def test_config_not_found_exits_configuration_error(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """config validate with no config file available exits CONFIGURATION_ERROR."""
+    monkeypatch.chdir(tmp_path)  # no .mergify.yml anywhere
+    runner = testing.CliRunner()
+    result = runner.invoke(cli_mod.cli, ["config", "validate"])
+    assert result.exit_code == ExitCode.CONFIGURATION_ERROR, result.output
+
+
+def test_config_invalid_yaml_exits_configuration_error(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """config validate with invalid YAML exits CONFIGURATION_ERROR."""
+    cfg = tmp_path / ".mergify.yml"
+    cfg.write_text("not: valid: yaml: [")
+    monkeypatch.chdir(tmp_path)
+    runner = testing.CliRunner()
+    result = runner.invoke(cli_mod.cli, ["config", "validate"])
+    assert result.exit_code == ExitCode.CONFIGURATION_ERROR, result.output
+
+
+def test_config_simulate_invalid_url_exits_2(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """config simulate with a non-PR URL exits 2 (click.BadParameter)."""
+    cfg = tmp_path / ".mergify.yml"
+    cfg.write_text("pull_request_rules: []\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MERGIFY_TOKEN", "fake")
+    runner = testing.CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        ["config", "simulate", "https://example.com/not-a-pr"],
+    )
+    assert result.exit_code == 2, result.output


### PR DESCRIPTION
Config-not-found, invalid YAML, and I/O errors now exit with
CONFIGURATION_ERROR (8). Schema fetch failures exit with
MERGIFY_API_ERROR (6). Invalid PR URL becomes click.BadParameter
(exit 2 - argument error, not a runtime failure).

Contract: docs/exit-codes.md.

Depends-On: #1229