### PR TITLE
refactor(ci): replace ClickException with typed MergifyError

### DIFF
--- a/mergify_cli/ci/cli.py
+++ b/mergify_cli/ci/cli.py
@@ -15,6 +15,7 @@ from mergify_cli.ci.queue import metadata as queue_metadata
 from mergify_cli.ci.scopes import cli as scopes_cli
 from mergify_cli.ci.scopes import exceptions as scopes_exc
 from mergify_cli.dym import DYMGroup
+from mergify_cli.exit_codes import ExitCode
 
 
 class JUnitFile(click.Path):
@@ -278,11 +279,11 @@ def scopes(
     if config_path is None:
         locations = ", ".join(detector.MERGIFY_CONFIG_PATHS)
         msg = f"Mergify configuration file not found. Looked in: {locations}"
-        raise click.ClickException(msg)
+        raise utils.MergifyError(msg, exit_code=ExitCode.CONFIGURATION_ERROR)
 
     if not pathlib.Path(config_path).is_file():
         msg = f"Config file '{config_path}' does not exist."
-        raise click.ClickException(msg)
+        raise utils.MergifyError(msg, exit_code=ExitCode.CONFIGURATION_ERROR)
 
     if base or head:
         ref = git_refs_detector.References(
@@ -299,7 +300,10 @@ def scopes(
             references=ref,
         )
     except scopes_exc.ScopesError as e:
-        raise click.ClickException(str(e)) from e
+        raise utils.MergifyError(
+            str(e),
+            exit_code=ExitCode.CONFIGURATION_ERROR,
+        ) from e
 
     if write is not None:
         scopes.save_to_file(write)
@@ -361,7 +365,10 @@ async def scopes_send(
         try:
             dump = scopes_cli.DetectedScope.load_from_file(file)
         except scopes_exc.ScopesError as e:
-            raise click.ClickException(str(e)) from e
+            raise utils.MergifyError(
+                str(e),
+                exit_code=ExitCode.CONFIGURATION_ERROR,
+            ) from e
         scopes.extend(dump.scopes)
 
     await scopes_cli.send_scopes(
@@ -380,9 +387,10 @@ async def scopes_send(
 def queue_info() -> None:
     metadata = queue_metadata.detect()
     if metadata is None:
-        raise click.ClickException(
+        raise utils.MergifyError(
             "Not running in a merge queue context. "
             "This command must be run on a merge queue draft pull request.",
+            exit_code=ExitCode.INVALID_STATE,
         )
 
     click.echo(json.dumps(metadata, indent=2))

--- a/mergify_cli/tests/ci/test_cli.py
+++ b/mergify_cli/tests/ci/test_cli.py
@@ -14,6 +14,7 @@ from mergify_cli.ci import cli as ci_cli
 from mergify_cli.ci.junit_processing import cli as junit_processing_cli
 from mergify_cli.ci.junit_processing import quarantine
 from mergify_cli.ci.junit_processing import upload
+from mergify_cli.exit_codes import ExitCode
 
 
 if TYPE_CHECKING:
@@ -394,8 +395,9 @@ def test_scopes_empty_mergify_config_env_uses_autodetection(
     runner = testing.CliRunner()
     result = runner.invoke(ci_cli.scopes, ["--base", "old", "--head", "new"])
 
-    # The command found the auto-detected config and ran (source is manual so exit 1)
-    assert result.exit_code == 1
+    # The command found the auto-detected config and ran; source is manual so
+    # ScopesError is raised -> CONFIGURATION_ERROR exit code.
+    assert result.exit_code == ExitCode.CONFIGURATION_ERROR
     assert "source `manual` has been set" in result.output
 
 
@@ -481,5 +483,5 @@ def test_queue_info_not_merge_queue(
 
     runner = testing.CliRunner()
     result = runner.invoke(ci_cli.queue_info, [])
-    assert result.exit_code == 1
+    assert result.exit_code == ExitCode.INVALID_STATE
     assert "Not running in a merge queue context" in result.output

--- a/mergify_cli/tests/ci/test_cli_exit_codes.py
+++ b/mergify_cli/tests/ci/test_cli_exit_codes.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import typing
+
+from click import testing
+
+from mergify_cli import cli as cli_mod
+from mergify_cli.exit_codes import ExitCode
+
+
+if typing.TYPE_CHECKING:
+    import pathlib
+
+    import pytest
+
+
+def test_ci_scopes_missing_config_exits_configuration_error(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    runner = testing.CliRunner()
+    result = runner.invoke(cli_mod.cli, ["ci", "scopes"])
+    assert result.exit_code == ExitCode.CONFIGURATION_ERROR, result.output
+
+
+def test_ci_scopes_nonexistent_config_path_exits_configuration_error(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    runner = testing.CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        ["ci", "scopes", "--config", str(tmp_path / "nope.yml")],
+    )
+    assert result.exit_code == ExitCode.CONFIGURATION_ERROR, result.output
+
+
+def test_ci_queue_info_outside_merge_queue_exits_invalid_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in [
+        "GITHUB_EVENT_NAME",
+        "GITHUB_EVENT_PATH",
+        "GITHUB_HEAD_REF",
+        "GITHUB_BASE_REF",
+        "MERGIFY_QUEUE_BATCH_ID",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    runner = testing.CliRunner()
+    result = runner.invoke(cli_mod.cli, ["ci", "queue-info"])
+    assert result.exit_code == ExitCode.INVALID_STATE, result.output


### PR DESCRIPTION
- scopes config-not-found / path-does-not-exist -> CONFIGURATION_ERROR
- scopes ScopesError -> CONFIGURATION_ERROR
- scopes_send ScopesError loading file -> CONFIGURATION_ERROR
- queue-info outside merge queue -> INVALID_STATE

Contract: docs/exit-codes.md.

Depends-On: #1230