### PR TITLE
feat(stack): add stack_squash with fixup-action default

### DIFF
--- a/mergify_cli/stack/squash.py
+++ b/mergify_cli/stack/squash.py
@@ -85,5 +85,57 @@ async def stack_squash(
     message: str | None,
     dry_run: bool,
 ) -> None:
-    # Placeholder — implemented in a later task.
-    raise NotImplementedError
+    os.chdir(await utils.git("rev-parse", "--show-toplevel"))
+    trunk = await utils.get_trunk()
+    base = await utils.git("merge-base", trunk, "HEAD")
+    commits = get_stack_commits(base)
+
+    if not commits:
+        console.print("No commits in the stack", style="green")
+        return
+
+    target = match_commit(target_prefix, commits)
+    srcs = [match_commit(p, commits) for p in src_prefixes]
+
+    # Validate: TARGET not among SRCs
+    if any(s[0] == target[0] for s in srcs):
+        console_error("a source commit cannot be the same as the target")
+        sys.exit(ExitCode.INVALID_STATE)
+
+    # Validate: no duplicate SRCs
+    src_shas = [s[0] for s in srcs]
+    if len(set(src_shas)) != len(src_shas):
+        seen: set[str] = set()
+        for prefix, sha in zip(src_prefixes, src_shas, strict=True):
+            if sha in seen:
+                console_error(
+                    f"duplicate — source prefix '{prefix}' resolves to the same commit as another",
+                )
+                sys.exit(ExitCode.INVALID_STATE)
+            seen.add(sha)
+
+    # Build new order: keep non-SRCs in original order; re-insert SRCs
+    # immediately after TARGET in the listed order.
+    src_sha_set = set(src_shas)
+    new_order: list[tuple[str, str, str]] = []
+    for commit in commits:
+        if commit[0] in src_sha_set:
+            continue
+        new_order.append(commit)
+        if commit[0] == target[0]:
+            new_order.extend(srcs)
+
+    # Action: SRCs are "fixup" when message is None (keeps TARGET's message),
+    # else "squash" (GIT_EDITOR writes the custom message).
+    action = "fixup" if message is None else "squash"
+    actions = dict.fromkeys(src_shas, action)
+
+    display_action_plan("Squash plan:", new_order, actions)
+
+    if dry_run:
+        console.print("Dry run — no changes made", style="green")
+        return
+
+    new_shas = [c[0] for c in new_order]
+    run_action_rebase(base, new_shas, actions, commit_message=message)
+    console.print("Commits squashed successfully.", style="green")

--- a/mergify_cli/tests/stack/test_squash.py
+++ b/mergify_cli/tests/stack/test_squash.py
@@ -24,6 +24,7 @@ import pytest
 
 from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack.squash import stack_fixup
+from mergify_cli.stack.squash import stack_squash
 
 
 if TYPE_CHECKING:
@@ -224,3 +225,34 @@ class TestStackFixup:
         await stack_fixup([cid_b[:8]], dry_run=False)
         feature = [s for s in _get_commit_subjects(repo) if s.startswith("Commit")]
         assert feature == ["Commit A", "Commit C"]
+
+
+class TestStackSquash:
+    async def test_squash_single_into_target_no_message(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """squash C into A (no -m): C folds into A keeping A's message."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_a = commits[0][0][:12]
+        sha_c = commits[2][0][:12]
+
+        await stack_squash(
+            src_prefixes=[sha_c],
+            target_prefix=sha_a,
+            message=None,
+            dry_run=False,
+        )
+
+        feature = [s for s in _get_commit_subjects(repo) if s.startswith("Commit")]
+        # C was reordered adjacent to A, then folded in; B stays where it was.
+        assert feature == ["Commit A", "Commit B"]
+        # All content preserved
+        assert (repo / "a.txt").exists()
+        assert (repo / "b.txt").exists()
+        assert (repo / "c.txt").exists()
+        # Message at A's position is still "Commit A"
+        log = _run_git("log", "--format=%s", cwd=repo).splitlines()
+        assert "Commit A" in log


### PR DESCRIPTION
Reorders source commits adjacent to the target and folds them in.
Without -m, uses the fixup action so the target's message wins.

Depends-On: #1254