### PR TITLE
feat(stack): add 'mergify stack note' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ the CLI handles creation, updates, rebasing, and synchronization.
 | `mergify stack list` | List commits and their associated PRs (with CI/review status) |
 | `mergify stack sync` | Fetch trunk, remove merged commits, rebase |
 | `mergify stack edit [COMMIT]` | Interactive edit of the stack history |
+| `mergify stack note [COMMIT]` | Attach a "why this commit was amended" note to a commit |
 | `mergify stack reorder C A B` | Reorder commits in the stack |
 | `mergify stack move X before Y` | Move a commit within the stack |
 | `mergify stack checkout` | Check out a stack from a remote repository |

--- a/mergify_cli/stack/cli.py
+++ b/mergify_cli/stack/cli.py
@@ -16,6 +16,7 @@ from mergify_cli.stack import edit as stack_edit_mod
 from mergify_cli.stack import list as stack_list_mod
 from mergify_cli.stack import move as stack_move_mod
 from mergify_cli.stack import new as stack_new_mod
+from mergify_cli.stack import note as stack_note_mod
 from mergify_cli.stack import open as stack_open_mod
 from mergify_cli.stack import push as stack_push_mod
 from mergify_cli.stack import reorder as stack_reorder_mod
@@ -200,6 +201,46 @@ async def setup(*, force: bool, check: bool) -> None:
 @utils.run_with_asyncio
 async def edit(*, commit: str | None) -> None:
     await stack_edit_mod.stack_edit(commit_prefix=commit)
+
+
+@stack.command(help="Attach a 'why was this commit amended' note to a commit")
+@click.argument("commit", required=False, default=None)
+@click.option(
+    "-m",
+    "--message",
+    "message",
+    default=None,
+    help="Note message. If omitted, opens $GIT_EDITOR.",
+)
+@click.option(
+    "--append",
+    "do_append",
+    is_flag=True,
+    help="Append to an existing note instead of replacing",
+)
+@click.option(
+    "--remove",
+    "do_remove",
+    is_flag=True,
+    help="Remove the note on the target commit",
+)
+@utils.run_with_asyncio
+async def note(
+    *,
+    commit: str | None,
+    message: str | None,
+    do_append: bool,
+    do_remove: bool,
+) -> None:
+    if do_remove and (message is not None or do_append):
+        msg = "--remove cannot be combined with --message or --append"
+        raise click.UsageError(msg)
+    await stack_note_mod.stack_note(
+        commit=commit,
+        message=message,
+        append=do_append,
+        remove=do_remove,
+    )
 
 
 @stack.command(help="Reorder the stack's commits")

--- a/mergify_cli/stack/note.py
+++ b/mergify_cli/stack/note.py
@@ -1,0 +1,138 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import os
+import pathlib
+import shlex
+import subprocess
+import sys
+import tempfile
+
+from mergify_cli import console
+from mergify_cli import console_error
+from mergify_cli import utils
+from mergify_cli.exit_codes import ExitCode
+from mergify_cli.stack.changes import is_change_id_prefix
+from mergify_cli.stack.reorder import get_stack_commits
+from mergify_cli.stack.reorder import match_commit
+
+
+NOTES_REF = "refs/notes/mergify/stack"
+
+_EDITOR_TEMPLATE = (
+    "\n# Why was this commit amended? Lines starting with # are ignored.\n"
+)
+
+
+def _read_note_from_editor() -> str:
+    """Open $GIT_EDITOR with a template, return the cleaned message."""
+    editor = (
+        os.environ.get("GIT_EDITOR")
+        or os.environ.get("VISUAL")
+        or os.environ.get("EDITOR")
+        or "vi"
+    )
+    with tempfile.NamedTemporaryFile(
+        "w",
+        suffix=".txt",
+        prefix="mergify_note_",
+        delete=False,
+        encoding="utf-8",
+    ) as f:
+        f.write(_EDITOR_TEMPLATE)
+        path = pathlib.Path(f.name)
+    try:
+        editor_parts = shlex.split(editor)
+        result = subprocess.run([*editor_parts, str(path)], check=False)  # noqa: S603
+        if result.returncode != 0:
+            msg = f"editor {editor!r} exited with status {result.returncode}"
+            raise RuntimeError(msg)
+        raw = path.read_text(encoding="utf-8")
+    finally:
+        path.unlink(missing_ok=True)
+    cleaned = "\n".join(
+        line for line in raw.splitlines() if not line.lstrip().startswith("#")
+    )
+    return cleaned.strip()
+
+
+async def _resolve_commit(commit: str | None) -> tuple[str, str]:
+    """Resolve *commit* (None, SHA, or Change-Id prefix) to (full_sha, subject)."""
+    if commit is None:
+        sha = await utils.git("rev-parse", "--verify", "HEAD^{commit}")  # noqa: RUF027
+        subject = await utils.git("log", "-1", "--format=%s", sha)
+        return sha, subject
+
+    if is_change_id_prefix(commit):
+        trunk = await utils.get_trunk()
+        base = await utils.git("merge-base", trunk, "HEAD")
+        commits = get_stack_commits(base)
+        sha, subject, _ = match_commit(commit, commits)
+        return sha, subject
+
+    sha = await utils.git("rev-parse", "--verify", f"{commit}^{{commit}}")
+    subject = await utils.git("log", "-1", "--format=%s", sha)
+    return sha, subject
+
+
+async def stack_note(
+    *,
+    commit: str | None,
+    message: str | None,
+    append: bool,
+    remove: bool,
+) -> None:
+    os.chdir(await utils.git("rev-parse", "--show-toplevel"))
+    sha, subject = await _resolve_commit(commit)
+
+    if remove:
+        try:
+            await utils.git("notes", f"--ref={NOTES_REF}", "show", sha)
+        except utils.CommandError:
+            console.print(f"No note on {sha[:12]} {subject}.")
+            return
+        await utils.git("notes", f"--ref={NOTES_REF}", "remove", sha)
+        console.print(f"Note removed from {sha[:12]} {subject}.")
+        return
+
+    if message is None:
+        message = _read_note_from_editor()
+
+    if not message or not message.strip():
+        console_error("note is empty, nothing attached.")
+        sys.exit(ExitCode.INVALID_STATE)
+    message = message.strip()
+
+    if append:
+        await utils.git(
+            "notes",
+            f"--ref={NOTES_REF}",
+            "append",
+            "-m",
+            message,
+            sha,
+        )
+    else:
+        await utils.git(
+            "notes",
+            f"--ref={NOTES_REF}",
+            "add",
+            "-f",
+            "-m",
+            message,
+            sha,
+        )
+    console.print(f"Note attached to {sha[:12]} {subject}.")

--- a/mergify_cli/stack/setup.py
+++ b/mergify_cli/stack/setup.py
@@ -194,6 +194,24 @@ async def get_hooks_status() -> dict[str, Any]:
     }
 
 
+async def _ensure_notes_display_ref() -> None:
+    """Configure ``notes.displayRef`` so ``git log`` shows mergify notes."""
+    desired = "refs/notes/mergify/*"
+    try:
+        current = await utils.git(
+            "config",
+            "--local",
+            "--get-all",
+            "notes.displayRef",
+        )
+        current_refs = current.splitlines()
+    except utils.CommandError:
+        current_refs = []
+    if desired not in current_refs:
+        await utils.git("config", "--local", "--add", "notes.displayRef", desired)
+        console.log(f"Added notes.displayRef = {desired}")
+
+
 async def stack_setup(*, force: bool = False) -> None:
     """Set up git hooks for the stack workflow.
 
@@ -204,6 +222,8 @@ async def stack_setup(*, force: bool = False) -> None:
 
     for hook_name in _get_git_hook_names():
         _install_git_hook(hooks_dir, hook_name, force=force)
+
+    await _ensure_notes_display_ref()
 
 
 async def ensure_hooks_updated() -> None:

--- a/mergify_cli/tests/stack/test_note.py
+++ b/mergify_cli/tests/stack/test_note.py
@@ -1,0 +1,292 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergify_cli.stack.note import NOTES_REF
+from mergify_cli.stack.note import stack_note
+
+
+if TYPE_CHECKING:
+    import pathlib
+
+
+def _run_git(*args: str, cwd: pathlib.Path | None = None) -> str:
+    return subprocess.check_output(
+        ["git", *args],
+        text=True,
+        cwd=cwd,
+    ).strip()
+
+
+@pytest.fixture
+def repo_with_commit(git_repo_with_hooks: pathlib.Path) -> pathlib.Path:
+    """A repo with one commit on main, cwd set to the repo."""
+    (git_repo_with_hooks / "file.txt").write_text("hello")
+    _run_git("add", "file.txt", cwd=git_repo_with_hooks)
+    _run_git("commit", "-m", "First commit", cwd=git_repo_with_hooks)
+    os.chdir(git_repo_with_hooks)
+    return git_repo_with_hooks
+
+
+class TestStackNote:
+    async def test_add_attaches_note_to_head(
+        self,
+        repo_with_commit: pathlib.Path,
+    ) -> None:
+        """`stack note -m MSG` attaches the note to HEAD in refs/notes/mergify."""
+        await stack_note(
+            commit=None,
+            message="fixed a typo",
+            append=False,
+            remove=False,
+        )
+
+        note_text = _run_git(
+            "notes",
+            f"--ref={NOTES_REF}",
+            "show",
+            "HEAD",
+            cwd=repo_with_commit,
+        )
+        assert note_text == "fixed a typo"
+
+    async def test_add_to_specific_sha(
+        self,
+        repo_with_commit: pathlib.Path,
+    ) -> None:
+        """`stack note SHA -m MSG` attaches the note to that SHA."""
+        # Make a second commit so HEAD differs from the target
+        (repo_with_commit / "file2.txt").write_text("world")
+        _run_git("add", "file2.txt", cwd=repo_with_commit)
+        _run_git("commit", "-m", "Second commit", cwd=repo_with_commit)
+        target_sha = _run_git("rev-parse", "HEAD~1", cwd=repo_with_commit)
+
+        await stack_note(
+            commit=target_sha[:10],
+            message="note for first",
+            append=False,
+            remove=False,
+        )
+
+        note_text = _run_git(
+            "notes",
+            f"--ref={NOTES_REF}",
+            "show",
+            target_sha,
+            cwd=repo_with_commit,
+        )
+        assert note_text == "note for first"
+
+    async def test_add_by_change_id_prefix(
+        self,
+        repo_with_commit: pathlib.Path,
+    ) -> None:
+        """`stack note <change-id-prefix>` resolves against stack commits."""
+        # Set upstream so get_trunk() works
+        origin_path = repo_with_commit.parent / f"{repo_with_commit.name}_origin.git"
+        _run_git("init", "--bare", str(origin_path))
+        _run_git("remote", "add", "origin", str(origin_path), cwd=repo_with_commit)
+        _run_git("push", "origin", "main", cwd=repo_with_commit)
+        _run_git("branch", "--set-upstream-to=origin/main", cwd=repo_with_commit)
+        _run_git("checkout", "-b", "feature", cwd=repo_with_commit)
+        _run_git("branch", "--set-upstream-to=origin/main", cwd=repo_with_commit)
+
+        # Hook adds Change-Id automatically
+        (repo_with_commit / "feat.txt").write_text("feat")
+        _run_git("add", "feat.txt", cwd=repo_with_commit)
+        _run_git("commit", "-m", "Feature commit", cwd=repo_with_commit)
+
+        body = _run_git("log", "-1", "--format=%b", cwd=repo_with_commit)
+        m = re.search(r"Change-Id: (I[0-9a-f]{40})", body)
+        assert m is not None, (
+            "commit-msg hook did not inject a Change-Id — "
+            "check git_repo_with_hooks fixture"
+        )
+        change_id = m.group(1)
+        target_sha = _run_git("rev-parse", "HEAD", cwd=repo_with_commit)
+
+        await stack_note(
+            commit=change_id[:9],
+            message="by change-id",
+            append=False,
+            remove=False,
+        )
+
+        note_text = _run_git(
+            "notes",
+            f"--ref={NOTES_REF}",
+            "show",
+            target_sha,
+            cwd=repo_with_commit,
+        )
+        assert note_text == "by change-id"
+
+    async def test_append_concatenates(
+        self,
+        repo_with_commit: pathlib.Path,
+    ) -> None:
+        """Second call with --append joins to the existing note with a blank line."""
+        await stack_note(commit=None, message="first line", append=False, remove=False)
+        await stack_note(commit=None, message="second line", append=True, remove=False)
+
+        note_text = _run_git(
+            "notes",
+            f"--ref={NOTES_REF}",
+            "show",
+            "HEAD",
+            cwd=repo_with_commit,
+        )
+        assert note_text == "first line\n\nsecond line"
+
+    async def test_replace_is_default(
+        self,
+        repo_with_commit: pathlib.Path,
+    ) -> None:
+        """Without --append, a second call replaces the existing note."""
+        await stack_note(commit=None, message="first", append=False, remove=False)
+        await stack_note(commit=None, message="second", append=False, remove=False)
+
+        note_text = _run_git(
+            "notes",
+            f"--ref={NOTES_REF}",
+            "show",
+            "HEAD",
+            cwd=repo_with_commit,
+        )
+        assert note_text == "second"
+
+    async def test_remove_deletes_note(
+        self,
+        repo_with_commit: pathlib.Path,
+    ) -> None:
+        """--remove deletes an existing note."""
+        await stack_note(commit=None, message="doomed", append=False, remove=False)
+        await stack_note(commit=None, message=None, append=False, remove=True)
+
+        # git notes show should exit non-zero when there is no note
+        result = subprocess.run(
+            ["git", "notes", f"--ref={NOTES_REF}", "show", "HEAD"],
+            cwd=repo_with_commit,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+
+    async def test_remove_is_idempotent(
+        self,
+        repo_with_commit: pathlib.Path,  # noqa: ARG002
+    ) -> None:
+        """--remove on a commit without a note exits 0 and prints a message."""
+        # Must not raise
+        await stack_note(commit=None, message=None, append=False, remove=True)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="fake editor uses .sh script")
+    async def test_editor_fallback_strips_comments(
+        self,
+        repo_with_commit: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """With no -m, opens $GIT_EDITOR with a template; comment lines are stripped."""
+        # Fake editor: replaces the file content with a user-provided message
+        # plus a comment line, simulating a user who wrote something and saved.
+        editor_script = repo_with_commit / "fake-editor.sh"
+        editor_script.write_text(
+            "#!/bin/sh\n"
+            'printf "real note text\\n# Why was this commit amended? Lines starting with # are ignored.\\n" > "$1"\n',
+        )
+        editor_script.chmod(0o755)
+        monkeypatch.setenv("GIT_EDITOR", str(editor_script))
+
+        await stack_note(commit=None, message=None, append=False, remove=False)
+
+        note_text = _run_git(
+            "notes",
+            f"--ref={NOTES_REF}",
+            "show",
+            "HEAD",
+            cwd=repo_with_commit,
+        )
+        assert note_text == "real note text"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="fake editor uses .sh script")
+    async def test_empty_message_rejected(
+        self,
+        repo_with_commit: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Editor returns only comment lines → sys.exit(1), no git call."""
+        from mergify_cli.exit_codes import ExitCode
+
+        editor_script = repo_with_commit / "empty-editor.sh"
+        editor_script.write_text(
+            '#!/bin/sh\nprintf "# only a comment\\n   \\n" > "$1"\n',
+        )
+        editor_script.chmod(0o755)
+        monkeypatch.setenv("GIT_EDITOR", str(editor_script))
+
+        with pytest.raises(SystemExit) as exc_info:
+            await stack_note(commit=None, message=None, append=False, remove=False)
+        assert exc_info.value.code == ExitCode.INVALID_STATE
+
+        # No note should have been written
+        result = subprocess.run(
+            ["git", "notes", f"--ref={NOTES_REF}", "show", "HEAD"],
+            cwd=repo_with_commit,
+            check=False,
+            capture_output=True,
+        )
+        assert result.returncode != 0
+
+    async def test_empty_inline_message_rejected(
+        self,
+        repo_with_commit: pathlib.Path,  # noqa: ARG002
+    ) -> None:
+        """Explicit empty -m is rejected too."""
+        from mergify_cli.exit_codes import ExitCode
+
+        with pytest.raises(SystemExit) as exc_info:
+            await stack_note(commit=None, message="   ", append=False, remove=False)
+        assert exc_info.value.code == ExitCode.INVALID_STATE
+
+    def test_cli_help_lists_note(self) -> None:
+        """`mergify stack note --help` lists the command."""
+        from click.testing import CliRunner
+
+        from mergify_cli.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["stack", "note", "--help"])
+        assert result.exit_code == 0
+        assert "note" in result.output.lower()
+
+    def test_cli_rejects_remove_with_message(self) -> None:
+        """`stack note --remove -m ...` fails with a clear usage error."""
+        from click.testing import CliRunner
+
+        from mergify_cli.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["stack", "note", "--remove", "-m", "x"])
+        assert result.exit_code != 0
+        assert "--remove cannot be combined" in result.output

--- a/mergify_cli/tests/stack/test_setup.py
+++ b/mergify_cli/tests/stack/test_setup.py
@@ -25,6 +25,13 @@ async def test_setup(
     hooks_dir = typing.cast("pathlib.Path", tmp_path) / ".git" / "hooks"
     hooks_dir.mkdir(parents=True)
     git_mock.mock("rev-parse", "--git-path", "hooks", output=str(hooks_dir))
+    git_mock.mock(
+        "config",
+        "--local",
+        "--get-all",
+        "notes.displayRef",
+        output="refs/notes/mergify/*",
+    )
     await setup.stack_setup()
 
     commit_msg_hook = hooks_dir / "commit-msg"
@@ -475,3 +482,36 @@ def test_duplicate_subject_gets_unique_change_ids(
         f"First:  {first_change_id}\n"
         f"Second: {second_change_id}"
     )
+
+
+async def test_setup_configures_notes_display_ref(
+    git_repo_with_hooks: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`stack setup` writes notes.displayRef = refs/notes/mergify once."""
+    monkeypatch.chdir(git_repo_with_hooks)
+    await setup.stack_setup()
+
+    value = subprocess.check_output(
+        ["git", "config", "--local", "--get", "notes.displayRef"],
+        text=True,
+        cwd=git_repo_with_hooks,
+    ).strip()
+    assert value == "refs/notes/mergify/*"
+
+
+async def test_setup_notes_display_ref_idempotent(
+    git_repo_with_hooks: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Running setup twice does not error and keeps the value."""
+    monkeypatch.chdir(git_repo_with_hooks)
+    await setup.stack_setup()
+    await setup.stack_setup()
+
+    value = subprocess.check_output(
+        ["git", "config", "--local", "--get", "notes.displayRef"],
+        text=True,
+        cwd=git_repo_with_hooks,
+    ).strip()
+    assert value == "refs/notes/mergify/*"


### PR DESCRIPTION
Attach free-text "why was this commit amended" notes to commits. Notes
live in refs/notes/mergify/stack, a dedicated leaf under the
refs/notes/mergify/ namespace (sibling to the MQ note refs). `mergify
stack setup` appends refs/notes/mergify/* to notes.displayRef so plain
`git log` shows all mergify notes (both stack and MQ) automatically.

Usage:

  mergify stack note [-m MESSAGE] [--append] [--remove] [COMMIT]

- COMMIT defaults to HEAD; accepts SHA prefix or Change-Id prefix.
- -m MESSAGE attaches the note inline; without it, $GIT_EDITOR opens
  with a template where comment lines (starting with #) are stripped.
- --append concatenates to an existing note.
- --remove deletes the note (idempotent).

This is the first of two PRs for the stack-notes feature. This PR adds
the command surface and local visibility via `git log`. A follow-up PR
pushes the notes ref to the remote and surfaces the reasons in the
revision-history PR comment.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>