### PR TITLE
refactor: migrate existing exits to typed ExitCode

### DIFF
--- a/mergify_cli/ci/cli.py
+++ b/mergify_cli/ci/cli.py
@@ -15,6 +15,7 @@ from mergify_cli.ci.queue import metadata as queue_metadata
 from mergify_cli.ci.scopes import cli as scopes_cli
 from mergify_cli.ci.scopes import exceptions as scopes_exc
 from mergify_cli.dym import DYMGroup
+from mergify_cli.exit_codes import ExitCode
 
 
 class JUnitFile(click.Path):
@@ -278,11 +279,11 @@ def scopes(
     if config_path is None:
         locations = ", ".join(detector.MERGIFY_CONFIG_PATHS)
         msg = f"Mergify configuration file not found. Looked in: {locations}"
-        raise click.ClickException(msg)
+        raise utils.MergifyError(msg, exit_code=ExitCode.CONFIGURATION_ERROR)
 
     if not pathlib.Path(config_path).is_file():
         msg = f"Config file '{config_path}' does not exist."
-        raise click.ClickException(msg)
+        raise utils.MergifyError(msg, exit_code=ExitCode.CONFIGURATION_ERROR)
 
     if base or head:
         ref = git_refs_detector.References(
@@ -299,7 +300,10 @@ def scopes(
             references=ref,
         )
     except scopes_exc.ScopesError as e:
-        raise click.ClickException(str(e)) from e
+        raise utils.MergifyError(
+            str(e),
+            exit_code=ExitCode.CONFIGURATION_ERROR,
+        ) from e
 
     if write is not None:
         scopes.save_to_file(write)
@@ -382,7 +386,10 @@ async def scopes_send(
         try:
             dump = scopes_cli.DetectedScope.load_from_file(scopes_json)
         except scopes_exc.ScopesError as e:
-            raise click.ClickException(str(e)) from e
+            raise utils.MergifyError(
+                str(e),
+                exit_code=ExitCode.CONFIGURATION_ERROR,
+            ) from e
         scopes.extend(dump.scopes)
     if scopes_file is not None:
         scopes.extend(
@@ -412,9 +419,10 @@ async def scopes_send(
 def queue_info() -> None:
     metadata = queue_metadata.detect()
     if metadata is None:
-        raise click.ClickException(
+        raise utils.MergifyError(
             "Not running in a merge queue context. "
             "This command must be run on a merge queue draft pull request.",
+            exit_code=ExitCode.INVALID_STATE,
         )
 
     click.echo(json.dumps(metadata, indent=2))

--- a/mergify_cli/config/cli.py
+++ b/mergify_cli/config/cli.py
@@ -27,11 +27,11 @@ def _resolve_config_path(config_path: str | None) -> str:
     if config_path is None:
         locations = ", ".join(MERGIFY_CONFIG_PATHS)
         msg = f"Mergify configuration file not found. Looked in: {locations}"
-        raise click.ClickException(msg)
+        raise utils.MergifyError(msg, exit_code=ExitCode.CONFIGURATION_ERROR)
 
     if not pathlib.Path(config_path).is_file():
         msg = f"Configuration file not found: {config_path}"
-        raise click.ClickException(msg)
+        raise utils.MergifyError(msg, exit_code=ExitCode.CONFIGURATION_ERROR)
 
     return config_path
 
@@ -64,18 +64,30 @@ def validate(ctx: click.Context) -> None:
     try:
         config_data = config_validate.load_yaml(config_path)
     except yaml.YAMLError as e:
-        raise click.ClickException(f"Invalid YAML in {config_path}: {e}") from e
+        raise utils.MergifyError(
+            f"Invalid YAML in {config_path}: {e}",
+            exit_code=ExitCode.CONFIGURATION_ERROR,
+        ) from e
     except (TypeError, OSError) as e:
-        raise click.ClickException(str(e)) from e
+        raise utils.MergifyError(
+            str(e),
+            exit_code=ExitCode.CONFIGURATION_ERROR,
+        ) from e
 
     try:
         with httpx.Client(timeout=30) as client:
             schema = config_validate.fetch_schema(client)
         result = config_validate.validate_config(config_data, schema)
     except httpx.HTTPError as e:
-        raise click.ClickException(f"Failed to fetch validation schema: {e}") from e
+        raise utils.MergifyError(
+            f"Failed to fetch validation schema: {e}",
+            exit_code=ExitCode.MERGIFY_API_ERROR,
+        ) from e
     except (ValueError, TypeError) as e:
-        raise click.ClickException(f"Failed to parse validation schema: {e}") from e
+        raise utils.MergifyError(
+            f"Failed to parse validation schema: {e}",
+            exit_code=ExitCode.GENERIC_ERROR,
+        ) from e
 
     escaped_path = escape(config_path)
 
@@ -93,7 +105,10 @@ def validate(ctx: click.Context) -> None:
             markup=False,
         )
 
-    raise SystemExit(ExitCode.CONFIGURATION_ERROR)
+    raise utils.MergifyError(
+        "configuration validation failed",
+        exit_code=ExitCode.CONFIGURATION_ERROR,
+    )
 
 
 _PR_URL_RE = re.compile(
@@ -105,7 +120,7 @@ def _parse_pr_url(url: str) -> tuple[str, int]:
     m = _PR_URL_RE.match(url)
     if not m:
         msg = f"Invalid pull request URL: {url}"
-        raise click.ClickException(msg)
+        raise click.BadParameter(msg)
     return f"{m.group('owner')}/{m.group('repo')}", int(m.group("number"))
 
 

--- a/mergify_cli/stack/checkout.py
+++ b/mergify_cli/stack/checkout.py
@@ -87,7 +87,7 @@ async def stack_checkout(
 
         if root_node is None:
             console.print("No stacked pull requests found")
-            sys.exit(0)
+            sys.exit(ExitCode.SUCCESS)
 
         console.log("Stacked pull requests:")
         node = root_node

--- a/mergify_cli/stack/open.py
+++ b/mergify_cli/stack/open.py
@@ -89,7 +89,7 @@ async def stack_open(
 
         if selected is None:
             # User cancelled (Ctrl+C)
-            sys.exit(0)
+            sys.exit(ExitCode.SUCCESS)
 
         entry = selected
     else:

--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -367,7 +367,7 @@ async def stack_push(
 
         if dry_run:
             console.log("[orange]Finished (dry-run mode).[/]")
-            sys.exit(0)
+            sys.exit(ExitCode.SUCCESS)
 
         if revision_history:
             # Fetch old PR heads for patch-id comparison before force-pushing

--- a/mergify_cli/tests/ci/test_cli.py
+++ b/mergify_cli/tests/ci/test_cli.py
@@ -14,6 +14,7 @@ from mergify_cli.ci import cli as ci_cli
 from mergify_cli.ci.junit_processing import cli as junit_processing_cli
 from mergify_cli.ci.junit_processing import quarantine
 from mergify_cli.ci.junit_processing import upload
+from mergify_cli.exit_codes import ExitCode
 
 
 if TYPE_CHECKING:
@@ -443,8 +444,9 @@ def test_scopes_empty_mergify_config_env_uses_autodetection(
     runner = testing.CliRunner()
     result = runner.invoke(ci_cli.scopes, ["--base", "old", "--head", "new"])
 
-    # The command found the auto-detected config and ran (source is manual so exit 1)
-    assert result.exit_code == 1
+    # The command found the auto-detected config and ran; source is manual so
+    # ScopesError is raised -> CONFIGURATION_ERROR exit code.
+    assert result.exit_code == ExitCode.CONFIGURATION_ERROR
     assert "source `manual` has been set" in result.output
 
 
@@ -530,5 +532,5 @@ def test_queue_info_not_merge_queue(
 
     runner = testing.CliRunner()
     result = runner.invoke(ci_cli.queue_info, [])
-    assert result.exit_code == 1
+    assert result.exit_code == ExitCode.INVALID_STATE
     assert "Not running in a merge queue context" in result.output

--- a/mergify_cli/tests/ci/test_cli_exit_codes.py
+++ b/mergify_cli/tests/ci/test_cli_exit_codes.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import typing
+
+from click import testing
+
+from mergify_cli import cli as cli_mod
+from mergify_cli.exit_codes import ExitCode
+
+
+if typing.TYPE_CHECKING:
+    import pathlib
+
+    import pytest
+
+
+def test_ci_scopes_missing_config_exits_configuration_error(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    runner = testing.CliRunner()
+    result = runner.invoke(cli_mod.cli, ["ci", "scopes"])
+    assert result.exit_code == ExitCode.CONFIGURATION_ERROR, result.output
+
+
+def test_ci_scopes_nonexistent_config_path_exits_configuration_error(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    runner = testing.CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        ["ci", "scopes", "--config", str(tmp_path / "nope.yml")],
+    )
+    assert result.exit_code == ExitCode.CONFIGURATION_ERROR, result.output
+
+
+def test_ci_queue_info_outside_merge_queue_exits_invalid_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in [
+        "GITHUB_EVENT_NAME",
+        "GITHUB_EVENT_PATH",
+        "GITHUB_HEAD_REF",
+        "GITHUB_BASE_REF",
+        "MERGIFY_QUEUE_BATCH_ID",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    runner = testing.CliRunner()
+    result = runner.invoke(cli_mod.cli, ["ci", "queue-info"])
+    assert result.exit_code == ExitCode.INVALID_STATE, result.output

--- a/mergify_cli/tests/ci/test_junit.py
+++ b/mergify_cli/tests/ci/test_junit.py
@@ -553,3 +553,68 @@ async def test_traceparent_injection(
     assert spans[0].parent.span_id == 0x7A085853722DC6D2
     for span in spans:
         assert span.context.trace_id == 0x80E1AFED08E019FC1110464CFA66635C
+
+
+# ── Exit code pinning tests ──
+
+
+def test_junit_invalid_xml_exits_generic_error(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Malformed XML exits GENERIC_ERROR."""
+    from click import testing
+
+    from mergify_cli import cli as cli_mod
+    from mergify_cli.exit_codes import ExitCode
+
+    bad = tmp_path / "bad.xml"
+    bad.write_text("<not-well-formed>")
+    runner = testing.CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        [
+            "ci",
+            "junit-process",
+            "--token",
+            "fake",
+            "--api-url",
+            "https://api.mergify.com",
+            "--repository",
+            "owner/repo",
+            "--tests-target-branch",
+            "main",
+            str(bad),
+        ],
+    )
+    assert result.exit_code == ExitCode.GENERIC_ERROR, result.output
+
+
+def test_junit_empty_file_exits_generic_error(
+    tmp_path: pathlib.Path,
+) -> None:
+    """JUnit file with no test cases exits GENERIC_ERROR."""
+    from click import testing
+
+    from mergify_cli import cli as cli_mod
+    from mergify_cli.exit_codes import ExitCode
+
+    empty = tmp_path / "empty.xml"
+    empty.write_text('<?xml version="1.0"?><testsuites/>')
+    runner = testing.CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        [
+            "ci",
+            "junit-process",
+            "--token",
+            "fake",
+            "--api-url",
+            "https://api.mergify.com",
+            "--repository",
+            "owner/repo",
+            "--tests-target-branch",
+            "main",
+            str(empty),
+        ],
+    )
+    assert result.exit_code == ExitCode.GENERIC_ERROR, result.output

--- a/mergify_cli/tests/config/test_validate.py
+++ b/mergify_cli/tests/config/test_validate.py
@@ -3,16 +3,20 @@ from __future__ import annotations
 import typing
 from unittest import mock
 
-
-if typing.TYPE_CHECKING:
-    import pathlib
-
+from click import testing
 from click.testing import CliRunner
 from httpx import Response
 import respx
 
+from mergify_cli import cli as cli_mod
 from mergify_cli.config.cli import config
 from mergify_cli.exit_codes import ExitCode
+
+
+if typing.TYPE_CHECKING:
+    import pathlib
+
+    import pytest
 
 
 _MINIMAL_SCHEMA: dict[str, object] = {
@@ -237,3 +241,44 @@ def test_simulate_config_not_found() -> None:
     )
     assert result.exit_code != 0
     assert "not found" in result.output.lower()
+
+
+def test_config_not_found_exits_configuration_error(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """config validate with no config file available exits CONFIGURATION_ERROR."""
+    monkeypatch.chdir(tmp_path)  # no .mergify.yml anywhere
+    runner = testing.CliRunner()
+    result = runner.invoke(cli_mod.cli, ["config", "validate"])
+    assert result.exit_code == ExitCode.CONFIGURATION_ERROR, result.output
+
+
+def test_config_invalid_yaml_exits_configuration_error(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """config validate with invalid YAML exits CONFIGURATION_ERROR."""
+    cfg = tmp_path / ".mergify.yml"
+    cfg.write_text("not: valid: yaml: [")
+    monkeypatch.chdir(tmp_path)
+    runner = testing.CliRunner()
+    result = runner.invoke(cli_mod.cli, ["config", "validate"])
+    assert result.exit_code == ExitCode.CONFIGURATION_ERROR, result.output
+
+
+def test_config_simulate_invalid_url_exits_2(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """config simulate with a non-PR URL exits 2 (click.BadParameter)."""
+    cfg = tmp_path / ".mergify.yml"
+    cfg.write_text("pull_request_rules: []\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MERGIFY_TOKEN", "fake")
+    runner = testing.CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        ["config", "simulate", "https://example.com/not-a-pr"],
+    )
+    assert result.exit_code == 2, result.output

--- a/mergify_cli/tests/test_exit_code_contract.py
+++ b/mergify_cli/tests/test_exit_code_contract.py
@@ -1,0 +1,105 @@
+"""Cross-command contract tests for exit codes.
+
+Each parametrize entry corresponds to a row in docs/exit-codes.md.
+Adding a failure mode to the CLI means adding a row here AND in
+docs/exit-codes.md. They stay in lockstep.
+"""
+
+from __future__ import annotations
+
+import typing
+
+from click import testing
+import pytest
+
+from mergify_cli import cli as cli_mod
+from mergify_cli.exit_codes import ExitCode
+
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+    import pathlib
+
+
+@pytest.mark.parametrize(
+    ("setup", "args", "expected_exit"),
+    [
+        pytest.param(
+            lambda tmp_path, monkeypatch: monkeypatch.chdir(tmp_path),
+            ["config", "validate"],
+            ExitCode.CONFIGURATION_ERROR,
+            id="config-validate-missing-file",
+        ),
+        pytest.param(
+            lambda tmp_path, monkeypatch: _write_and_cd(
+                tmp_path,
+                monkeypatch,
+                "not: valid: [",
+            ),
+            ["config", "validate"],
+            ExitCode.CONFIGURATION_ERROR,
+            id="config-validate-invalid-yaml",
+        ),
+        pytest.param(
+            lambda tmp_path, monkeypatch: _prepare_simulate_env(tmp_path, monkeypatch),  # noqa: PLW0108
+            ["config", "simulate", "https://example.com/not-a-pr"],
+            2,
+            id="config-simulate-bad-url",
+        ),
+        pytest.param(
+            lambda tmp_path, monkeypatch: monkeypatch.chdir(tmp_path),
+            ["ci", "scopes"],
+            ExitCode.CONFIGURATION_ERROR,
+            id="ci-scopes-missing-config",
+        ),
+        pytest.param(
+            lambda _tmp_path, monkeypatch: _clear_mq_env(monkeypatch),
+            ["ci", "queue-info"],
+            ExitCode.INVALID_STATE,
+            id="ci-queue-info-outside-mq",
+        ),
+    ],
+)
+def test_exit_code_contract(
+    setup: Callable[[pathlib.Path, pytest.MonkeyPatch], None],
+    args: list[str],
+    expected_exit: int,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each entry asserts (args under setup) -> expected_exit."""
+    setup(tmp_path, monkeypatch)
+    runner = testing.CliRunner()
+    result = runner.invoke(cli_mod.cli, args)
+    assert result.exit_code == expected_exit, (
+        f"expected {expected_exit}, got {result.exit_code}\noutput: {result.output}"
+    )
+
+
+def _write_and_cd(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    yaml_content: str,
+) -> None:
+    (tmp_path / ".mergify.yml").write_text(yaml_content)
+    monkeypatch.chdir(tmp_path)
+
+
+def _prepare_simulate_env(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / ".mergify.yml").write_text("pull_request_rules: []\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MERGIFY_TOKEN", "fake")
+
+
+def _clear_mq_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in [
+        "GITHUB_EVENT_NAME",
+        "GITHUB_EVENT_PATH",
+        "GITHUB_HEAD_REF",
+        "GITHUB_BASE_REF",
+        "MERGIFY_QUEUE_BATCH_ID",
+    ]:
+        monkeypatch.delenv(var, raising=False)


### PR DESCRIPTION
Applies the contract from docs/exit-codes.md across the CLI:

- config/cli.py: 7 ClickException raises -> MergifyError with
  CONFIGURATION_ERROR / MERGIFY_API_ERROR / GENERIC_ERROR;
  1 SystemExit -> MergifyError; invalid PR URL -> click.BadParameter
  (exit 2)
- ci/cli.py: 5 ClickException raises -> MergifyError
  (scopes/scopes_send -> CONFIGURATION_ERROR; queue_info outside
  merge queue context -> INVALID_STATE)
- stack/{open,push,checkout}.py: bare sys.exit(0) ->
  sys.exit(ExitCode.SUCCESS) for uniformity
- junit-process: pin existing GENERIC_ERROR exits against
  regression (invalid XML, empty reports)
- Add parametrized cross-command exit-code contract walker

UX impact: semantic failures now exit with the documented typed
code instead of bare 1. Scripts relying on exit == 1 for config
or ci-scopes errors need updating. `config simulate` with a bad
PR URL now exits 2 (click.BadParameter) rather than 1.

Contract: docs/exit-codes.md.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Depends-On: #1240