### PR TITLE
feat(rust): add mergify-core foundation types (Phase 1.2a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,11 @@ dependencies = [
 [[package]]
 name = "mergify-core"
 version = "0.0.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "mergify-py-shim"
@@ -312,6 +317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]

--- a/crates/mergify-core/Cargo.toml
+++ b/crates/mergify-core/Cargo.toml
@@ -9,5 +9,10 @@ authors.workspace = true
 description = "Shared foundations for mergify-cli: HTTP, auth, errors, output, git, config, prompts."
 publish = false
 
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "2.0"
+
 [lints]
 workspace = true

--- a/crates/mergify-core/src/error.rs
+++ b/crates/mergify-core/src/error.rs
@@ -1,0 +1,94 @@
+//! Top-level CLI error type.
+//!
+//! Commands produce typed errors that map deterministically to an
+//! [`ExitCode`]. The binary's `main()` converts a `CliError` into
+//! the appropriate `ExitCode` and writes a human-readable message
+//! to stderr before exiting.
+//!
+//! This enum grows as new error sources are added. Today it covers
+//! the categories needed to port the `config` pilot (Phase 1.3);
+//! subsequent sub-phases add variants for HTTP failures, git
+//! subprocess failures, and so on.
+
+use std::io;
+
+use crate::exit_code::ExitCode;
+
+#[derive(thiserror::Error, Debug)]
+pub enum CliError {
+    /// Configuration file missing, unparseable, or failing schema
+    /// validation. Maps to [`ExitCode::ConfigurationError`].
+    #[error("{0}")]
+    Configuration(String),
+
+    /// CLI invariant violated (e.g. branch targets itself, ambiguous
+    /// commit reference, command run outside a merge queue context).
+    /// Maps to [`ExitCode::InvalidState`].
+    #[error("{0}")]
+    InvalidState(String),
+
+    /// Stack, branch, or commit not found. Maps to
+    /// [`ExitCode::StackNotFound`].
+    #[error("{0}")]
+    StackNotFound(String),
+
+    /// Rebase or merge conflict. Maps to [`ExitCode::Conflict`].
+    #[error("{0}")]
+    Conflict(String),
+
+    /// Unclassified runtime failure (I/O error, bug, third-party
+    /// panic captured and rethrown). Maps to
+    /// [`ExitCode::GenericError`].
+    #[error("{0}")]
+    Generic(String),
+
+    /// `std::io` error surfaced verbatim. Maps to
+    /// [`ExitCode::GenericError`].
+    #[error("{0}")]
+    Io(#[from] io::Error),
+}
+
+impl CliError {
+    /// The exit code the binary should return for this error.
+    #[must_use]
+    pub const fn exit_code(&self) -> ExitCode {
+        match self {
+            Self::Configuration(_) => ExitCode::ConfigurationError,
+            Self::InvalidState(_) => ExitCode::InvalidState,
+            Self::StackNotFound(_) => ExitCode::StackNotFound,
+            Self::Conflict(_) => ExitCode::Conflict,
+            Self::Generic(_) | Self::Io(_) => ExitCode::GenericError,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exit_code_mapping_is_total_and_stable() {
+        assert_eq!(
+            CliError::Configuration("x".into()).exit_code(),
+            ExitCode::ConfigurationError,
+        );
+        assert_eq!(
+            CliError::InvalidState("x".into()).exit_code(),
+            ExitCode::InvalidState,
+        );
+        assert_eq!(
+            CliError::StackNotFound("x".into()).exit_code(),
+            ExitCode::StackNotFound,
+        );
+        assert_eq!(
+            CliError::Conflict("x".into()).exit_code(),
+            ExitCode::Conflict
+        );
+        assert_eq!(
+            CliError::Generic("x".into()).exit_code(),
+            ExitCode::GenericError
+        );
+        let io_err = io::Error::other("boom");
+        assert_eq!(CliError::from(io_err).exit_code(), ExitCode::GenericError);
+    }
+}

--- a/crates/mergify-core/src/exit_code.rs
+++ b/crates/mergify-core/src/exit_code.rs
@@ -1,0 +1,98 @@
+//! Typed exit codes for the mergify CLI.
+//!
+//! Mirrors `mergify_cli.exit_codes.ExitCode` in the Python
+//! implementation. The contract — which (command, failure mode)
+//! maps to which exit code — is locked by Phase 0.1 and enforced by
+//! the compat-test harness. Changing a variant's numeric value is a
+//! breaking change for downstream scripts.
+
+use std::process::ExitCode as ProcessExitCode;
+
+/// Structured exit codes. Code 2 is reserved for Click's built-in
+/// usage errors in the Python implementation and is therefore not
+/// a variant here — it can only be produced by the CLI argument
+/// parser (clap in Rust, click in Python).
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum ExitCode {
+    Success = 0,
+    GenericError = 1,
+    StackNotFound = 3,
+    Conflict = 4,
+    GitHubApiError = 5,
+    MergifyApiError = 6,
+    InvalidState = 7,
+    ConfigurationError = 8,
+}
+
+impl ExitCode {
+    /// Raw u8 value suitable for `std::process::exit` or
+    /// `std::process::ExitCode::from`.
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+impl From<ExitCode> for u8 {
+    fn from(code: ExitCode) -> Self {
+        code.as_u8()
+    }
+}
+
+impl From<ExitCode> for ProcessExitCode {
+    fn from(code: ExitCode) -> Self {
+        Self::from(code.as_u8())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn values_match_python_contract() {
+        // These numeric values are the contract. Changing any of
+        // them is a breaking change for downstream scripts.
+        assert_eq!(ExitCode::Success.as_u8(), 0);
+        assert_eq!(ExitCode::GenericError.as_u8(), 1);
+        assert_eq!(ExitCode::StackNotFound.as_u8(), 3);
+        assert_eq!(ExitCode::Conflict.as_u8(), 4);
+        assert_eq!(ExitCode::GitHubApiError.as_u8(), 5);
+        assert_eq!(ExitCode::MergifyApiError.as_u8(), 6);
+        assert_eq!(ExitCode::InvalidState.as_u8(), 7);
+        assert_eq!(ExitCode::ConfigurationError.as_u8(), 8);
+    }
+
+    #[test]
+    fn two_is_not_used() {
+        // Code 2 is reserved for Click/clap CLI argument errors.
+        // No variant may shadow it.
+        for code in [
+            ExitCode::Success,
+            ExitCode::GenericError,
+            ExitCode::StackNotFound,
+            ExitCode::Conflict,
+            ExitCode::GitHubApiError,
+            ExitCode::MergifyApiError,
+            ExitCode::InvalidState,
+            ExitCode::ConfigurationError,
+        ] {
+            assert_ne!(code.as_u8(), 2, "{code:?} must not use code 2");
+        }
+    }
+
+    #[test]
+    fn converts_to_u8() {
+        let code: u8 = ExitCode::ConfigurationError.into();
+        assert_eq!(code, 8);
+    }
+
+    #[test]
+    fn converts_to_process_exit_code() {
+        // ProcessExitCode is opaque, so we can't assert its numeric
+        // value directly, but we verify the conversion at least
+        // type-checks and does not panic.
+        let _: ProcessExitCode = ExitCode::Success.into();
+    }
+}

--- a/crates/mergify-core/src/lib.rs
+++ b/crates/mergify-core/src/lib.rs
@@ -1,8 +1,25 @@
 //! Shared foundations for the mergify CLI Rust port.
 //!
-//! This crate is intentionally empty in Phase 1.0 — it is the container
-//! that subsequent phases fill with the HTTP client, auth, error types,
-//! output traits, git operations, config loading, and interactive prompts.
+//! Phase 1.2 populates this crate with:
+//!
+//! - [`exit_code::ExitCode`] — typed exit codes mirroring the
+//!   Python `exit_codes.py` contract.
+//! - [`error::CliError`] — top-level error enum with deterministic
+//!   mapping to an `ExitCode`.
+//! - [`output::Output`] — trait for emitting command results in
+//!   either JSON or human mode with stdout/stderr discipline baked
+//!   in.
+//!
+//! HTTP client, git operations, interactive prompts, and config
+//! loading arrive in subsequent sub-phases.
+
+pub mod error;
+pub mod exit_code;
+pub mod output;
+
+pub use error::CliError;
+pub use exit_code::ExitCode;
+pub use output::{Output, OutputMode, StdioOutput};
 
 /// Compile-time version string taken from the crate package metadata
 /// via ``CARGO_PKG_VERSION``.

--- a/crates/mergify-core/src/output.rs
+++ b/crates/mergify-core/src/output.rs
@@ -1,0 +1,221 @@
+//! Command output abstraction.
+//!
+//! Every ported command writes its result through an [`Output`]
+//! trait object rather than calling `println!` / `eprintln!`
+//! directly. This keeps the JSON and human rendering paths
+//! symmetric, lets commands stay test-friendly, and gives a single
+//! place to enforce the "stdout must be a single JSON document
+//! under `--json`" invariant (Phase 0.3).
+//!
+//! The trait is deliberately small. Commands emit one "result"
+//! value that knows how to render itself both as JSON (via
+//! [`serde::Serialize`]) and as human prose (via a closure). More
+//! specialized affordances — progress bars, spinners, tables — are
+//! added as ported commands need them.
+
+use std::io::{self, Write};
+
+use serde::Serialize;
+
+/// Abstraction over the two rendering modes a command can emit
+/// into. Commands take `&mut dyn Output` so tests can swap in a
+/// fake sink — the stock approach is [`StdioOutput::with_sinks`]
+/// plus a custom `Write` (see the test module for an example
+/// using `Arc<Mutex<Vec<u8>>>`).
+pub trait Output {
+    /// Emit a value as the command's primary result.
+    ///
+    /// In JSON mode this serializes `value` and writes it to the
+    /// stdout sink as a single JSON document. In human mode the
+    /// provided `human` closure is invoked with the stdout sink
+    /// instead — this is where the command renders tables, prose,
+    /// colored output, etc.
+    ///
+    /// Commands must call this exactly once per invocation.
+    fn emit(
+        &mut self,
+        value: &dyn ErasedSerialize,
+        human: &mut dyn FnMut(&mut dyn Write) -> io::Result<()>,
+    ) -> io::Result<()>;
+
+    /// Emit a progress or status message. In JSON mode this is a
+    /// no-op to preserve stdout purity; in human mode it writes to
+    /// stderr so piping stdout into a file is unaffected.
+    fn status(&mut self, message: &str) -> io::Result<()>;
+}
+
+/// `dyn Serialize` cannot be constructed directly because
+/// `Serialize` is not object-safe. This trait is — any
+/// `&T: Serialize` can be passed as `&dyn ErasedSerialize`.
+///
+/// Returns a `Result` so serialization failures (custom `Serialize`
+/// impls, unrepresentable values, etc.) are surfaced through
+/// [`Output::emit`] rather than silently producing `null`.
+pub trait ErasedSerialize {
+    fn to_json_value(&self) -> serde_json::Result<serde_json::Value>;
+}
+
+impl<T: Serialize + ?Sized> ErasedSerialize for T {
+    fn to_json_value(&self) -> serde_json::Result<serde_json::Value> {
+        serde_json::to_value(self)
+    }
+}
+
+/// Production [`Output`] that writes to the real streams
+/// (stdout / stderr).
+pub struct StdioOutput {
+    mode: OutputMode,
+    stdout: Box<dyn Write + Send>,
+    stderr: Box<dyn Write + Send>,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum OutputMode {
+    Human,
+    Json,
+}
+
+impl StdioOutput {
+    #[must_use]
+    pub fn new(mode: OutputMode) -> Self {
+        Self {
+            mode,
+            stdout: Box::new(io::stdout()),
+            stderr: Box::new(io::stderr()),
+        }
+    }
+
+    /// Construct with explicit sinks. Used by tests to capture
+    /// output.
+    pub fn with_sinks<O, E>(mode: OutputMode, stdout: O, stderr: E) -> Self
+    where
+        O: Write + Send + 'static,
+        E: Write + Send + 'static,
+    {
+        Self {
+            mode,
+            stdout: Box::new(stdout),
+            stderr: Box::new(stderr),
+        }
+    }
+}
+
+impl Output for StdioOutput {
+    fn emit(
+        &mut self,
+        value: &dyn ErasedSerialize,
+        human: &mut dyn FnMut(&mut dyn Write) -> io::Result<()>,
+    ) -> io::Result<()> {
+        match self.mode {
+            OutputMode::Json => {
+                let json = value
+                    .to_json_value()
+                    .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+                let mut rendered = serde_json::to_string_pretty(&json)
+                    .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+                rendered.push('\n');
+                self.stdout.write_all(rendered.as_bytes())
+            }
+            OutputMode::Human => human(&mut *self.stdout),
+        }
+    }
+
+    fn status(&mut self, message: &str) -> io::Result<()> {
+        match self.mode {
+            OutputMode::Json => Ok(()),
+            OutputMode::Human => writeln!(self.stderr, "{message}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Serialize)]
+    struct Result {
+        valid: bool,
+        errors: Vec<String>,
+    }
+
+    type SharedBytes = std::sync::Arc<std::sync::Mutex<Vec<u8>>>;
+
+    struct Captured {
+        output: StdioOutput,
+        stdout: SharedBytes,
+        stderr: SharedBytes,
+    }
+
+    fn captured(mode: OutputMode) -> Captured {
+        let stdout: SharedBytes = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let stderr: SharedBytes = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let output = StdioOutput::with_sinks(
+            mode,
+            SharedWriter(std::sync::Arc::clone(&stdout)),
+            SharedWriter(std::sync::Arc::clone(&stderr)),
+        );
+        Captured {
+            output,
+            stdout,
+            stderr,
+        }
+    }
+
+    struct SharedWriter(SharedBytes);
+
+    impl Write for SharedWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn json_mode_writes_pretty_json_to_stdout_and_nothing_to_stderr() {
+        let mut cap = captured(OutputMode::Json);
+        let value = Result {
+            valid: false,
+            errors: vec!["bad thing".to_string()],
+        };
+        cap.output.status("fetching schema…").unwrap();
+        cap.output
+            .emit(&value, &mut |_| {
+                unreachable!("human closure must not run in JSON mode")
+            })
+            .unwrap();
+
+        let stdout_bytes = cap.stdout.lock().unwrap().clone();
+        let stdout_str = String::from_utf8(stdout_bytes).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&stdout_str).unwrap();
+        assert_eq!(parsed["valid"], false);
+        assert_eq!(parsed["errors"][0], "bad thing");
+
+        // `status` is a no-op in JSON mode.
+        assert!(cap.stderr.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn human_mode_writes_closure_output_to_stdout_and_status_to_stderr() {
+        let mut cap = captured(OutputMode::Human);
+        let value = Result {
+            valid: true,
+            errors: vec![],
+        };
+        cap.output.status("fetching schema…").unwrap();
+        cap.output
+            .emit(&value, &mut |w| writeln!(w, "Configuration OK"))
+            .unwrap();
+
+        assert_eq!(
+            String::from_utf8(cap.stdout.lock().unwrap().clone()).unwrap(),
+            "Configuration OK\n",
+        );
+        assert_eq!(
+            String::from_utf8(cap.stderr.lock().unwrap().clone()).unwrap(),
+            "fetching schema…\n",
+        );
+    }
+}


### PR DESCRIPTION
Populates ``mergify-core`` with the three type-system pieces every
ported command will depend on:

- ``exit_code::ExitCode`` — typed mirror of Python's ``ExitCode``
  enum with the locked numeric values from docs/exit-codes.md. Code
  2 is reserved for clap argument errors, matching Python's Click
  reservation.
- ``error::CliError`` — top-level error enum with deterministic
  ``exit_code()`` mapping. Today it covers Configuration,
  InvalidState, StackNotFound, Conflict, Generic, and Io variants;
  HTTP and Git variants land alongside their implementations in
  1.2b / 1.2d.
- ``output::Output`` trait + ``StdioOutput`` impl — commands emit
  through a trait object so the ``--json`` vs human rendering
  decision is a single place (stdout purity invariant from Phase
  0.3 enforced by construction). Tests capture output via
  ``Arc<Mutex<Vec<u8>>>`` sinks.

Deferred to separate PRs so each is reviewable in isolation:

- 1.2b ``mergify-core::http`` — reqwest wrapper, retry, typed errors
- 1.2c colored/spinner affordances on top of ``StdioOutput``
- 1.2d ``GitOps`` trait (only needed for stack commands)
- Config loading, interactive prompts — added as ported commands
  demand them

7 unit tests cover the locked exit-code values, the ``CliError ->
ExitCode`` mapping, and the JSON/human split.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>