### PR TITLE
feat(stack): add mergify stack fixup command

### DIFF
--- a/mergify_cli/stack/cli.py
+++ b/mergify_cli/stack/cli.py
@@ -20,6 +20,7 @@ from mergify_cli.stack import open as stack_open_mod
 from mergify_cli.stack import push as stack_push_mod
 from mergify_cli.stack import reorder as stack_reorder_mod
 from mergify_cli.stack import setup as stack_setup_mod
+from mergify_cli.stack import squash as stack_squash_mod
 from mergify_cli.stack import sync as stack_sync_mod
 
 
@@ -566,3 +567,17 @@ async def open_cmd(
         token=ctx.obj["token"],
         commit=commit,
     )
+
+
+@stack.command(help="Fixup commits into their parent (drops their messages)")
+@click.argument("commits", nargs=-1, required=True)
+@click.option(
+    "--dry-run",
+    "-n",
+    is_flag=True,
+    default=False,
+    help="Show the plan without rebasing",
+)
+@utils.run_with_asyncio
+async def fixup(*, commits: tuple[str, ...], dry_run: bool) -> None:
+    await stack_squash_mod.stack_fixup(list(commits), dry_run=dry_run)

--- a/mergify_cli/stack/reorder.py
+++ b/mergify_cli/stack/reorder.py
@@ -94,8 +94,8 @@ def run_scripted_rebase(base: str, script_content: str) -> None:
     """Run ``git rebase -i`` with a custom sequence-editor script.
 
     Writes *script_content* to a temporary Python file, sets it as
-    ``GIT_SEQUENCE_EDITOR``, then executes the rebase.  The temp file
-    is cleaned up afterwards regardless of outcome.
+    ``GIT_SEQUENCE_EDITOR``, then executes the rebase. The temp file
+    is cleaned up regardless of outcome.
     """
     tmp_fd, tmp_path = tempfile.mkstemp(suffix=".py", prefix="mergify_rebase_")
     try:
@@ -130,10 +130,37 @@ def run_scripted_rebase(base: str, script_content: str) -> None:
 
 def run_rebase(base: str, ordered_shas: list[str]) -> None:
     """Run ``git rebase -i`` reordering picks to match *ordered_shas*."""
+    run_action_rebase(base, ordered_shas, {})
+
+
+def run_action_rebase(
+    base: str,
+    ordered_shas: list[str],
+    actions: dict[str, str],
+    exec_after_sha: str | None = None,
+    exec_command: str | None = None,
+) -> None:
+    """Run ``git rebase -i`` reordering picks and changing their action.
+
+    *ordered_shas* is the desired full order (as in ``run_rebase``).
+
+    *actions* maps sha -> action string (``"fixup"`` is the expected
+    value for stack_squash/stack_fixup). Each listed sha has its
+    ``pick`` replaced by the given action. Shas not in *actions* stay
+    as ``pick``.
+
+    If *exec_after_sha* and *exec_command* are both provided, an
+    ``exec <exec_command>`` line is inserted right after the row for
+    *exec_after_sha*. Used by squash to amend the combined commit's
+    message while HEAD still points at it.
+    """
     script_content = (
         "#!/usr/bin/env python3\n"
         "import sys\n"
         "order = " + repr(ordered_shas) + "\n"
+        "actions = " + repr(actions) + "\n"
+        "exec_after_sha = " + repr(exec_after_sha) + "\n"
+        "exec_command = " + repr(exec_command) + "\n"
         "todo_path = sys.argv[1]\n"
         "with open(todo_path) as f:\n"
         "    lines = f.readlines()\n"
@@ -151,10 +178,26 @@ def run_rebase(base: str, ordered_shas: list[str]) -> None:
         "        other_lines.append(line)\n"
         "reordered = []\n"
         "for sha in order:\n"
-        "    for key in pick_lines:\n"
+        "    matched = False\n"
+        "    for key, line in pick_lines.items():\n"
         "        if sha.startswith(key) or key.startswith(sha):\n"
-        "            reordered.append(pick_lines[key])\n"
+        "            matched = True\n"
+        "            action = None\n"
+        "            for act_sha, act in actions.items():\n"
+        "                if sha.startswith(act_sha) or act_sha.startswith(sha):\n"
+        "                    action = act\n"
+        "                    break\n"
+        "            if action is not None:\n"
+        "                _parts = line.split(None, 1)\n"
+        "                rest = _parts[1] if len(_parts) > 1 else ''\n"
+        "                line = action + ' ' + rest\n"
+        "            reordered.append(line)\n"
+        "            if exec_after_sha is not None and exec_command is not None:\n"
+        "                if sha.startswith(exec_after_sha) or exec_after_sha.startswith(sha):\n"
+        "                    reordered.append('exec ' + exec_command + '\\n')\n"
         "            break\n"
+        "    if not matched:\n"
+        "        raise SystemExit('no rebase-todo line matches sha ' + sha)\n"
         "with open(todo_path, 'w') as f:\n"
         "    f.writelines(reordered + other_lines)\n"
     )
@@ -170,6 +213,23 @@ def display_plan(
     for idx, (sha, subject, change_id) in enumerate(commits, 1):
         cid_display = f" ({change_id[:12]})" if change_id else ""
         console.log(f"  {idx}. {sha[:12]} {subject}{cid_display}")
+
+
+def display_action_plan(
+    title: str,
+    commits: list[tuple[str, str, str]],
+    actions: dict[str, str],
+) -> None:
+    """Print the planned commit order, tagging rows with their action."""
+    console.log(title)
+    for idx, (sha, subject, change_id) in enumerate(commits, 1):
+        cid_display = f" ({change_id[:12]})" if change_id else ""
+        tag = ""
+        for act_sha, act in actions.items():
+            if sha.startswith(act_sha) or act_sha.startswith(sha):
+                tag = f" [{act}]"
+                break
+        console.log(f"  {idx}. {sha[:12]} {subject}{cid_display}{tag}")
 
 
 async def stack_reorder(

--- a/mergify_cli/stack/squash.py
+++ b/mergify_cli/stack/squash.py
@@ -1,0 +1,89 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import os
+import sys
+
+from mergify_cli import console
+from mergify_cli import console_error
+from mergify_cli import utils
+from mergify_cli.exit_codes import ExitCode
+from mergify_cli.stack.reorder import display_action_plan
+from mergify_cli.stack.reorder import get_stack_commits
+from mergify_cli.stack.reorder import match_commit
+from mergify_cli.stack.reorder import run_action_rebase
+
+
+async def stack_fixup(
+    commit_prefixes: list[str],
+    *,
+    dry_run: bool,
+) -> None:
+    os.chdir(await utils.git("rev-parse", "--show-toplevel"))
+    trunk = await utils.get_trunk()
+    base = await utils.git("merge-base", trunk, "HEAD")
+    commits = get_stack_commits(base)
+
+    if not commits:
+        console.print("No commits in the stack", style="green")
+        return
+
+    matched = [match_commit(p, commits) for p in commit_prefixes]
+
+    # Check for duplicates
+    matched_shas = [c[0] for c in matched]
+    if len(set(matched_shas)) != len(matched_shas):
+        seen: set[str] = set()
+        for prefix, sha in zip(commit_prefixes, matched_shas, strict=True):
+            if sha in seen:
+                console_error(
+                    f"duplicate — prefix '{prefix}' resolves to the same commit as another prefix",
+                )
+                sys.exit(ExitCode.INVALID_STATE)
+            seen.add(sha)
+
+    # Each listed commit must have a parent inside the stack (not the first)
+    first_sha = commits[0][0]
+    for sha in matched_shas:
+        if sha == first_sha:
+            console_error(
+                "cannot fixup the first commit of the stack — no parent in stack",
+            )
+            sys.exit(ExitCode.INVALID_STATE)
+
+    actions = dict.fromkeys(matched_shas, "fixup")
+    current_shas = [c[0] for c in commits]
+
+    display_action_plan("Fixup plan:", commits, actions)
+
+    if dry_run:
+        console.print("Dry run — no changes made", style="green")
+        return
+
+    run_action_rebase(base, current_shas, actions)
+    console.print("Commits squashed successfully.", style="green")
+
+
+async def stack_squash(
+    src_prefixes: list[str],
+    target_prefix: str,
+    *,
+    message: str | None,
+    dry_run: bool,
+) -> None:
+    # Placeholder — implemented in a later task.
+    raise NotImplementedError

--- a/mergify_cli/tests/stack/test_squash.py
+++ b/mergify_cli/tests/stack/test_squash.py
@@ -1,0 +1,226 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergify_cli.exit_codes import ExitCode
+from mergify_cli.stack.squash import stack_fixup
+
+
+if TYPE_CHECKING:
+    import pathlib
+
+
+def _run_git(*args: str, cwd: pathlib.Path | None = None) -> str:
+    return subprocess.check_output(
+        ["git", *args],
+        text=True,
+        cwd=cwd,
+    ).strip()
+
+
+def _create_commit(
+    repo: pathlib.Path,
+    filename: str,
+    content: str,
+    message: str,
+) -> tuple[str, str | None]:
+    (repo / filename).write_text(content)
+    _run_git("add", filename, cwd=repo)
+    _run_git("commit", "-m", message, cwd=repo)
+    sha = _run_git("rev-parse", "HEAD", cwd=repo)
+    body = _run_git("log", "-1", "--format=%b", "HEAD", cwd=repo)
+    change_id_match = re.search(r"Change-Id: (I[0-9a-z]{40})", body)
+    return sha, change_id_match.group(1) if change_id_match else None
+
+
+def _get_commit_subjects(repo: pathlib.Path, n: int = 10) -> list[str]:
+    raw = _run_git(
+        "log",
+        "--reverse",
+        f"-{n}",
+        "--format=%s",
+        cwd=repo,
+    )
+    return [line for line in raw.splitlines() if line.strip()]
+
+
+def _get_head_message(repo: pathlib.Path, sha: str = "HEAD") -> str:
+    return _run_git("log", "-1", "--format=%B", sha, cwd=repo).strip()
+
+
+def _setup_tracking(repo: pathlib.Path) -> None:
+    origin_path = repo.parent / f"{repo.name}_origin.git"
+    _run_git("init", "--bare", str(origin_path))
+    _run_git("remote", "add", "origin", str(origin_path), cwd=repo)
+    _run_git("push", "origin", "main", cwd=repo)
+    _run_git("branch", "--set-upstream-to=origin/main", cwd=repo)
+
+
+@pytest.fixture
+def stack_repo(
+    git_repo_with_hooks: pathlib.Path,
+) -> tuple[pathlib.Path, list[tuple[str, str | None]]]:
+    """Create a repo with 3 feature commits (A, B, C) on top of main."""
+    repo = git_repo_with_hooks
+
+    (repo / "init.txt").write_text("init")
+    _run_git("add", "init.txt", cwd=repo)
+    _run_git("commit", "-m", "Initial commit", cwd=repo)
+
+    _setup_tracking(repo)
+
+    _run_git("checkout", "-b", "feature", "main", cwd=repo)
+    _run_git("branch", "--set-upstream-to=origin/main", cwd=repo)
+
+    commits = []
+    for label, filename in [("A", "a.txt"), ("B", "b.txt"), ("C", "c.txt")]:
+        sha, cid = _create_commit(repo, filename, f"content {label}", f"Commit {label}")
+        commits.append((sha, cid))
+
+    return repo, commits
+
+
+class TestStackFixup:
+    async def test_fixup_single_into_parent(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """fixup B: B folds into A, A's message preserved, C unchanged."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_b = commits[1][0][:12]
+
+        await stack_fixup([sha_b], dry_run=False)
+
+        subjects = _get_commit_subjects(repo)
+        feature_subjects = [s for s in subjects if s.startswith("Commit")]
+        assert feature_subjects == ["Commit A", "Commit C"]
+
+        # Verify both files are present (B's content was preserved)
+        assert (repo / "a.txt").exists()
+        assert (repo / "b.txt").exists()
+        assert (repo / "c.txt").exists()
+
+    async def test_fixup_multiple_into_parents(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """fixup B C: B folds into A, C folds into (now A+B); stack becomes [A]."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_b = commits[1][0][:12]
+        sha_c = commits[2][0][:12]
+
+        await stack_fixup([sha_b, sha_c], dry_run=False)
+
+        feature = [s for s in _get_commit_subjects(repo) if s.startswith("Commit")]
+        assert feature == ["Commit A"]
+        assert (repo / "a.txt").exists()
+        assert (repo / "b.txt").exists()
+        assert (repo / "c.txt").exists()
+
+    async def test_fixup_first_commit_errors(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """fixup A (the first stack commit) must error — no parent in stack."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_a = commits[0][0][:12]
+
+        with pytest.raises(SystemExit) as exc_info:
+            await stack_fixup([sha_a], dry_run=False)
+        assert exc_info.value.code == ExitCode.INVALID_STATE
+
+    async def test_fixup_unknown_prefix_errors(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        repo, _commits = stack_repo
+        os.chdir(repo)
+
+        with pytest.raises(SystemExit) as exc_info:
+            await stack_fixup(["deadbeef"], dry_run=False)
+        assert exc_info.value.code == ExitCode.STACK_NOT_FOUND
+
+    async def test_fixup_duplicate_prefix_errors(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_b = commits[1][0][:12]
+
+        with pytest.raises(SystemExit) as exc_info:
+            await stack_fixup([sha_b, sha_b], dry_run=False)
+        assert exc_info.value.code == ExitCode.INVALID_STATE
+
+    async def test_fixup_dry_run(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        head_before = _run_git("rev-parse", "HEAD", cwd=repo)
+
+        sha_b = commits[1][0][:12]
+        await stack_fixup([sha_b], dry_run=True)
+
+        head_after = _run_git("rev-parse", "HEAD", cwd=repo)
+        assert head_before == head_after
+
+    async def test_fixup_empty_stack(
+        self,
+        git_repo_with_hooks: pathlib.Path,
+    ) -> None:
+        repo = git_repo_with_hooks
+        (repo / "init.txt").write_text("init")
+        _run_git("add", "init.txt", cwd=repo)
+        _run_git("commit", "-m", "Initial commit", cwd=repo)
+        _setup_tracking(repo)
+        _run_git("checkout", "-b", "feature", "main", cwd=repo)
+        _run_git("branch", "--set-upstream-to=origin/main", cwd=repo)
+
+        os.chdir(repo)
+
+        # Should print no-op message and return without raising
+        await stack_fixup(["anything"], dry_run=False)
+
+    async def test_fixup_with_change_id(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        cid_b = commits[1][1]
+        assert cid_b is not None
+
+        await stack_fixup([cid_b[:8]], dry_run=False)
+        feature = [s for s in _get_commit_subjects(repo) if s.startswith("Commit")]
+        assert feature == ["Commit A", "Commit C"]

--- a/skills/mergify-stack/SKILL.md
+++ b/skills/mergify-stack/SKILL.md
@@ -22,6 +22,7 @@ A branch is a stack. Keep stacks short and focused:
 - **Fixes**: Use `git commit --amend` (never create new commits to fix issues)
 - **Mid-stack fixes**: Stash any local changes first (`git stash -u`), then use `git rebase -i` to edit the specific commit, amend it, continue rebase, then `mergify stack push`, then `git stash pop`
 - **Reordering**: Stash any local changes first (`git stash -u`), then use `mergify stack reorder` (list all commits in desired order) or `mergify stack move` (move a single commit) instead of manual `git rebase -i` — non-interactive and avoids `GIT_SEQUENCE_EDITOR` quoting issues
+- **Fixup**: Stash any local changes first (`git stash -u`), then use `mergify stack fixup <SHA>...` to fold a commit into its parent (drops the listed commit's message). Non-interactive — never use `git rebase -i` for this.
 - **Commit titles**: Follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `docs:`)
 - **PR title & body**: `mergify stack` copies the commit message title to the PR title and the commit message body to the PR body — so write commit messages as if they were PR descriptions. **Everything that should appear in the PR (ticket references, context, test plans) MUST go in the commit message.**
 - **Ticket references**: Include ticket/issue references (e.g., `MRGFY-1234`, `Fixes #123`) in the commit message body, not added separately to the PR.
@@ -38,6 +39,7 @@ A branch is a stack. Keep stacks short and focused:
 | `gh pr edit --title "..."` | Edit the commit message, then `mergify stack push` | PR title/body are overwritten from commit messages on every push |
 | `gh pr merge` or `gh pr close` | PR lifecycle is fully managed — do nothing | PR lifecycle is fully managed by the stack tool |
 | `git commit` on `main` | `mergify stack new <name>` first | `mergify stack push` will fail on the default branch |
+| `git rebase -i` to fixup a commit | `mergify stack fixup <SHA>` | Non-interactive — works inside LLM/agent sessions; no editor spawned |
 | Deferring lint fixes to a later commit | Include the fix in the commit that caused it | Each commit runs CI independently; later commits won't save earlier ones |
 | Rebase/reorder/checkout/sync with dirty worktree | `git stash -u` first, then `git stash pop` after | Uncommitted changes are lost or cause conflicts during these operations |
 
@@ -55,6 +57,8 @@ mergify stack move X first   # Move commit X to the top of the stack
 mergify stack move X last    # Move commit X to the bottom of the stack
 mergify stack move X before Y  # Move commit X before commit Y
 mergify stack move X after Y   # Move commit X after commit Y
+mergify stack fixup X              # Fold commit X into its parent (drops X's message)
+mergify stack fixup X Y Z          # Fold each into its parent (multi-fixup)
 ```
 
 Use `mergify stack checkout NAME` to check out a stack that exists on GitHub (e.g. a colleague's stack). NAME is the remote branch name of the stack. It fetches all stacked PRs, creates a local branch, and sets up tracking. Use `--branch` to override the local branch name.
@@ -88,6 +92,7 @@ git stash -u                # Stash tracked + untracked changes if any
 **Operations that require this check:**
 - `git rebase -i` (mid-stack fixes)
 - `mergify stack reorder` / `mergify stack move`
+- `mergify stack fixup`
 - `mergify stack checkout`
 - `mergify stack sync`
 - `mergify stack new` (switches to new branch)


### PR DESCRIPTION
Add "mergify stack fixup COMMIT..." which folds each listed commit into
its parent inside the stack (dropping its message) without opening an
editor. Multiple commits can be listed: each folds into its own parent.

Errors when a listed commit is first-in-stack, unknown, or duplicated.
Supports --dry-run.

Depends-On: #1264