### PR TITLE
refactor(stack): use ExitCode.SUCCESS instead of bare sys.exit(0)

### DIFF
--- a/mergify_cli/stack/checkout.py
+++ b/mergify_cli/stack/checkout.py
@@ -87,7 +87,7 @@ async def stack_checkout(
 
         if root_node is None:
             console.print("No stacked pull requests found")
-            sys.exit(0)
+            sys.exit(ExitCode.SUCCESS)
 
         console.log("Stacked pull requests:")
         node = root_node

--- a/mergify_cli/stack/open.py
+++ b/mergify_cli/stack/open.py
@@ -89,7 +89,7 @@ async def stack_open(
 
         if selected is None:
             # User cancelled (Ctrl+C)
-            sys.exit(0)
+            sys.exit(ExitCode.SUCCESS)
 
         entry = selected
     else:

--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -367,7 +367,7 @@ async def stack_push(
 
         if dry_run:
             console.log("[orange]Finished (dry-run mode).[/]")
-            sys.exit(0)
+            sys.exit(ExitCode.SUCCESS)
 
         if revision_history:
             # Fetch old PR heads for patch-id comparison before force-pushing


### PR DESCRIPTION
Consistency with the rest of the codebase. No behavior change.

Depends-On: #1231