### PR TITLE
refactor(stack): schema-lock `stack list --json` output

### DIFF
--- a/mergify_cli/freeze/cli.py
+++ b/mergify_cli/freeze/cli.py
@@ -182,6 +182,10 @@ async def list_cmd(ctx: click.Context, *, output_json: bool) -> None:
         freezes = await freeze_api.list_freezes(client, ctx.obj["repository"])
 
     if output_json:
+        # JSON output is a passthrough of the Mergify API response.
+        # The schema is Mergify's API contract, not this CLI's — no
+        # transformation, no renaming, no filtering. The Rust port
+        # must preserve this passthrough behavior.
         click.echo(json.dumps(freezes, indent=2))
     else:
         _print_freeze_table(freezes)

--- a/mergify_cli/queue/cli.py
+++ b/mergify_cli/queue/cli.py
@@ -395,6 +395,9 @@ async def status(ctx: click.Context, *, branch: str | None, output_json: bool) -
     if output_json:
         import json
 
+        # JSON output is a passthrough of the Mergify API response.
+        # The schema is Mergify's API contract, not this CLI's — the
+        # Rust port must preserve this passthrough behavior.
         click.echo(json.dumps(data, indent=2))
         return
 
@@ -564,6 +567,9 @@ async def show(
     if output_json:
         import json
 
+        # JSON output is a passthrough of the Mergify API response.
+        # The schema is Mergify's API contract, not this CLI's — the
+        # Rust port must preserve this passthrough behavior.
         click.echo(json.dumps(data, indent=2))
         return
 

--- a/mergify_cli/stack/list_schema.py
+++ b/mergify_cli/stack/list_schema.py
@@ -1,0 +1,82 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""Schema lock for `mergify stack list --json` output.
+
+Mirrors ``StackListOutput.to_dict()`` exactly. The test suite validates
+the command's JSON output against ``StackListJsonOutput`` with
+``extra="forbid"`` so any drift — extra fields, missing fields, wrong
+types, or new literal values — fails loudly.
+
+This is part of the machine-readable compat contract that the Rust
+port must preserve byte-for-byte. Changing any field here is a
+breaking change to downstream scripts and requires a coordinated
+announcement.
+
+`freeze list`, `queue status`, and `queue show` are not locked here
+— those commands pass the Mergify API response through unchanged,
+so their schema is the API's contract, not ours.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import pydantic
+
+
+class _StrictSchemaBase(pydantic.BaseModel):
+    """Base for schema-lock models.
+
+    ``extra="forbid"`` rejects unknown fields; ``strict=True`` disables
+    Pydantic's type coercion so a drift like emitting an int as a string
+    (or vice versa) fails validation instead of passing silently.
+    """
+
+    model_config = pydantic.ConfigDict(extra="forbid", strict=True)
+
+
+class CICheckJson(_StrictSchemaBase):
+    name: str
+    status: str
+
+
+class ReviewJson(_StrictSchemaBase):
+    user: str
+    state: str
+
+
+class StackEntryJson(_StrictSchemaBase):
+    commit_sha: str
+    title: str
+    change_id: str
+    status: typing.Literal["merged", "draft", "open", "no_pr"]
+    pull_number: int | None
+    pull_url: str | None
+    ci_status: typing.Literal["passing", "failing", "pending", "unknown"]
+    ci_checks: list[CICheckJson]
+    review_status: typing.Literal[
+        "approved",
+        "changes_requested",
+        "pending",
+        "unknown",
+    ]
+    reviews: list[ReviewJson]
+    mergeable: bool | None
+
+
+class StackListJsonOutput(_StrictSchemaBase):
+    branch: str
+    trunk: str
+    entries: list[StackEntryJson]

--- a/mergify_cli/tests/stack/test_list.py
+++ b/mergify_cli/tests/stack/test_list.py
@@ -21,6 +21,7 @@ import pytest
 
 from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack import list as stack_list_mod
+from mergify_cli.stack import list_schema as stack_list_schema
 from mergify_cli.tests import utils as test_utils
 
 
@@ -363,6 +364,12 @@ async def test_stack_list_json_output(
 
     captured = capsys.readouterr()
     output = json.loads(captured.out)
+
+    # Schema lock: the output must parse cleanly into the pinned model
+    # with extra="forbid". Any drift (new field, renamed field, wrong
+    # type, new literal value) fails here. Update the model and the
+    # Rust port's matching types in lockstep.
+    stack_list_schema.StackListJsonOutput.model_validate(output)
 
     assert output["branch"] == "current-branch"
     assert output["trunk"] == "origin/main"


### PR DESCRIPTION
Pins the JSON output shape of `mergify stack list --json` so any
drift is caught in CI. The Rust port will reuse this model as its
output schema, and downstream scripts that parse this output get a
stable contract.

- New `mergify_cli/stack/list_schema.py` with Pydantic BaseModels
  mirroring StackListOutput.to_dict(). extra="forbid" rejects any
  new/renamed/removed fields or wrong types.
- test_stack_list_json_output now validates parsed output against
  StackListJsonOutput. Failing here means either the code drifted
  (needs revert) or the shape changed intentionally (update both
  the dataclass and the schema in one commit, treat as a breaking
  change for consumers).

`freeze list`, `queue status`, `queue show` are deliberately NOT
locked: their JSON output is a passthrough of the Mergify API
response, so the schema is the API's contract, not this CLI's.
Added inline comments documenting that invariant so the Rust port
preserves the passthrough behavior without introducing
transformations.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>