### PR TITLE
test: formalize --json stdout/stderr discipline

### DIFF
--- a/mergify_cli/freeze/cli.py
+++ b/mergify_cli/freeze/cli.py
@@ -182,6 +182,10 @@ async def list_cmd(ctx: click.Context, *, output_json: bool) -> None:
         freezes = await freeze_api.list_freezes(client, ctx.obj["repository"])
 
     if output_json:
+        # JSON output is a passthrough of the Mergify API response.
+        # The schema is Mergify's API contract, not this CLI's — no
+        # transformation, no renaming, no filtering. The Rust port
+        # must preserve this passthrough behavior.
         click.echo(json.dumps(freezes, indent=2))
     else:
         _print_freeze_table(freezes)

--- a/mergify_cli/queue/cli.py
+++ b/mergify_cli/queue/cli.py
@@ -395,6 +395,9 @@ async def status(ctx: click.Context, *, branch: str | None, output_json: bool) -
     if output_json:
         import json
 
+        # JSON output is a passthrough of the Mergify API response.
+        # The schema is Mergify's API contract, not this CLI's — the
+        # Rust port must preserve this passthrough behavior.
         click.echo(json.dumps(data, indent=2))
         return
 
@@ -564,6 +567,9 @@ async def show(
     if output_json:
         import json
 
+        # JSON output is a passthrough of the Mergify API response.
+        # The schema is Mergify's API contract, not this CLI's — the
+        # Rust port must preserve this passthrough behavior.
         click.echo(json.dumps(data, indent=2))
         return
 

--- a/mergify_cli/stack/list_schema.py
+++ b/mergify_cli/stack/list_schema.py
@@ -1,0 +1,82 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""Schema lock for `mergify stack list --json` output.
+
+Mirrors ``StackListOutput.to_dict()`` exactly. The test suite validates
+the command's JSON output against ``StackListJsonOutput`` with
+``extra="forbid"`` so any drift — extra fields, missing fields, wrong
+types, or new literal values — fails loudly.
+
+This is part of the machine-readable compat contract that the Rust
+port must preserve byte-for-byte. Changing any field here is a
+breaking change to downstream scripts and requires a coordinated
+announcement.
+
+`freeze list`, `queue status`, and `queue show` are not locked here
+— those commands pass the Mergify API response through unchanged,
+so their schema is the API's contract, not ours.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import pydantic
+
+
+class _StrictSchemaBase(pydantic.BaseModel):
+    """Base for schema-lock models.
+
+    ``extra="forbid"`` rejects unknown fields; ``strict=True`` disables
+    Pydantic's type coercion so a drift like emitting an int as a string
+    (or vice versa) fails validation instead of passing silently.
+    """
+
+    model_config = pydantic.ConfigDict(extra="forbid", strict=True)
+
+
+class CICheckJson(_StrictSchemaBase):
+    name: str
+    status: str
+
+
+class ReviewJson(_StrictSchemaBase):
+    user: str
+    state: str
+
+
+class StackEntryJson(_StrictSchemaBase):
+    commit_sha: str
+    title: str
+    change_id: str
+    status: typing.Literal["merged", "draft", "open", "no_pr"]
+    pull_number: int | None
+    pull_url: str | None
+    ci_status: typing.Literal["passing", "failing", "pending", "unknown"]
+    ci_checks: list[CICheckJson]
+    review_status: typing.Literal[
+        "approved",
+        "changes_requested",
+        "pending",
+        "unknown",
+    ]
+    reviews: list[ReviewJson]
+    mergeable: bool | None
+
+
+class StackListJsonOutput(_StrictSchemaBase):
+    branch: str
+    trunk: str
+    entries: list[StackEntryJson]

--- a/mergify_cli/tests/freeze/test_cli.py
+++ b/mergify_cli/tests/freeze/test_cli.py
@@ -10,6 +10,7 @@ import pytest
 import respx
 
 from mergify_cli.freeze.cli import freeze
+from mergify_cli.tests import utils as test_utils
 
 
 FAKE_FREEZE = {
@@ -78,7 +79,7 @@ def test_list_json() -> None:
         runner = CliRunner()
         result = runner.invoke(freeze, [*BASE_ARGS, "list", "--json"])
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        data = test_utils.assert_stdout_is_single_json_document(result.output)
         assert len(data) == 1
         assert data[0]["reason"] == "Release prep"
 
@@ -110,7 +111,7 @@ def test_list_json_with_exclude_conditions() -> None:
         runner = CliRunner()
         result = runner.invoke(freeze, [*BASE_ARGS, "list", "--json"])
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        data = test_utils.assert_stdout_is_single_json_document(result.output)
         assert data[0]["exclude_conditions"] == ["label=hotfix"]
 
 

--- a/mergify_cli/tests/queue/test_cli.py
+++ b/mergify_cli/tests/queue/test_cli.py
@@ -12,6 +12,7 @@ from mergify_cli.exit_codes import ExitCode
 from mergify_cli.queue.cli import _relative_time
 from mergify_cli.queue.cli import _topological_sort
 from mergify_cli.queue.cli import queue
+from mergify_cli.tests import utils as test_utils
 
 
 FAKE_PR = {
@@ -252,8 +253,6 @@ class TestStatusCommand:
         assert "Queue is empty" in result.output
 
     def test_json_output(self) -> None:
-        import json
-
         api_response = {
             "batches": [FAKE_BATCH],
             "waiting_pull_requests": [FAKE_PR],
@@ -262,7 +261,7 @@ class TestStatusCommand:
         with respx.mock(base_url="https://api.mergify.com") as mock:
             result = _invoke_status(mock, api_response, extra_args=["--json"])
         assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
+        data = test_utils.assert_stdout_is_single_json_document(result.output)
         assert len(data["batches"]) == 1
         assert len(data["waiting_pull_requests"]) == 1
 

--- a/mergify_cli/tests/queue/test_show.py
+++ b/mergify_cli/tests/queue/test_show.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-import json
 import typing
 from unittest.mock import patch
 
@@ -11,6 +10,7 @@ import respx
 
 from mergify_cli.exit_codes import ExitCode
 from mergify_cli.queue.cli import queue
+from mergify_cli.tests import utils as test_utils
 
 
 FAKE_CHECK_SUCCESS = {
@@ -205,7 +205,7 @@ class TestShowCommand:
                 extra_args=["--json"],
             )
         assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
+        data = test_utils.assert_stdout_is_single_json_document(result.output)
         assert data["number"] == 123
         assert data["position"] == 3
         assert data["mergeability_check"]["ci_state"] == "pending"

--- a/mergify_cli/tests/stack/test_list.py
+++ b/mergify_cli/tests/stack/test_list.py
@@ -21,6 +21,7 @@ import pytest
 
 from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack import list as stack_list_mod
+from mergify_cli.stack import list_schema as stack_list_schema
 from mergify_cli.tests import utils as test_utils
 
 
@@ -363,6 +364,12 @@ async def test_stack_list_json_output(
 
     captured = capsys.readouterr()
     output = json.loads(captured.out)
+
+    # Schema lock: the output must parse cleanly into the pinned model
+    # with extra="forbid". Any drift (new field, renamed field, wrong
+    # type, new literal value) fails here. Update the model and the
+    # Rust port's matching types in lockstep.
+    stack_list_schema.StackListJsonOutput.model_validate(output)
 
     assert output["branch"] == "current-branch"
     assert output["trunk"] == "origin/main"

--- a/mergify_cli/tests/stack/test_list.py
+++ b/mergify_cli/tests/stack/test_list.py
@@ -363,7 +363,7 @@ async def test_stack_list_json_output(
     )
 
     captured = capsys.readouterr()
-    output = json.loads(captured.out)
+    output = test_utils.assert_stdout_is_single_json_document(captured.out)
 
     # Schema lock: the output must parse cleanly into the pinned model
     # with extra="forbid". Any drift (new field, renamed field, wrong

--- a/mergify_cli/tests/utils.py
+++ b/mergify_cli/tests/utils.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 import subprocess
 import typing
 from unittest import mock
@@ -22,6 +23,34 @@ from unittest import mock
 
 if typing.TYPE_CHECKING:
     from collections import abc
+
+
+def assert_stdout_is_single_json_document(stdout: str) -> typing.Any:
+    """Assert that ``stdout`` contains exactly one JSON document and return it.
+
+    Formalizes the ``--json`` output discipline: under ``--json`` mode,
+    stdout MUST be exactly one JSON document and nothing else — no
+    progress bars, no status messages, no prefix or suffix text. Any
+    non-JSON content breaks downstream scripts that pipe the output
+    into ``jq``, ``python -m json.tool``, or similar.
+
+    ``json.loads`` rejects trailing non-whitespace content, so calling
+    this is equivalent to calling ``json.loads(stdout)`` — the helper
+    exists to name the invariant and produce a clearer failure message.
+
+    Use this in any test that exercises a ``--json`` code path.
+    """
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as e:
+        msg = (
+            "stdout is not a single JSON document — "
+            "likely a progress message, banner, or other text leaked "
+            "into the --json output path.\n"
+            f"json error: {e}\n"
+            f"stdout: {stdout!r}"
+        )
+        raise AssertionError(msg) from e
 
 
 class _CommitRequired(typing.TypedDict):


### PR DESCRIPTION
Introduces a named test helper, ``assert_stdout_is_single_json_document``,
and wires it into the four ``--json`` tests (``stack list``,
``queue status``, ``queue show``, ``freeze list``).

The helper asserts that stdout under ``--json`` mode contains
exactly one JSON document — no banners, no progress lines, no
trailing text. Functionally identical to ``json.loads(stdout)``
(which already rejects trailing non-whitespace), but the helper
gives future readers a clearly-named invariant to grep for and
produces an explanatory failure message instead of a raw
``JSONDecodeError``.

Nothing to fix in production code: a sweep of ``console.print``,
``click.echo``, and ``print()`` call sites found no leaks into the
``--json`` code paths. Recent fixes on main (e.g. 7adb94b) already
cleaned up known cases. This PR exists to keep the invariant
visible so future changes don't quietly regress it.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Depends-On: #1243