### PR TITLE
feat(stack): add mergify stack squash command

### DIFF
--- a/mergify_cli/stack/cli.py
+++ b/mergify_cli/stack/cli.py
@@ -622,3 +622,54 @@ async def open_cmd(
 @utils.run_with_asyncio
 async def fixup(*, commits: tuple[str, ...], dry_run: bool) -> None:
     await stack_squash_mod.stack_fixup(list(commits), dry_run=dry_run)
+
+
+@stack.command(help="Squash commits into a target commit")
+@click.argument("tokens", nargs=-1, required=True)
+@click.option(
+    "-m",
+    "--message",
+    "message",
+    default=None,
+    help="Final commit message (required to rename; otherwise target's is kept)",
+)
+@click.option(
+    "--dry-run",
+    "-n",
+    is_flag=True,
+    default=False,
+    help="Show the plan without rebasing",
+)
+@utils.run_with_asyncio
+async def squash(
+    *,
+    tokens: tuple[str, ...],
+    message: str | None,
+    dry_run: bool,
+) -> None:
+    srcs, target = _parse_squash_tokens(tokens)
+    await stack_squash_mod.stack_squash(
+        src_prefixes=srcs,
+        target_prefix=target,
+        message=message,
+        dry_run=dry_run,
+    )
+
+
+def _parse_squash_tokens(tokens: tuple[str, ...]) -> tuple[list[str], str]:
+    """Parse ``SRC... into TARGET`` from a flat tuple of tokens.
+
+    Raises :class:`click.BadParameter` on shape errors.
+    """
+    into_positions = [i for i, t in enumerate(tokens) if t == "into"]
+    if len(into_positions) != 1:
+        msg = "squash requires exactly one 'into' keyword: SRC... into TARGET"
+        raise click.BadParameter(msg)
+    idx = into_positions[0]
+    srcs = list(tokens[:idx])
+    after = tokens[idx + 1 :]
+    if not srcs:
+        raise click.BadParameter("at least one source commit required before 'into'")
+    if len(after) != 1:
+        raise click.BadParameter("exactly one target commit required after 'into'")
+    return srcs, after[0]

--- a/mergify_cli/stack/squash.py
+++ b/mergify_cli/stack/squash.py
@@ -16,7 +16,10 @@
 from __future__ import annotations
 
 import os
+import pathlib
+import shlex
 import sys
+import tempfile
 
 from mergify_cli import console
 from mergify_cli import console_error
@@ -85,5 +88,79 @@ async def stack_squash(
     message: str | None,
     dry_run: bool,
 ) -> None:
-    # Placeholder — implemented in a later task.
-    raise NotImplementedError
+    os.chdir(await utils.git("rev-parse", "--show-toplevel"))
+    trunk = await utils.get_trunk()
+    base = await utils.git("merge-base", trunk, "HEAD")
+    commits = get_stack_commits(base)
+
+    if not commits:
+        console.print("No commits in the stack", style="green")
+        return
+
+    target = match_commit(target_prefix, commits)
+    srcs = [match_commit(p, commits) for p in src_prefixes]
+
+    # Validate: TARGET not among SRCs
+    if any(s[0] == target[0] for s in srcs):
+        console_error("a source commit cannot be the same as the target")
+        sys.exit(ExitCode.INVALID_STATE)
+
+    # Validate: no duplicate SRCs
+    src_shas = [s[0] for s in srcs]
+    if len(set(src_shas)) != len(src_shas):
+        seen: set[str] = set()
+        for prefix, sha in zip(src_prefixes, src_shas, strict=True):
+            if sha in seen:
+                console_error(
+                    f"duplicate — source prefix '{prefix}' resolves to the same commit as another",
+                )
+                sys.exit(ExitCode.INVALID_STATE)
+            seen.add(sha)
+
+    # Build new order: keep non-SRCs in original order; re-insert SRCs
+    # immediately after TARGET in the listed order.
+    src_sha_set = set(src_shas)
+    new_order: list[tuple[str, str, str]] = []
+    for commit in commits:
+        if commit[0] in src_sha_set:
+            continue
+        new_order.append(commit)
+        if commit[0] == target[0]:
+            new_order.extend(srcs)
+
+    # Always use the fixup action: it folds without opening an editor and
+    # preserves TARGET's message and Change-Id. A custom message, if
+    # requested, is applied via an `exec git commit --amend -F <file> ...`
+    # line inserted right after the last fixup — while HEAD still points
+    # at the combined target commit. The amend runs prepare-commit-msg so
+    # the Change-Id is re-attached. The message is passed via a temp
+    # file (not `-m "..."`) so multi-line messages survive embedding
+    # into a single rebase-todo line.
+    actions = dict.fromkeys(src_shas, "fixup")
+
+    display_action_plan("Squash plan:", new_order, actions)
+
+    if dry_run:
+        console.print("Dry run — no changes made", style="green")
+        return
+
+    new_shas = [c[0] for c in new_order]
+
+    if message is None:
+        run_action_rebase(base, new_shas, actions)
+    else:
+        msg_fd, msg_path = tempfile.mkstemp(suffix=".txt", prefix="mergify_squash_msg_")
+        try:
+            with os.fdopen(msg_fd, "w") as f:
+                f.write(message)
+            run_action_rebase(
+                base,
+                new_shas,
+                actions,
+                exec_after_sha=src_shas[-1],
+                exec_command=f"git commit --amend -F {shlex.quote(msg_path)}",
+            )
+        finally:
+            pathlib.Path(msg_path).unlink(missing_ok=True)
+
+    console.print("Commits squashed successfully.", style="green")

--- a/mergify_cli/tests/stack/test_squash.py
+++ b/mergify_cli/tests/stack/test_squash.py
@@ -24,6 +24,7 @@ import pytest
 
 from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack.squash import stack_fixup
+from mergify_cli.stack.squash import stack_squash
 
 
 if TYPE_CHECKING:
@@ -224,3 +225,272 @@ class TestStackFixup:
         await stack_fixup([cid_b[:8]], dry_run=False)
         feature = [s for s in _get_commit_subjects(repo) if s.startswith("Commit")]
         assert feature == ["Commit A", "Commit C"]
+
+
+class TestStackSquash:
+    async def test_squash_single_into_target_no_message(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """squash C into A (no -m): C folds into A keeping A's message."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_a = commits[0][0][:12]
+        sha_c = commits[2][0][:12]
+
+        await stack_squash(
+            src_prefixes=[sha_c],
+            target_prefix=sha_a,
+            message=None,
+            dry_run=False,
+        )
+
+        feature = [s for s in _get_commit_subjects(repo) if s.startswith("Commit")]
+        # C was reordered adjacent to A, then folded in; B stays where it was.
+        assert feature == ["Commit A", "Commit B"]
+        # All content preserved
+        assert (repo / "a.txt").exists()
+        assert (repo / "b.txt").exists()
+        assert (repo / "c.txt").exists()
+        # Message at A's position is still "Commit A"
+        log = _run_git("log", "--format=%s", cwd=repo).splitlines()
+        assert "Commit A" in log
+
+    async def test_squash_with_custom_message(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """squash C into A -m 'combined': final commit message is 'combined'."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_a = commits[0][0][:12]
+        sha_c = commits[2][0][:12]
+
+        await stack_squash(
+            src_prefixes=[sha_c],
+            target_prefix=sha_a,
+            message="feat: combined A+C",
+            dry_run=False,
+        )
+
+        feature = [
+            s for s in _get_commit_subjects(repo) if s.startswith(("Commit", "feat"))
+        ]
+        assert "feat: combined A+C" in feature
+        # Original "Commit A" title is gone — replaced by the custom one
+        assert "Commit A" not in feature
+
+    async def test_squash_with_multiline_message(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """Multi-line message survives the rebase-todo / exec indirection."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_a = commits[0][0][:12]
+        sha_c = commits[2][0][:12]
+
+        message = (
+            "feat: combined with body\n"
+            "\n"
+            "A body paragraph explaining the combined change.\n"
+            "Second line of the body with a 'single quote' and \"double\".\n"
+        )
+
+        await stack_squash(
+            src_prefixes=[sha_c],
+            target_prefix=sha_a,
+            message=message,
+            dry_run=False,
+        )
+
+        # The commit's full message should contain both the subject and body.
+        subjects = _get_commit_subjects(repo)
+        assert "feat: combined with body" in subjects
+        full_msg = _get_head_message(repo, "HEAD~1")
+        assert "A body paragraph explaining the combined change." in full_msg
+        assert "Second line of the body" in full_msg
+
+    async def test_squash_multiple_srcs_reordered(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """squash B C into A: B and C are folded into A; stack becomes [A]."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_a = commits[0][0][:12]
+        sha_b = commits[1][0][:12]
+        sha_c = commits[2][0][:12]
+
+        await stack_squash(
+            src_prefixes=[sha_b, sha_c],
+            target_prefix=sha_a,
+            message=None,
+            dry_run=False,
+        )
+
+        feature = [s for s in _get_commit_subjects(repo) if s.startswith("Commit")]
+        assert feature == ["Commit A"]
+        assert (repo / "a.txt").exists()
+        assert (repo / "b.txt").exists()
+        assert (repo / "c.txt").exists()
+
+    async def test_squash_reorder_preserves_non_srcs(
+        self,
+        git_repo_with_hooks: pathlib.Path,
+    ) -> None:
+        """A, B, C, D: squash D into A. Non-SRCs B, C keep original order."""
+        repo = git_repo_with_hooks
+        (repo / "init.txt").write_text("init")
+        _run_git("add", "init.txt", cwd=repo)
+        _run_git("commit", "-m", "Initial commit", cwd=repo)
+        _setup_tracking(repo)
+        _run_git("checkout", "-b", "feature", "main", cwd=repo)
+        _run_git("branch", "--set-upstream-to=origin/main", cwd=repo)
+
+        commits = []
+        for label, filename in [
+            ("A", "a.txt"),
+            ("B", "b.txt"),
+            ("C", "c.txt"),
+            ("D", "d.txt"),
+        ]:
+            sha, _cid = _create_commit(
+                repo,
+                filename,
+                f"content {label}",
+                f"Commit {label}",
+            )
+            commits.append(sha)
+
+        os.chdir(repo)
+        await stack_squash(
+            src_prefixes=[commits[3][:12]],
+            target_prefix=commits[0][:12],
+            message=None,
+            dry_run=False,
+        )
+
+        feature = [s for s in _get_commit_subjects(repo) if s.startswith("Commit")]
+        # A remains first; D folded into A; B and C keep original order.
+        assert feature == ["Commit A", "Commit B", "Commit C"]
+
+    async def test_squash_src_equals_target_errors(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_a = commits[0][0][:12]
+
+        with pytest.raises(SystemExit) as exc_info:
+            await stack_squash(
+                src_prefixes=[sha_a],
+                target_prefix=sha_a,
+                message=None,
+                dry_run=False,
+            )
+        assert exc_info.value.code == ExitCode.INVALID_STATE
+
+    async def test_squash_duplicate_srcs_errors(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_a = commits[0][0][:12]
+        sha_b = commits[1][0][:12]
+
+        with pytest.raises(SystemExit) as exc_info:
+            await stack_squash(
+                src_prefixes=[sha_b, sha_b],
+                target_prefix=sha_a,
+                message=None,
+                dry_run=False,
+            )
+        assert exc_info.value.code == ExitCode.INVALID_STATE
+
+    async def test_squash_unknown_src_errors(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_a = commits[0][0][:12]
+
+        with pytest.raises(SystemExit) as exc_info:
+            await stack_squash(
+                src_prefixes=["deadbeef"],
+                target_prefix=sha_a,
+                message=None,
+                dry_run=False,
+            )
+        assert exc_info.value.code == ExitCode.STACK_NOT_FOUND
+
+    async def test_squash_unknown_target_errors(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_b = commits[1][0][:12]
+
+        with pytest.raises(SystemExit) as exc_info:
+            await stack_squash(
+                src_prefixes=[sha_b],
+                target_prefix="deadbeef",
+                message=None,
+                dry_run=False,
+            )
+        assert exc_info.value.code == ExitCode.STACK_NOT_FOUND
+
+    async def test_squash_dry_run(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        head_before = _run_git("rev-parse", "HEAD", cwd=repo)
+
+        sha_a = commits[0][0][:12]
+        sha_c = commits[2][0][:12]
+
+        await stack_squash(
+            src_prefixes=[sha_c],
+            target_prefix=sha_a,
+            message=None,
+            dry_run=True,
+        )
+
+        head_after = _run_git("rev-parse", "HEAD", cwd=repo)
+        assert head_before == head_after
+
+    async def test_squash_empty_stack(
+        self,
+        git_repo_with_hooks: pathlib.Path,
+    ) -> None:
+        repo = git_repo_with_hooks
+        (repo / "init.txt").write_text("init")
+        _run_git("add", "init.txt", cwd=repo)
+        _run_git("commit", "-m", "Initial commit", cwd=repo)
+        _setup_tracking(repo)
+        _run_git("checkout", "-b", "feature", "main", cwd=repo)
+        _run_git("branch", "--set-upstream-to=origin/main", cwd=repo)
+
+        os.chdir(repo)
+
+        await stack_squash(
+            src_prefixes=["any"],
+            target_prefix="thing",
+            message=None,
+            dry_run=False,
+        )

--- a/mergify_cli/tests/stack/test_squash_cli.py
+++ b/mergify_cli/tests/stack/test_squash_cli.py
@@ -1,0 +1,53 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from mergify_cli.stack.cli import _parse_squash_tokens
+
+
+class TestParseSquashTokens:
+    def test_single_src(self) -> None:
+        srcs, target = _parse_squash_tokens(("A", "into", "X"))
+        assert srcs == ["A"]
+        assert target == "X"
+
+    def test_multiple_srcs(self) -> None:
+        srcs, target = _parse_squash_tokens(("A", "B", "C", "into", "X"))
+        assert srcs == ["A", "B", "C"]
+        assert target == "X"
+
+    def test_missing_into_errors(self) -> None:
+        with pytest.raises(click.BadParameter):
+            _parse_squash_tokens(("A", "B", "C", "X"))
+
+    def test_two_intos_errors(self) -> None:
+        with pytest.raises(click.BadParameter):
+            _parse_squash_tokens(("A", "into", "B", "into", "X"))
+
+    def test_no_srcs_errors(self) -> None:
+        with pytest.raises(click.BadParameter):
+            _parse_squash_tokens(("into", "X"))
+
+    def test_no_target_errors(self) -> None:
+        with pytest.raises(click.BadParameter):
+            _parse_squash_tokens(("A", "into"))
+
+    def test_multiple_targets_errors(self) -> None:
+        with pytest.raises(click.BadParameter):
+            _parse_squash_tokens(("A", "into", "X", "Y"))

--- a/skills/mergify-stack/SKILL.md
+++ b/skills/mergify-stack/SKILL.md
@@ -23,6 +23,7 @@ A branch is a stack. Keep stacks short and focused:
 - **Mid-stack fixes**: Stash any local changes first (`git stash -u`), then use `git rebase -i` to edit the specific commit, amend it, continue rebase, then `mergify stack push`, then `git stash pop`
 - **Reordering**: Stash any local changes first (`git stash -u`), then use `mergify stack reorder` (list all commits in desired order) or `mergify stack move` (move a single commit) instead of manual `git rebase -i` — non-interactive and avoids `GIT_SEQUENCE_EDITOR` quoting issues
 - **Fixup**: Stash any local changes first (`git stash -u`), then use `mergify stack fixup <SHA>...` to fold a commit into its parent (drops the listed commit's message). Non-interactive — never use `git rebase -i` for this.
+- **Squash**: Stash any local changes first (`git stash -u`), then use `mergify stack squash SRC... into TARGET [-m "msg"]` to combine multiple commits into one, with an optional custom message. Non-interactive — never use `git rebase -i` for this.
 - **Commit titles**: Follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `docs:`)
 - **PR title & body**: `mergify stack` copies the commit message title to the PR title and the commit message body to the PR body — so write commit messages as if they were PR descriptions. **Everything that should appear in the PR (ticket references, context, test plans) MUST go in the commit message.**
 - **Ticket references**: Include ticket/issue references (e.g., `MRGFY-1234`, `Fixes #123`) in the commit message body, not added separately to the PR.
@@ -40,6 +41,7 @@ A branch is a stack. Keep stacks short and focused:
 | `gh pr merge` or `gh pr close` | PR lifecycle is fully managed — do nothing | PR lifecycle is fully managed by the stack tool |
 | `git commit` on `main` | `mergify stack new <name>` first | `mergify stack push` will fail on the default branch |
 | `git rebase -i` to fixup a commit | `mergify stack fixup <SHA>` | Non-interactive — works inside LLM/agent sessions; no editor spawned |
+| `git rebase -i` to squash commits | `mergify stack squash A B into X [-m "..."]` | Non-interactive — works inside LLM/agent sessions; no editor spawned |
 | Deferring lint fixes to a later commit | Include the fix in the commit that caused it | Each commit runs CI independently; later commits won't save earlier ones |
 | Rebase/reorder/checkout/sync with dirty worktree | `git stash -u` first, then `git stash pop` after | Uncommitted changes are lost or cause conflicts during these operations |
 
@@ -59,6 +61,8 @@ mergify stack move X before Y  # Move commit X before commit Y
 mergify stack move X after Y   # Move commit X after commit Y
 mergify stack fixup X              # Fold commit X into its parent (drops X's message)
 mergify stack fixup X Y Z          # Fold each into its parent (multi-fixup)
+mergify stack squash X into Y      # Reorder X adjacent to Y, fold X into Y (keeps Y's message)
+mergify stack squash X Y into Z -m "msg"  # Fold X Y into Z with a custom message
 ```
 
 Use `mergify stack checkout NAME` to check out a stack that exists on GitHub (e.g. a colleague's stack). NAME is the remote branch name of the stack. It fetches all stacked PRs, creates a local branch, and sets up tracking. Use `--branch` to override the local branch name.
@@ -93,6 +97,7 @@ git stash -u                # Stash tracked + untracked changes if any
 - `git rebase -i` (mid-stack fixes)
 - `mergify stack reorder` / `mergify stack move`
 - `mergify stack fixup`
+- `mergify stack squash`
 - `mergify stack checkout`
 - `mergify stack sync`
 - `mergify stack new` (switches to new branch)


### PR DESCRIPTION
Add "mergify stack squash SRC... into TARGET [-m MESSAGE]" which reorders
SRC commits adjacent to TARGET and folds them in without opening an
editor. Without -m, TARGET's message is kept (via the fixup rebase
action). With -m, the rebase inserts an `exec git commit --amend -m ...`
line right after the last fixup source, which runs while HEAD still
points at the combined target — so prepare-commit-msg re-attaches the
Change-Id normally.

Errors when SRC == TARGET, when a SRC is duplicated, or when a SRC or
TARGET prefix is unknown. Supports --dry-run.

Click does not allow two positionals when one is variadic, so the CLI
takes a single tokens tuple and parses "SRC... into TARGET" manually
(_parse_squash_tokens); parser edge cases are covered by unit tests.

Also documents the squash command in skills/mergify-stack/SKILL.md.