### PR TITLE
feat(stack): push notes and surface reasons in revision history

### DIFF
--- a/mergify_cli/stack/changes.py
+++ b/mergify_cli/stack/changes.py
@@ -183,6 +183,7 @@ class LocalChange(Change):
     base_branch: str
     dest_branch: str
     action: ActionT
+    reason: str = ""
 
     @property
     def commit_short_sha(self) -> str:

--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -29,6 +29,7 @@ from mergify_cli import console_error
 from mergify_cli import utils
 from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack import changes
+from mergify_cli.stack.note import NOTES_REF
 
 
 if typing.TYPE_CHECKING:
@@ -72,11 +73,47 @@ def format_pull_description(
     return message + depends_on_header
 
 
+async def fetch_notes_ref(remote: str) -> bool:
+    """Fetch ``refs/notes/mergify/stack`` from *remote* when the local ref
+    does not already exist.
+
+    Returns True when the local ref is present (either pre-existing or
+    newly fetched) so a lease SHA is available for the subsequent push.
+    Returns False only on first push (ref absent both locally and remotely).
+
+    If the local ref already exists (e.g. from a prior ``stack note`` that
+    hasn't been pushed yet), the fetch is skipped to avoid clobbering
+    unpushed local notes. A divergent remote is then caught by the
+    ``--force-with-lease`` check at push time.
+    """
+    try:
+        await utils.git("rev-parse", "--verify", NOTES_REF)
+    except utils.CommandError:
+        pass
+    else:
+        # Local ref exists; don't overwrite.
+        return True
+
+    try:
+        await utils.git(
+            "fetch",
+            remote,
+            "--no-write-fetch-head",
+            f"{NOTES_REF}:{NOTES_REF}",
+        )
+    except utils.CommandError as exc:
+        if b"couldn't find remote ref" not in exc.stdout:
+            raise
+        return False
+    return True
+
+
 async def push_branches(
     remote: str,
     local_changes: list[changes.LocalChange],
     *,
     no_verify: bool = False,
+    notes_ref_fetched: bool = False,
 ) -> None:
     changes_to_push = [c for c in local_changes if c.action in {"create", "update"}]
     if not changes_to_push:
@@ -85,16 +122,24 @@ async def push_branches(
     lease_args: list[str] = []
     for c in changes_to_push:
         if c.action == "update":
-            # Explicit lease: reject push if the remote branch has moved
-            # since we last read it via the GitHub API.
             lease_args.append(
                 f"--force-with-lease=refs/heads/{c.dest_branch}:{c.pull_head_sha}",
             )
         else:
-            # New branch — no remote ref expected; force is sufficient.
             lease_args.append(f"--force-with-lease=refs/heads/{c.dest_branch}:")
 
+    notes_local_sha: str | None = None
+    try:
+        notes_local_sha = await utils.git("rev-parse", "--verify", NOTES_REF)
+    except utils.CommandError:
+        pass
+
+    if notes_local_sha is not None and notes_ref_fetched:
+        lease_args.append(f"--force-with-lease={NOTES_REF}:{notes_local_sha}")
+
     refspecs = [f"{c.commit_sha}:refs/heads/{c.dest_branch}" for c in changes_to_push]
+    if notes_local_sha is not None:
+        refspecs.append(f"+{NOTES_REF}:{NOTES_REF}")
 
     no_verify_args = ("--no-verify",) if no_verify else ()
     os.environ["MERGIFY_STACK_PUSH"] = "1"
@@ -109,6 +154,34 @@ async def push_branches(
         )
     finally:
         os.environ.pop("MERGIFY_STACK_PUSH", None)
+
+
+async def read_reasons(local_changes: list[changes.LocalChange]) -> None:
+    """Populate ``c.reason`` from ``refs/notes/mergify/stack`` for each
+    change in ``create`` or ``update`` state.
+
+    Commits without a note get an empty string. Unexpected git errors
+    (missing binary, permission failures, corrupted object store, …)
+    propagate to the caller so real problems surface instead of being
+    silently swallowed.
+    """
+
+    async def read_one(c: changes.LocalChange) -> None:
+        if c.action not in {"create", "update"}:
+            return
+        try:
+            c.reason = await utils.git(
+                "notes",
+                f"--ref={NOTES_REF}",
+                "show",
+                c.commit_sha,
+            )
+        except utils.CommandError as exc:
+            if b"no note found" not in exc.stdout:
+                raise
+            c.reason = ""
+
+    await asyncio.gather(*(read_one(c) for c in local_changes))
 
 
 async def _git_patch_id(sha: str) -> str:
@@ -333,6 +406,8 @@ async def stack_push(
         )
         sys.exit(ExitCode.STACK_NOT_FOUND)
 
+    notes_ref_fetched = await fetch_notes_ref(remote)
+
     async with utils.get_github_http_client(github_server, token) as client:
         with console.status("Retrieving latest pushed stacks"):
             remote_changes = await changes.get_remote_changes(
@@ -360,6 +435,8 @@ async def stack_push(
             # pull requests will need to be updated, so we can directly plan
             # them as "update" instead of "skip-up-to-date".
             planned_changes.replace_local_action(old="skip-up-to-date", new="update")
+
+        await read_reasons(planned_changes.locals)
 
         changes.display_plan(
             planned_changes,
@@ -393,7 +470,12 @@ async def stack_push(
                     )
 
         with console.status("Pushing stacked branches..."):
-            await push_branches(remote, planned_changes.locals, no_verify=no_verify)
+            await push_branches(
+                remote,
+                planned_changes.locals,
+                no_verify=no_verify,
+                notes_ref_fetched=notes_ref_fetched,
+            )
 
         console.log("Updating and/or creating stacked pull requests:", style="green")
 
@@ -500,6 +582,19 @@ class StackComment:
         ) or comment["body"].startswith(StackComment._STACK_COMMENT_OLD_HEADER)
 
 
+_MAX_REASON_LEN = 200
+
+
+def _escape_reason(reason: str) -> str:
+    """Escape a reason for a markdown table cell (no newlines, no pipes)."""
+    if not reason:
+        return ""
+    s = reason.replace("\\", "\\\\").replace("|", "\\|").replace("\n", "<br>")
+    if len(s) > _MAX_REASON_LEN:
+        s = s[: _MAX_REASON_LEN - 1] + "…"
+    return s
+
+
 @dataclasses.dataclass
 class _RevisionEntry:
     number: int
@@ -519,6 +614,8 @@ class _RevisionEntry:
         if self.timestamp is None:
             return None
         return self.timestamp.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    reason: str = ""
 
 
 @dataclasses.dataclass
@@ -556,10 +653,11 @@ class RevisionHistoryComment:
         new_sha: str,
         change_type: str,
         timestamp: datetime.datetime,
+        reason: str = "",
     ) -> RevisionHistoryComment:
         entries = [
             _RevisionEntry(1, "initial", None, old_sha, timestamp),
-            _RevisionEntry(2, change_type, old_sha, new_sha, timestamp),
+            _RevisionEntry(2, change_type, old_sha, new_sha, timestamp, reason=reason),
         ]
         return cls(
             github_server=github_server,
@@ -575,10 +673,18 @@ class RevisionHistoryComment:
         new_sha: str,
         change_type: str,
         timestamp: datetime.datetime,
+        reason: str = "",
     ) -> None:
         next_number = len(self.entries) + 1
         self.entries.append(
-            _RevisionEntry(next_number, change_type, old_sha, new_sha, timestamp),
+            _RevisionEntry(
+                next_number,
+                change_type,
+                old_sha,
+                new_sha,
+                timestamp,
+                reason=reason,
+            ),
         )
 
     def _render_entry(self, entry: _RevisionEntry) -> str:
@@ -587,9 +693,10 @@ class RevisionHistoryComment:
         else:
             url = self._compare_url(entry.old_sha, entry.new_sha)
             changes_cell = f"[`{entry.old_sha[:7]} \u2192 {entry.new_sha[:7]}`]({url})"
+        reason_cell = _escape_reason(entry.reason)
         return (
-            f"| {entry.number} | {entry.change_type} | {changes_cell} "
-            f"| {entry.timestamp_human} |"
+            f"| {entry.number} | {entry.change_type} | {changes_cell} | "
+            f"{reason_cell} | {entry.timestamp_human} |"
         )
 
     def _json_marker(self, pull_number: int) -> str:
@@ -603,6 +710,7 @@ class RevisionHistoryComment:
                     "old_sha": e.old_sha,
                     "new_sha": e.new_sha,
                     "timestamp_iso": e.timestamp_iso,
+                    "reason": e.reason,
                     "compare_url": (
                         None
                         if e.old_sha is None
@@ -621,8 +729,8 @@ class RevisionHistoryComment:
     def body(self, pull_number: int) -> str:
         lines = [
             self.REVISION_COMMENT_FIRST_LINE,
-            "| # | Type | Changes | Date |",
-            "|---|------|---------|------|",
+            "| # | Type | Changes | Reason | Date |",
+            "|---|------|---------|--------|------|",
         ]
         for i, entry in enumerate(self.entries):
             if i < len(self._raw_rows):
@@ -636,8 +744,11 @@ class RevisionHistoryComment:
         r"^<!-- mergify-revision-data: (?P<payload>\{.*\}) -->$",
     )
 
-    _ROW_RE: typing.ClassVar[re.Pattern[str]] = re.compile(
+    _ROW_RE_4: typing.ClassVar[re.Pattern[str]] = re.compile(
         r"^\| (\d+) \| (\w+) \| .+ \| (.+) \|$",
+    )
+    _ROW_RE_5: typing.ClassVar[re.Pattern[str]] = re.compile(
+        r"^\| (\d+) \| (\w+) \| .+ \| (.*) \| (.+) \|$",
     )
 
     @classmethod
@@ -656,20 +767,39 @@ class RevisionHistoryComment:
         raw_rows: list[str] = []
         marker_entries: list[typing.Any] | None = None
         for line in body.splitlines():
-            m = cls._ROW_RE.match(line)
-            if m:
-                number = int(m.group(1))
-                change_type = m.group(2)
-                timestamp_str = m.group(3).strip()
+            m5 = cls._ROW_RE_5.match(line)
+            if m5:
+                number = int(m5.group(1))
+                change_type = m5.group(2)
+                timestamp_str = m5.group(4).strip()
                 try:
-                    timestamp = datetime.datetime.strptime(
+                    parsed_timestamp: datetime.datetime | None = (
+                        datetime.datetime.strptime(
+                            timestamp_str,
+                            "%Y-%m-%d %H:%M UTC",
+                        ).replace(tzinfo=datetime.UTC)
+                    )
+                except ValueError:
+                    parsed_timestamp = None
+                entries.append(
+                    _RevisionEntry(number, change_type, None, "", parsed_timestamp),
+                )
+                raw_rows.append(line)
+                continue
+            m4 = cls._ROW_RE_4.match(line)
+            if m4:
+                number = int(m4.group(1))
+                change_type = m4.group(2)
+                timestamp_str = m4.group(3).strip()
+                try:
+                    parsed_timestamp = datetime.datetime.strptime(
                         timestamp_str,
                         "%Y-%m-%d %H:%M UTC",
                     ).replace(tzinfo=datetime.UTC)
                 except ValueError:
-                    timestamp = None
+                    parsed_timestamp = None
                 entries.append(
-                    _RevisionEntry(number, change_type, None, "", timestamp),
+                    _RevisionEntry(number, change_type, None, "", parsed_timestamp),
                 )
                 raw_rows.append(line)
                 continue
@@ -712,6 +842,9 @@ class RevisionHistoryComment:
                         pass
                 elif timestamp_iso is None:
                     entry.timestamp = None
+                reason = data.get("reason")
+                if isinstance(reason, str):
+                    entry.reason = reason
 
         return cls(
             github_server=github_server,
@@ -819,6 +952,7 @@ async def _update_revision_for_pull(
                         new_sha=new_sha,
                         change_type=change_type,
                         timestamp=timestamp,
+                        reason=change.reason,
                     )
                     new_body = parsed.body(pull_number)
                     if comment["body"] != new_body:
@@ -836,6 +970,7 @@ async def _update_revision_for_pull(
                     new_sha=new_sha,
                     change_type=change_type,
                     timestamp=timestamp,
+                    reason=change.reason,
                 )
                 await client.patch(
                     comment["url"],
@@ -852,6 +987,7 @@ async def _update_revision_for_pull(
             new_sha=new_sha,
             change_type=change_type,
             timestamp=timestamp,
+            reason=change.reason,
         )
         await client.post(
             f"/repos/{user}/{repo}/issues/{pull_number}/comments",

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -109,8 +109,10 @@ async def test_stack_push_forwards_no_verify(
         "--atomic",
         "--no-verify",
         "--force-with-lease=refs/heads/current-branch/title-commit-1--29617d37:",
+        "--force-with-lease=refs/notes/mergify/stack:fake_notes_sha",
         "origin",
         "commit1_sha:refs/heads/current-branch/title-commit-1--29617d37",
+        "+refs/notes/mergify/stack:refs/notes/mergify/stack",
     )
 
 
@@ -127,6 +129,8 @@ async def test_push_branches_no_verify(git_mock: test_utils.GitMock) -> None:
             action="create",
         ),
     ]
+    # Local notes ref exists; notes_ref_fetched=False so no lease, but refspec included
+    git_mock.mock("rev-parse", "--verify", "refs/notes/mergify/stack", output="abc123")
     git_mock.mock(
         "push",
         "--atomic",
@@ -134,10 +138,16 @@ async def test_push_branches_no_verify(git_mock: test_utils.GitMock) -> None:
         "--force-with-lease=refs/heads/stack/title--29617d37:",
         "origin",
         "commit1_sha:refs/heads/stack/title--29617d37",
+        "+refs/notes/mergify/stack:refs/notes/mergify/stack",
         output="",
     )
 
-    await push.push_branches("origin", local_changes, no_verify=True)
+    await push.push_branches(
+        "origin",
+        local_changes,
+        no_verify=True,
+        notes_ref_fetched=False,
+    )
 
     assert git_mock.has_been_called_with(
         "push",
@@ -146,6 +156,7 @@ async def test_push_branches_no_verify(git_mock: test_utils.GitMock) -> None:
         "--force-with-lease=refs/heads/stack/title--29617d37:",
         "origin",
         "commit1_sha:refs/heads/stack/title--29617d37",
+        "+refs/notes/mergify/stack:refs/notes/mergify/stack",
     )
 
 
@@ -1125,6 +1136,7 @@ def test_revision_history_body_contains_json_marker() -> None:
                 "old_sha": None,
                 "new_sha": "abc1234567890abcdef1234567890abcdef123456",
                 "timestamp_iso": "2026-04-14T14:30:00Z",
+                "reason": "",
                 "compare_url": None,
             },
             {
@@ -1133,6 +1145,7 @@ def test_revision_history_body_contains_json_marker() -> None:
                 "old_sha": "abc1234567890abcdef1234567890abcdef123456",
                 "new_sha": "def5678901234567890abcdef1234567890abcdef",
                 "timestamp_iso": "2026-04-14T14:30:00Z",
+                "reason": "",
                 "compare_url": (
                     "https://github.com/owner/repo/compare/"
                     "abc1234567890abcdef1234567890abcdef123456..."
@@ -1773,6 +1786,160 @@ def test_revision_history_parse_without_json_marker_recovers_timestamp() -> None
     assert parsed.entries[1].timestamp_iso == "2026-04-14T14:30:00Z"
 
 
+def test_local_change_has_reason_default_empty() -> None:
+    """LocalChange exposes a .reason attribute defaulting to ''."""
+    c = changes.LocalChange(
+        id=changes.ChangeId("I29617d37762fd69809c255d7e7073cb11f8fbf50"),
+        pull=None,
+        commit_sha="abc",
+        title="t",
+        message="m",
+        base_branch="main",
+        dest_branch="stack/t--29617d37",
+        action="create",
+    )
+    assert not c.reason
+
+
+async def test_read_reasons_reads_notes_for_updated_changes(
+    git_mock: test_utils.GitMock,
+) -> None:
+    """read_reasons() fills LocalChange.reason from refs/notes/mergify/stack."""
+    from mergify_cli.stack.note import NOTES_REF
+
+    local_changes = [
+        changes.LocalChange(
+            id=changes.ChangeId("I1" + "a" * 39),
+            pull=None,
+            commit_sha="new1",
+            title="T1",
+            message="M",
+            base_branch="main",
+            dest_branch="stack/t1--deadbeef",
+            action="update",
+        ),
+        changes.LocalChange(
+            id=changes.ChangeId("I2" + "a" * 39),
+            pull=None,
+            commit_sha="new2",
+            title="T2",
+            message="M",
+            base_branch="main",
+            dest_branch="stack/t2--cafebabe",
+            action="update",
+        ),
+    ]
+    git_mock.mock(
+        "notes",
+        f"--ref={NOTES_REF}",
+        "show",
+        "new1",
+        output="reason one",
+    )
+    git_mock.mock(
+        "notes",
+        f"--ref={NOTES_REF}",
+        "show",
+        "new2",
+        output="",
+    )
+
+    await push.read_reasons(local_changes)
+
+    assert local_changes[0].reason == "reason one"
+
+
+def test_revision_history_comment_renders_reason_column() -> None:
+    """`body()` emits a 5-column table with a Reason cell."""
+    comment = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="abc1234567890abcdef1234567890abcdef123456",
+        new_sha="def5678901234567890abcdef1234567890abcdef",
+        change_type="content",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+        reason="fixed typo",
+    )
+    body = comment.body(pull_number=1)
+    assert "| # | Type | Changes | Reason | Date |" in body
+    # Row 2 has a reason, row 1 (initial) has an empty reason
+    assert "| 2 | content | " in body
+    assert "fixed typo" in body
+
+
+def test_revision_history_comment_escapes_reason() -> None:
+    """Newlines become `<br>` and pipes are backslash-escaped."""
+    comment = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="a" * 40,
+        new_sha="b" * 40,
+        change_type="content",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+        reason="line1\nline2 | pipe",
+    )
+    body = comment.body(pull_number=1)
+    assert "line1<br>line2 \\| pipe" in body
+
+
+def test_revision_history_comment_truncates_long_reason() -> None:
+    """Reasons over 200 chars are truncated with an ellipsis."""
+    reason = "x" * 250
+    comment = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="a" * 40,
+        new_sha="b" * 40,
+        change_type="content",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+        reason=reason,
+    )
+    body = comment.body(pull_number=1)
+    assert "x" * 199 + "…" in body
+
+
+def test_revision_history_comment_parse_legacy_4_column() -> None:
+    """Legacy (pre-reason) 4-column bodies parse and round-trip verbatim."""
+    legacy = (
+        "### Revision history\n"
+        "| # | Type | Changes | Date |\n"
+        "|---|------|---------|------|\n"
+        "| 1 | initial | `abc1234` | 2026-04-14 10:00 UTC |\n"
+        "| 2 | content | [`abc1234 \u2192 def5678`](https://github.com/owner/repo/compare/abc1234...def5678) | 2026-04-14 12:00 UTC |\n"
+    )
+    parsed = push.RevisionHistoryComment.parse(
+        legacy,
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+    )
+    assert parsed is not None
+    assert parsed.entries[0].old_sha is None
+    assert not parsed.entries[0].new_sha
+    assert parsed.entries[0].timestamp_iso == "2026-04-14T10:00:00Z"
+    assert parsed.entries[1].old_sha is None
+    assert not parsed.entries[1].new_sha
+    assert parsed.entries[1].timestamp_iso == "2026-04-14T12:00:00Z"
+    # Appending a new row with a reason must preserve legacy rows verbatim
+    parsed.append(
+        old_sha="def5678901234567890abcdef1234567890abcdef",
+        new_sha="abcdef01234567890abcdef01234567890abcdef0",
+        change_type="rebase",
+        timestamp=datetime.datetime(2026, 4, 15, 9, 10, tzinfo=datetime.UTC),
+        reason="rebased on main",
+    )
+    body = parsed.body(pull_number=1)
+    # Legacy rows unchanged
+    assert "| 1 | initial | `abc1234` | 2026-04-14 10:00 UTC |" in body
+    assert "| 2 | content | [`abc1234 \u2192 def5678`]" in body
+    # New row has the Reason column
+    assert "| 3 | rebase | " in body
+    assert "rebased on main" in body
+
+
 def test_revision_history_round_trip_preserves_full_data() -> None:
     original = push.RevisionHistoryComment.create_initial(
         github_server="https://api.github.com",
@@ -1795,6 +1962,7 @@ def test_revision_history_round_trip_preserves_full_data() -> None:
         new_sha="789abcdef01234567890abcdef01234567890abcd",
         change_type="rebase",
         timestamp=datetime.datetime(2026, 4, 15, 9, 10, tzinfo=datetime.UTC),
+        reason="",
     )
     new_body = parsed.body(pull_number=1)
 
@@ -1810,3 +1978,322 @@ def test_revision_history_round_trip_preserves_full_data() -> None:
     assert payload["entries"][0]["old_sha"] is None
     assert payload["entries"][1]["old_sha"] is not None
     assert payload["entries"][2]["old_sha"] is not None
+
+
+def test_revision_history_comment_parse_5_column() -> None:
+    """New 5-column bodies parse and round-trip."""
+    new_format = (
+        "### Revision history\n"
+        "| # | Type | Changes | Reason | Date |\n"
+        "|---|------|---------|--------|------|\n"
+        "| 1 | initial | `abc1234` |  | 2026-04-14 10:00 UTC |\n"
+        "| 2 | content | [`abc1234 \u2192 def5678`](https://github.com/o/r/compare/abc1234...def5678) | fixed typo | 2026-04-14 12:00 UTC |\n"
+    )
+    parsed = push.RevisionHistoryComment.parse(
+        new_format,
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+    )
+    assert parsed is not None
+    parsed.append(
+        old_sha="d" * 40,
+        new_sha="e" * 40,
+        change_type="rebase",
+        timestamp=datetime.datetime(2026, 4, 15, 9, 10, tzinfo=datetime.UTC),
+        reason="",
+    )
+    body = parsed.body(pull_number=1)
+    assert "| 3 | rebase |" in body
+    assert "fixed typo" in body  # row 2 preserved verbatim
+    assert "x" * 201 not in body
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_revision_comment_includes_reason_from_local_change(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    """When a commit has a reason, it appears in the new revision row."""
+    from mergify_cli.stack.note import NOTES_REF
+
+    git_mock.commit(
+        test_utils.Commit(
+            sha="third_sha",
+            title="Title",
+            message="Message",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            head_ref="current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize(
+        remote_shas={"I29617d37762fd69809c255d7e7073cb11f8fbf50": "second_sha"},
+    )
+    # Override the empty-note default with an actual note
+    git_mock.mock(
+        "notes",
+        f"--ref={NOTES_REF}",
+        "show",
+        "third_sha",
+        output="fixed typo in sql",
+    )
+    git_mock.mock("fetch", "origin", "refs/pull/123/head", output="")
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/123",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/123").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/123",
+            "number": "123",
+            "title": "Title",
+            "head": {
+                "sha": "second_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "body": "body",
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    respx_mock.patch("/repos/user/repo/pulls/123").respond(200, json={})
+    respx_mock.get("/repos/user/repo/issues/123/comments").respond(200, json=[])
+    post_comment_mock = respx_mock.post(
+        "/repos/user/repo/issues/123/comments",
+    ).respond(200, json={})
+
+    with mock.patch.object(push, "detect_change_type", return_value="content"):
+        await push.stack_push(
+            github_server="https://api.github.com/",
+            token="",
+            skip_rebase=False,
+            next_only=False,
+            branch_prefix="",
+            dry_run=False,
+            trunk=("origin", "main"),
+        )
+
+    # Find the POST that created the revision comment
+    revision_posts = [
+        json.loads(call.request.content)["body"]
+        for call in post_comment_mock.calls
+        if json.loads(call.request.content)["body"].startswith("### Revision history")
+    ]
+    assert revision_posts, "expected a revision-history comment to be POSTed"
+    body = revision_posts[0]
+    assert "| # | Type | Changes | Reason | Date |" in body
+    assert "fixed typo in sql" in body
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_stack_push_fetches_notes_ref(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    """`stack push` fetches refs/notes/mergify/stack before planning."""
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit1_sha",
+            title="Title commit 1",
+            message="Message commit 1",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(200, json={"items": []})
+    respx_mock.post("/repos/user/repo/pulls").respond(
+        200,
+        json={
+            "html_url": "https://github.com/repo/user/pull/1",
+            "number": "1",
+            "title": "Title commit 1",
+            "head": {"sha": "commit1_sha"},
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    respx_mock.get("/repos/user/repo/issues/1/comments").respond(200, json=[])
+
+    await push.stack_push(
+        github_server="https://api.github.com/",
+        token="",
+        skip_rebase=False,
+        next_only=False,
+        branch_prefix="",
+        dry_run=False,
+        trunk=("origin", "main"),
+    )
+
+    assert git_mock.has_been_called_with(
+        "fetch",
+        "origin",
+        "--no-write-fetch-head",
+        "refs/notes/mergify/stack:refs/notes/mergify/stack",
+    )
+
+
+async def test_fetch_notes_ref_skips_fetch_when_local_ref_exists(
+    git_mock: test_utils.GitMock,
+) -> None:
+    """fetch_notes_ref returns True without fetching when the local ref already exists."""
+    git_mock.mock("rev-parse", "--verify", "refs/notes/mergify/stack", output="abc123")
+
+    result = await push.fetch_notes_ref("origin")
+
+    assert result is True
+    assert not git_mock.has_been_called_with(
+        "fetch",
+        "origin",
+        "--no-write-fetch-head",
+        "refs/notes/mergify/stack:refs/notes/mergify/stack",
+    )
+
+
+async def test_push_branches_pushes_notes_ref_atomically(
+    git_mock: test_utils.GitMock,
+) -> None:
+    """push_branches includes `+refs/notes/mergify/stack:refs/notes/mergify/stack` in the push."""
+    local_changes = [
+        changes.LocalChange(
+            id=changes.ChangeId("I29617d37762fd69809c255d7e7073cb11f8fbf50"),
+            pull=None,
+            commit_sha="commit1_sha",
+            title="Title",
+            message="Message",
+            base_branch="main",
+            dest_branch="stack/title--29617d37",
+            action="create",
+        ),
+    ]
+    # Notes ref existed on remote before push (lease uses fetched SHA "deadbeef")
+    git_mock.mock(
+        "rev-parse",
+        "--verify",
+        "refs/notes/mergify/stack",
+        output="deadbeef",
+    )
+    git_mock.mock(
+        "push",
+        "--atomic",
+        "--force-with-lease=refs/heads/stack/title--29617d37:",
+        "--force-with-lease=refs/notes/mergify/stack:deadbeef",
+        "origin",
+        "commit1_sha:refs/heads/stack/title--29617d37",
+        "+refs/notes/mergify/stack:refs/notes/mergify/stack",
+        output="",
+    )
+
+    await push.push_branches("origin", local_changes, notes_ref_fetched=True)
+
+    assert git_mock.has_been_called_with(
+        "push",
+        "--atomic",
+        "--force-with-lease=refs/heads/stack/title--29617d37:",
+        "--force-with-lease=refs/notes/mergify/stack:deadbeef",
+        "origin",
+        "commit1_sha:refs/heads/stack/title--29617d37",
+        "+refs/notes/mergify/stack:refs/notes/mergify/stack",
+    )
+
+
+async def test_push_branches_first_push_omits_notes_lease(
+    git_mock: test_utils.GitMock,
+) -> None:
+    """When the notes ref was not on the remote, omit its lease."""
+    local_changes = [
+        changes.LocalChange(
+            id=changes.ChangeId("I29617d37762fd69809c255d7e7073cb11f8fbf50"),
+            pull=None,
+            commit_sha="commit1_sha",
+            title="Title",
+            message="Message",
+            base_branch="main",
+            dest_branch="stack/title--29617d37",
+            action="create",
+        ),
+    ]
+    # Local notes ref exists (abc123), but wasn't fetched from remote — no lease, but include refspec
+    git_mock.mock("rev-parse", "--verify", "refs/notes/mergify/stack", output="abc123")
+    git_mock.mock(
+        "push",
+        "--atomic",
+        "--force-with-lease=refs/heads/stack/title--29617d37:",
+        "origin",
+        "commit1_sha:refs/heads/stack/title--29617d37",
+        "+refs/notes/mergify/stack:refs/notes/mergify/stack",
+        output="",
+    )
+
+    await push.push_branches("origin", local_changes, notes_ref_fetched=False)
+
+    assert git_mock.has_been_called_with(
+        "push",
+        "--atomic",
+        "--force-with-lease=refs/heads/stack/title--29617d37:",
+        "origin",
+        "commit1_sha:refs/heads/stack/title--29617d37",
+        "+refs/notes/mergify/stack:refs/notes/mergify/stack",
+    )
+
+
+async def test_push_branches_skips_notes_when_local_ref_absent(
+    git_mock: test_utils.GitMock,
+) -> None:
+    """When the local notes ref does not exist, omit it from the push entirely."""
+    local_changes = [
+        changes.LocalChange(
+            id=changes.ChangeId("I29617d37762fd69809c255d7e7073cb11f8fbf50"),
+            pull=None,
+            commit_sha="commit1_sha",
+            title="Title",
+            message="Message",
+            base_branch="main",
+            dest_branch="stack/title--29617d37",
+            action="create",
+        ),
+    ]
+    # Local notes ref does not exist — rev-parse --verify raises CommandError
+    git_mock.mock_error("rev-parse", "--verify", "refs/notes/mergify/stack")
+    git_mock.mock(
+        "push",
+        "--atomic",
+        "--force-with-lease=refs/heads/stack/title--29617d37:",
+        "origin",
+        "commit1_sha:refs/heads/stack/title--29617d37",
+        output="",
+    )
+
+    await push.push_branches("origin", local_changes, notes_ref_fetched=False)
+
+    assert git_mock.has_been_called_with(
+        "push",
+        "--atomic",
+        "--force-with-lease=refs/heads/stack/title--29617d37:",
+        "origin",
+        "commit1_sha:refs/heads/stack/title--29617d37",
+    )
+    assert not git_mock.has_been_called_with(
+        "push",
+        "--atomic",
+        "--force-with-lease=refs/heads/stack/title--29617d37:",
+        "origin",
+        "commit1_sha:refs/heads/stack/title--29617d37",
+        "+refs/notes/mergify/stack:refs/notes/mergify/stack",
+    )

--- a/mergify_cli/tests/utils.py
+++ b/mergify_cli/tests/utils.py
@@ -70,16 +70,36 @@ class GitMock:
         init=False,
         default_factory=dict,
     )
+    _mocked_errors: list[tuple[str, ...]] = dataclasses.field(
+        init=False,
+        default_factory=list,
+    )
     _commits: list[Commit] = dataclasses.field(init=False, default_factory=list)
     _called: list[tuple[str, ...]] = dataclasses.field(init=False, default_factory=list)
 
     def mock(self, *args: str, output: str) -> None:
         self._mocked[args] = output
 
+    def mock_error(self, *args: str) -> None:
+        """Register a one-shot call that should raise CommandError.
+
+        Each registration is consumed once; registering the same args twice
+        means the first two calls raise and subsequent calls fall through to
+        ``_mocked`` (or "not mocked").
+        """
+        self._mocked_errors.append(args)
+
     def has_been_called_with(self, *args: str) -> bool:
         return args in self._called
 
     async def __call__(self, *args: str) -> str:
+        from mergify_cli import utils
+
+        if args in self._mocked_errors:
+            self._mocked_errors.remove(args)
+            self._called.append(args)
+            raise utils.CommandError(args, 128, b"")
+
         if args in self._mocked:
             self._called.append(args)
             return self._mocked[args]
@@ -108,6 +128,19 @@ class GitMock:
         remote_shas: dict[str, str] | None = None,
         no_verify: bool = False,
     ) -> None:
+        # Register the rev-parse --verify probe used by fetch_notes_ref
+        # (local ref absent → CommandError so the fetch is attempted)
+        self.mock_error("rev-parse", "--verify", "refs/notes/mergify/stack")
+
+        # Register the refs/notes/mergify fetch probe (no + since local ref absent)
+        self.mock(
+            "fetch",
+            "origin",
+            "--no-write-fetch-head",
+            "refs/notes/mergify/stack:refs/notes/mergify/stack",
+            output="",
+        )
+
         # Register batch log mock
         records = []
         for c in self._commits:
@@ -119,6 +152,24 @@ class GitMock:
             "--format=%H%x00%s%x00%b%x1e",
             "base_commit_sha..current-branch",
             output="\x1e".join(records) + "\x1e" if records else "",
+        )
+
+        # Register batch note-read mock (empty = "no note")
+        for c in self._commits:
+            self.mock(
+                "notes",
+                "--ref=refs/notes/mergify/stack",
+                "show",
+                c["sha"],
+                output="",
+            )
+
+        # Register notes rev-parse --verify (used to check if local ref exists)
+        self.mock(
+            "rev-parse",
+            "--verify",
+            "refs/notes/mergify/stack",
+            output="fake_notes_sha",
         )
 
         # Register batch push mock with explicit per-ref leases
@@ -142,13 +193,17 @@ class GitMock:
 
         no_verify_args: tuple[str, ...] = ("--no-verify",) if no_verify else ()
 
+        # notes_ref_fetched=True: lease uses the SHA from rev-parse --verify
+        notes_lease = "--force-with-lease=refs/notes/mergify/stack:fake_notes_sha"
         self.mock(
             "push",
             "--atomic",
             *no_verify_args,
             *lease_args,
+            notes_lease,
             "origin",
             *refspecs,
+            "+refs/notes/mergify/stack:refs/notes/mergify/stack",
             output="",
         )
 


### PR DESCRIPTION
Complete the stack-notes feature: fetch refs/notes/mergify from the
remote before planning, read the note attached to each updated commit
into LocalChange.reason, and push the ref atomically alongside the
stack branches with --force-with-lease.

The revision-history PR comment gains a new "Reason" column:

  | # | Type | Changes | Reason | Date |

The parser accepts both the legacy 4-column format and the new 5-column
format, preserving legacy rows verbatim so old comments aren't rewritten.

Reason cells escape pipes and newlines for markdown-table safety and
truncate at 200 characters. Error catches for the notes fetch and the
per-commit notes read are narrowed to the specific "ref/note not found"
cases so other failures (auth, network, corruption) still surface.

Depends-On: the preceding 'stack note' command PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>