### PR TITLE
feat(stack): add stack_fixup for single-commit fixup

### DIFF
--- a/mergify_cli/stack/squash.py
+++ b/mergify_cli/stack/squash.py
@@ -1,0 +1,89 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import os
+import sys
+
+from mergify_cli import console
+from mergify_cli import console_error
+from mergify_cli import utils
+from mergify_cli.exit_codes import ExitCode
+from mergify_cli.stack.reorder import display_action_plan
+from mergify_cli.stack.reorder import get_stack_commits
+from mergify_cli.stack.reorder import match_commit
+from mergify_cli.stack.reorder import run_action_rebase
+
+
+async def stack_fixup(
+    commit_prefixes: list[str],
+    *,
+    dry_run: bool,
+) -> None:
+    os.chdir(await utils.git("rev-parse", "--show-toplevel"))
+    trunk = await utils.get_trunk()
+    base = await utils.git("merge-base", trunk, "HEAD")
+    commits = get_stack_commits(base)
+
+    if not commits:
+        console.print("No commits in the stack", style="green")
+        return
+
+    matched = [match_commit(p, commits) for p in commit_prefixes]
+
+    # Check for duplicates
+    matched_shas = [c[0] for c in matched]
+    if len(set(matched_shas)) != len(matched_shas):
+        seen: set[str] = set()
+        for prefix, sha in zip(commit_prefixes, matched_shas, strict=True):
+            if sha in seen:
+                console_error(
+                    f"duplicate — prefix '{prefix}' resolves to the same commit as another prefix",
+                )
+                sys.exit(ExitCode.INVALID_STATE)
+            seen.add(sha)
+
+    # Each listed commit must have a parent inside the stack (not the first)
+    first_sha = commits[0][0]
+    for sha in matched_shas:
+        if sha == first_sha:
+            console_error(
+                "cannot fixup the first commit of the stack — no parent in stack",
+            )
+            sys.exit(ExitCode.INVALID_STATE)
+
+    actions = dict.fromkeys(matched_shas, "fixup")
+    current_shas = [c[0] for c in commits]
+
+    display_action_plan("Fixup plan:", commits, actions)
+
+    if dry_run:
+        console.print("Dry run — no changes made", style="green")
+        return
+
+    run_action_rebase(base, current_shas, actions)
+    console.print("Commits squashed successfully.", style="green")
+
+
+async def stack_squash(
+    src_prefixes: list[str],
+    target_prefix: str,
+    *,
+    message: str | None,
+    dry_run: bool,
+) -> None:
+    # Placeholder — implemented in a later task.
+    raise NotImplementedError

--- a/mergify_cli/tests/stack/test_squash.py
+++ b/mergify_cli/tests/stack/test_squash.py
@@ -1,0 +1,122 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergify_cli.stack.squash import stack_fixup
+
+
+if TYPE_CHECKING:
+    import pathlib
+
+
+def _run_git(*args: str, cwd: pathlib.Path | None = None) -> str:
+    return subprocess.check_output(
+        ["git", *args],
+        text=True,
+        cwd=cwd,
+    ).strip()
+
+
+def _create_commit(
+    repo: pathlib.Path,
+    filename: str,
+    content: str,
+    message: str,
+) -> tuple[str, str | None]:
+    (repo / filename).write_text(content)
+    _run_git("add", filename, cwd=repo)
+    _run_git("commit", "-m", message, cwd=repo)
+    sha = _run_git("rev-parse", "HEAD", cwd=repo)
+    body = _run_git("log", "-1", "--format=%b", "HEAD", cwd=repo)
+    change_id_match = re.search(r"Change-Id: (I[0-9a-z]{40})", body)
+    return sha, change_id_match.group(1) if change_id_match else None
+
+
+def _get_commit_subjects(repo: pathlib.Path, n: int = 10) -> list[str]:
+    raw = _run_git(
+        "log",
+        "--reverse",
+        f"-{n}",
+        "--format=%s",
+        cwd=repo,
+    )
+    return [line for line in raw.splitlines() if line.strip()]
+
+
+def _get_head_message(repo: pathlib.Path, sha: str = "HEAD") -> str:
+    return _run_git("log", "-1", "--format=%B", sha, cwd=repo).strip()
+
+
+def _setup_tracking(repo: pathlib.Path) -> None:
+    origin_path = repo.parent / f"{repo.name}_origin.git"
+    _run_git("init", "--bare", str(origin_path))
+    _run_git("remote", "add", "origin", str(origin_path), cwd=repo)
+    _run_git("push", "origin", "main", cwd=repo)
+    _run_git("branch", "--set-upstream-to=origin/main", cwd=repo)
+
+
+@pytest.fixture
+def stack_repo(
+    git_repo_with_hooks: pathlib.Path,
+) -> tuple[pathlib.Path, list[tuple[str, str | None]]]:
+    """Create a repo with 3 feature commits (A, B, C) on top of main."""
+    repo = git_repo_with_hooks
+
+    (repo / "init.txt").write_text("init")
+    _run_git("add", "init.txt", cwd=repo)
+    _run_git("commit", "-m", "Initial commit", cwd=repo)
+
+    _setup_tracking(repo)
+
+    _run_git("checkout", "-b", "feature", "main", cwd=repo)
+    _run_git("branch", "--set-upstream-to=origin/main", cwd=repo)
+
+    commits = []
+    for label, filename in [("A", "a.txt"), ("B", "b.txt"), ("C", "c.txt")]:
+        sha, cid = _create_commit(repo, filename, f"content {label}", f"Commit {label}")
+        commits.append((sha, cid))
+
+    return repo, commits
+
+
+class TestStackFixup:
+    async def test_fixup_single_into_parent(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """fixup B: B folds into A, A's message preserved, C unchanged."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_b = commits[1][0][:12]
+
+        await stack_fixup([sha_b], dry_run=False)
+
+        subjects = _get_commit_subjects(repo)
+        feature_subjects = [s for s in subjects if s.startswith("Commit")]
+        assert feature_subjects == ["Commit A", "Commit C"]
+
+        # Verify both files are present (B's content was preserved)
+        assert (repo / "a.txt").exists()
+        assert (repo / "b.txt").exists()
+        assert (repo / "c.txt").exists()


### PR DESCRIPTION
Folds a listed commit into its parent inside the stack, dropping the
commit's message. Uses the new run_action_rebase helper.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Depends-On: #1252