### PR TITLE
feat(rust): add mergify-py-shim with embedded Python fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,597 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
 name = "mergify-cli"
 version = "0.0.0"
 dependencies = [
  "mergify-core",
+ "mergify-py-shim",
 ]
 
 [[package]]
 name = "mergify-core"
 version = "0.0.0"
+
+[[package]]
+name = "mergify-py-shim"
+version = "0.0.0"
+dependencies = [
+ "dirs",
+ "fs2",
+ "include_dir",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -1,15 +1,27 @@
 //! `mergify` binary entry point.
 //!
-//! This is the Phase 1.0 scaffolding stub: it prints an identification
-//! line and exits 0 so CI can verify the Rust toolchain, build, and
-//! release profile end-to-end. Subsequent phases replace this with the
-//! real clap-based dispatch that forwards commands to native Rust
-//! implementations or the embedded Python shim.
+//! In Phase 1.1 the binary is purely a wrapper: every command is
+//! handed off to [`mergify_py_shim::run`], which extracts the
+//! embedded Python source on first use and invokes
+//! `python3 -m mergify_cli`. From an external observer's view,
+//! running the Rust binary is indistinguishable from running the
+//! Python CLI directly.
+//!
+//! Phase 1.3+ will start intercepting specific subcommands (starting
+//! with `config validate`) and dispatch them to native Rust
+//! implementations, falling back to [`mergify_py_shim::run`] only
+//! for the commands that haven't been ported yet.
 
-fn main() {
-    println!(
-        "mergify {} — Rust scaffolding (Phase 1.0). \
-         Use the Python CLI for actual functionality.",
-        mergify_core::VERSION,
-    );
+use std::env;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().skip(1).collect();
+    match mergify_py_shim::run(&args) {
+        Ok(code) => ExitCode::from(u8::try_from(code).unwrap_or(1)),
+        Err(err) => {
+            eprintln!("mergify: {err}");
+            ExitCode::FAILURE
+        }
+    }
 }

--- a/crates/mergify-py-shim/Cargo.toml
+++ b/crates/mergify-py-shim/Cargo.toml
@@ -1,21 +1,22 @@
 [package]
-name = "mergify-cli"
+name = "mergify-py-shim"
 version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-description = "mergify CLI — Rust implementation."
+description = "Embedded Python fallback for un-ported mergify-cli commands."
 publish = false
 
-[[bin]]
-name = "mergify"
-path = "src/main.rs"
-
 [dependencies]
-mergify-core = { path = "../mergify-core" }
-mergify-py-shim = { path = "../mergify-py-shim" }
+dirs = "6.0"
+fs2 = "0.4"
+include_dir = "0.7"
+thiserror = "2.0"
+
+[dev-dependencies]
+tempfile = "3.14"
 
 [lints]
 workspace = true

--- a/crates/mergify-py-shim/src/lib.rs
+++ b/crates/mergify-py-shim/src/lib.rs
@@ -1,0 +1,298 @@
+//! Python shim for the mergify CLI Rust port.
+//!
+//! The current Python source is embedded at compile time via
+//! [`include_dir`]. On first invocation the shim extracts the
+//! embedded tree to a per-user cache directory (atomic, file-locked)
+//! and invokes `python3 -m mergify_cli` with that directory on
+//! `PYTHONPATH`. Args, stdin, stdout, stderr, and the exit code are
+//! passed through transparently.
+//!
+//! When a command is ported to native Rust in Phase 1.3+, the caller
+//! dispatches to the native implementation first and falls back to
+//! [`run`] only for un-ported commands. Phase 6 removes this crate
+//! entirely once the port is complete.
+//!
+//! The cache is keyed on `CARGO_PKG_VERSION`. During dev (`0.0.0`),
+//! that means the cache is shared across builds — if you change the
+//! embedded Python source while developing, clear
+//! `~/.cache/mergify/py/` to force a re-extract. The release
+//! pipeline in Phase 1.5 stamps a real version + git SHA, after
+//! which every build invalidates cleanly.
+
+use std::env;
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+
+use fs2::FileExt;
+use include_dir::Dir;
+use include_dir::DirEntry;
+use include_dir::include_dir;
+
+static PY_SOURCE: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/../../mergify_cli");
+
+/// Cache key under `~/.cache/mergify/py/`. Tied to the binary's
+/// build version so a new binary auto-invalidates any older extract.
+const CACHE_KEY: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(thiserror::Error, Debug)]
+pub enum ShimError {
+    #[error(
+        "python3 not found on PATH. mergify requires Python 3.13+ during the port; install it and try again"
+    )]
+    PythonNotFound,
+
+    #[error("could not locate user cache directory on this platform")]
+    CacheDirNotFound,
+
+    #[error("could not prepare embedded Python source at {path}: {source}")]
+    Extraction {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+
+    #[error("could not invoke python3: {0}")]
+    Invocation(#[source] io::Error),
+}
+
+/// Run the embedded Python CLI with the given argv tail.
+///
+/// Returns the exit code to propagate to the OS.
+pub fn run(args: &[String]) -> Result<i32, ShimError> {
+    let cache_base = cache_base()?;
+    let source_root = ensure_extracted(&cache_base)?;
+    invoke_python(&source_root, args)
+}
+
+fn cache_base() -> Result<PathBuf, ShimError> {
+    Ok(dirs::cache_dir()
+        .ok_or(ShimError::CacheDirNotFound)?
+        .join("mergify")
+        .join("py"))
+}
+
+/// Ensure the embedded Python source is present on disk under
+/// `<cache_base>/<CACHE_KEY>/` and return that directory (which
+/// contains a `mergify_cli/` subdirectory, ready for `PYTHONPATH`).
+fn ensure_extracted(cache_base: &Path) -> Result<PathBuf, ShimError> {
+    let target_dir = cache_base.join(CACHE_KEY);
+    let sentinel = target_dir.join(".complete");
+
+    // Fast path: already extracted.
+    if sentinel.exists() {
+        return Ok(target_dir);
+    }
+
+    fs::create_dir_all(cache_base).map_err(|source| ShimError::Extraction {
+        path: cache_base.to_path_buf(),
+        source,
+    })?;
+
+    // Lock a sibling file (not the target dir itself, which is about
+    // to be renamed). Blocks until we have exclusive access so two
+    // concurrent first-runs serialize on the extraction.
+    let lock_path = cache_base.join(format!("{CACHE_KEY}.lock"));
+    let lock_file = fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|source| ShimError::Extraction {
+            path: lock_path.clone(),
+            source,
+        })?;
+    FileExt::lock_exclusive(&lock_file).map_err(|source| ShimError::Extraction {
+        path: lock_path.clone(),
+        source,
+    })?;
+
+    // Double-check under lock: another process may have extracted
+    // while we were waiting.
+    if sentinel.exists() {
+        return Ok(target_dir);
+    }
+
+    // Clean up any `*.extracting-*` dirs left behind by a crashed
+    // previous attempt. We hold the lock, so no other process is
+    // currently extracting for this cache key.
+    let extracting_prefix = format!("{CACHE_KEY}.extracting-");
+    if let Ok(entries) = fs::read_dir(cache_base) {
+        for entry in entries.flatten() {
+            if entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with(&extracting_prefix))
+            {
+                let _ = fs::remove_dir_all(entry.path());
+            }
+        }
+    }
+
+    // Extract to a sibling temp dir, then atomic rename. Name
+    // includes PID + a nanosecond timestamp so concurrent writers
+    // (if any) don't collide even under an unlikely PID collision.
+    let unique_suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let temp_dir = cache_base.join(format!(
+        "{CACHE_KEY}.extracting-{}-{unique_suffix}",
+        std::process::id(),
+    ));
+    fs::create_dir_all(&temp_dir).map_err(|source| ShimError::Extraction {
+        path: temp_dir.clone(),
+        source,
+    })?;
+
+    extract_into(&PY_SOURCE, &temp_dir.join("mergify_cli")).map_err(|source| {
+        ShimError::Extraction {
+            path: temp_dir.clone(),
+            source,
+        }
+    })?;
+
+    // Rename is atomic on the same filesystem. If a previous
+    // interrupted run left a partial target, clear it first.
+    if target_dir.exists() {
+        fs::remove_dir_all(&target_dir).map_err(|source| ShimError::Extraction {
+            path: target_dir.clone(),
+            source,
+        })?;
+    }
+    fs::rename(&temp_dir, &target_dir).map_err(|source| ShimError::Extraction {
+        path: target_dir.clone(),
+        source,
+    })?;
+
+    // Sentinel last — its presence means "extraction complete".
+    fs::write(&sentinel, b"").map_err(|source| ShimError::Extraction {
+        path: sentinel.clone(),
+        source,
+    })?;
+
+    Ok(target_dir)
+}
+
+/// Write every file in `dir` under `target` (creating directories as
+/// needed). `include_dir` stores each file's path relative to the
+/// root Dir, so `target.join(file.path())` gives the full output
+/// path even for deeply nested files.
+fn extract_into(dir: &Dir<'_>, target: &Path) -> io::Result<()> {
+    fs::create_dir_all(target)?;
+    let mut stack: Vec<&Dir<'_>> = vec![dir];
+    while let Some(current) = stack.pop() {
+        for entry in current.entries() {
+            match entry {
+                DirEntry::Dir(subdir) => {
+                    // subdir.path() is relative to the root Dir; strip
+                    // the mergify_cli/ prefix the same way the file
+                    // branch below does.
+                    let relative = subdir
+                        .path()
+                        .strip_prefix(dir.path())
+                        .unwrap_or(subdir.path());
+                    fs::create_dir_all(target.join(relative))?;
+                    stack.push(subdir);
+                }
+                DirEntry::File(file) => {
+                    let relative = file.path().strip_prefix(dir.path()).unwrap_or(file.path());
+                    let dest = target.join(relative);
+                    if let Some(parent) = dest.parent() {
+                        fs::create_dir_all(parent)?;
+                    }
+                    fs::write(dest, file.contents())?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn invoke_python(source_root: &Path, args: &[String]) -> Result<i32, ShimError> {
+    // Prepend the extracted dir to PYTHONPATH so `python3 -m
+    // mergify_cli` resolves regardless of the user's environment.
+    let mut paths = vec![source_root.to_path_buf()];
+    if let Ok(existing) = env::var("PYTHONPATH") {
+        paths.extend(env::split_paths(&existing));
+    }
+    let new_pythonpath = env::join_paths(paths).map_err(|e| {
+        ShimError::Invocation(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("could not construct PYTHONPATH: {e}"),
+        ))
+    })?;
+
+    let status = Command::new("python3")
+        .arg("-m")
+        .arg("mergify_cli")
+        .args(args)
+        .env("PYTHONPATH", new_pythonpath)
+        // PYTHONSAFEPATH=1 stops Python from prepending the current
+        // working directory to sys.path. Without it, a user running
+        // from a directory that happens to contain a `mergify_cli/`
+        // folder would import that instead of our extracted copy.
+        // This repo's Python CLI requires Python 3.13+, which
+        // supports PYTHONSAFEPATH (introduced in 3.11).
+        .env("PYTHONSAFEPATH", "1")
+        .status()
+        .map_err(|e| match e.kind() {
+            io::ErrorKind::NotFound => ShimError::PythonNotFound,
+            _ => ShimError::Invocation(e),
+        })?;
+
+    Ok(status.code().unwrap_or(1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_into_writes_embedded_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("mergify_cli");
+        extract_into(&PY_SOURCE, &target).unwrap();
+
+        // Spot-check a handful of files we know exist in the Python
+        // source tree. Using files close to the root keeps the test
+        // robust to refactors of subdirectories.
+        assert!(target.join("__init__.py").is_file());
+        assert!(target.join("cli.py").is_file());
+        assert!(target.join("exit_codes.py").is_file());
+    }
+
+    #[test]
+    fn extract_into_preserves_nested_structure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("mergify_cli");
+        extract_into(&PY_SOURCE, &target).unwrap();
+
+        // Nested files get their full path reconstructed.
+        assert!(target.join("ci").is_dir());
+        assert!(target.join("stack").join("list.py").is_file());
+    }
+
+    #[test]
+    fn ensure_extracted_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("cache");
+
+        let first = ensure_extracted(&base).unwrap();
+        let mtime_before = fs::metadata(first.join(".complete"))
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        let second = ensure_extracted(&base).unwrap();
+        let mtime_after = fs::metadata(second.join(".complete"))
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        assert_eq!(first, second);
+        // Sentinel is not rewritten on the fast path.
+        assert_eq!(mtime_before, mtime_after);
+    }
+}


### PR DESCRIPTION
Adds the Python shim that lets the Rust binary dispatch every
command to the existing Python implementation. Phase 1.1's
deliverable: a Rust binary that, from a user's perspective,
behaves identically to the Python CLI.

## What the shim does

1. Embeds the full ``mergify_cli/`` Python source at compile time
   via ``include_dir!``. Today the payload is ~400KB of .py files
   plus tests; Phase 1.5 will add a build-time filter to drop the
   tests tree and any ``__pycache__`` directories.
2. On first invocation, extracts to
   ``~/.cache/mergify/py/<CARGO_PKG_VERSION>/mergify_cli/`` under a
   file lock. Extraction is atomic: write to a temp dir, rename,
   then write a ``.complete`` sentinel. Concurrent first-runs
   serialize safely; the fast path (sentinel present) touches only
   one ``exists()`` syscall.
3. Invokes ``python3 -m mergify_cli <args>`` with the extracted
   directory prepended to ``PYTHONPATH`` and ``PYTHONSAFEPATH=1``
   so the cwd never shadows the extracted tree. Exit code and
   stdin/stdout/stderr are forwarded transparently.

## Cache keying

Today the cache is keyed on ``CARGO_PKG_VERSION``. Since that's
``0.0.0`` during dev, the cache is shared across builds — clear
``~/.cache/mergify/py/`` by hand when iterating on Python source
in a worktree. Phase 1.5 stamps a real version + git SHA, after
which every build invalidates cleanly.

## Binary wire-up

``crates/mergify-cli/src/main.rs`` now delegates every argv tail
to ``mergify_py_shim::run``. When Phase 1.3+ ports the first
command, native Rust dispatch intercepts it before falling back
to the shim for un-ported commands. Phase 6 deletes the shim
crate entirely.

## Known gap

``python3`` on PATH must have mergify_cli's runtime dependencies
(``httpx``, ``rich``, ``pydantic``, etc.) importable — the shim
embeds only the source, not site-packages. Locally you get this
via ``uv run``; in production the Python deps have to come from
somewhere (PyPI install, a bootstrap venv, or a ``pip``-backed
first-run step). Phase 1.5 decides the mechanism. For Phase 1.1
the shim mechanics are validated in isolation.

## Tests

Three unit tests in the shim crate cover the extraction logic:
files get written, nested directories preserved, second call is
idempotent (sentinel fast-path). End-to-end smoke: ``uv run
./target/release/mergify --help`` extracts and produces Python's
help output.

Binary size: 2.6 MB. Well under the 15 MB design target.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>