### PR TITLE
feat(ci): read MQ info note from refs/notes/mergify/ namespace

### DIFF
--- a/mergify_cli/ci/queue/notes.py
+++ b/mergify_cli/ci/queue/notes.py
@@ -1,9 +1,9 @@
 """Read a Mergify merge-queue info note from the current git repository.
 
 The engine publishes MQ batch metadata as a git note on the draft branch's head
-commit under `refs/notes/<mq_branch_name>`. Reading it requires only a git
-fetch, no GitHub token — handy for CI providers like Buildkite that don't ship
-the webhook payload to the build.
+commit under `refs/notes/mergify/<mq_branch_name>`. Reading it requires only a
+git fetch, no GitHub token — handy for CI providers like Buildkite that don't
+ship the webhook payload to the build.
 
 All errors (missing ref, missing note, bad YAML) are swallowed and reported as
 `None` so callers can fall back to legacy detection paths.
@@ -25,7 +25,11 @@ def read_mq_info_note(
     branch_name: str,
     head_sha: str,
 ) -> metadata.MergeQueueMetadata | None:
-    notes_ref = f"refs/notes/{branch_name}"
+    # Mirrors the engine's refs/notes/mergify/<branch> namespace. Passing
+    # "mergify/<branch>" to `git notes --ref=` lets git expand it to
+    # refs/notes/mergify/<branch>.
+    notes_ref_short = f"mergify/{branch_name}"
+    notes_ref = f"refs/notes/{notes_ref_short}"
 
     # The engine force-updates the notes ref on MQ retries (fresh commit, no
     # parents), so the remote SHA moves non-linearly. A '+' on the refspec is
@@ -48,7 +52,7 @@ def read_mq_info_note(
 
     try:
         content = subprocess.check_output(  # noqa: S603
-            ["git", "notes", f"--ref={branch_name}", "show", head_sha],
+            ["git", "notes", f"--ref={notes_ref_short}", "show", head_sha],
             text=True,
             encoding="utf-8",
             stderr=subprocess.DEVNULL,

--- a/mergify_cli/tests/ci/queue/test_notes.py
+++ b/mergify_cli/tests/ci/queue/test_notes.py
@@ -9,7 +9,8 @@ from mergify_cli.ci.queue import notes
 BRANCH = "mergify/merge-queue/abcdef0123"
 HEAD_SHA = "a" * 40
 BASE_SHA = "b" * 40
-NOTES_REF = f"refs/notes/{BRANCH}"
+NOTES_REF_SHORT = f"mergify/{BRANCH}"
+NOTES_REF = f"refs/notes/{NOTES_REF_SHORT}"
 
 
 def _completed(returncode: int = 0) -> subprocess.CompletedProcess[str]:
@@ -50,7 +51,7 @@ checking_base_sha: {BASE_SHA}
 
     check_output_mock.assert_called_once()
     show_cmd = check_output_mock.call_args.args[0]
-    assert show_cmd == ["git", "notes", f"--ref={BRANCH}", "show", HEAD_SHA]
+    assert show_cmd == ["git", "notes", f"--ref={NOTES_REF_SHORT}", "show", HEAD_SHA]
 
     assert result is not None
     assert result["checking_base_sha"] == BASE_SHA


### PR DESCRIPTION
Mirrors the engine change that moved the MQ batch metadata note from
refs/notes/<mq_branch> to refs/notes/mergify/<mq_branch> so it stays out
of the repo's default refs/notes/* listing. The fetch refspec and the
`git notes --ref=` argument are updated accordingly.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>