### PR TITLE
feat(stack): preserve approvals by default in stack push

### DIFF
--- a/mergify_cli/github_types.py
+++ b/mergify_cli/github_types.py
@@ -21,6 +21,7 @@ class PullRequest(typing.TypedDict):
     merged_at: str | None
     merge_commit_sha: str | None
     mergeable: bool | None
+    mergeable_state: typing.NotRequired[str | None]
 
 
 class Comment(typing.TypedDict):

--- a/mergify_cli/stack/approvals.py
+++ b/mergify_cli/stack/approvals.py
@@ -1,0 +1,190 @@
+#
+#  Copyright © 2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import enum
+import typing
+
+import httpx
+
+
+if typing.TYPE_CHECKING:
+    from mergify_cli import github_types
+    from mergify_cli.stack import changes
+
+
+MAX_CONCURRENT_API_CALLS = 5
+
+
+async def _pull_is_approved(
+    client: httpx.AsyncClient,
+    user: str,
+    repo: str,
+    pull_number: int,
+    sem: asyncio.Semaphore,
+) -> bool:
+    async with sem:
+        r = await client.get(f"/repos/{user}/{repo}/pulls/{pull_number}/reviews")
+        r.raise_for_status()
+        reviews = r.json()
+
+    latest_by_reviewer: dict[str, str] = {}
+    for review in reviews:
+        state = review["state"]
+        if state in {"COMMENTED", "PENDING"}:
+            continue
+        login = (review.get("user") or {}).get("login")
+        if not login:
+            continue
+        latest_by_reviewer[login] = state
+
+    return any(state == "APPROVED" for state in latest_by_reviewer.values())
+
+
+async def fetch_approved_pull_numbers(
+    client: httpx.AsyncClient,
+    user: str,
+    repo: str,
+    pulls: list[github_types.PullRequest],
+) -> set[int]:
+    if not pulls:
+        return set()
+
+    sem = asyncio.Semaphore(MAX_CONCURRENT_API_CALLS)
+    numbers = [int(pull["number"]) for pull in pulls]
+    results = await asyncio.gather(
+        *(_pull_is_approved(client, user, repo, n, sem) for n in numbers),
+    )
+    return {n for n, approved in zip(numbers, results, strict=True) if approved}
+
+
+CONFLICT_STATE = "dirty"
+_MERGEABLE_RETRY_DELAY_SECONDS = 1.0
+
+
+async def bottom_pull_has_conflict(
+    client: httpx.AsyncClient,
+    user: str,
+    repo: str,
+    bottom_pull: github_types.PullRequest | None,
+) -> bool:
+    if bottom_pull is None:
+        return False
+
+    pull_number = int(bottom_pull["number"])
+    url = f"/repos/{user}/{repo}/pulls/{pull_number}"
+
+    try:
+        r = await client.get(url)
+        r.raise_for_status()
+        data = r.json()
+
+        if data.get("mergeable") is None:
+            await asyncio.sleep(_MERGEABLE_RETRY_DELAY_SECONDS)
+            r = await client.get(url)
+            r.raise_for_status()
+            data = r.json()
+    except httpx.HTTPError:
+        return False
+
+    return bool(data.get("mergeable_state") == CONFLICT_STATE)
+
+
+class RebaseReason(enum.Enum):
+    EXPLICIT_SKIP = "explicit_skip"
+    FORCED = "forced"
+    CONFLICT_OVERRIDE = "conflict_override"
+    SKIPPED_FOR_APPROVALS = "skipped_for_approvals"
+    NO_APPROVALS = "no_approvals"
+
+
+@dataclasses.dataclass
+class RebaseDecision:
+    should_rebase: bool
+    reason: RebaseReason
+    approved_pulls: list[github_types.PullRequest]
+
+
+async def decide_rebase(
+    client: httpx.AsyncClient,
+    user: str,
+    repo: str,
+    *,
+    planned_changes: changes.Changes,
+    skip_rebase: bool,
+    force_rebase: bool,
+) -> RebaseDecision:
+    if skip_rebase:
+        return RebaseDecision(
+            should_rebase=False,
+            reason=RebaseReason.EXPLICIT_SKIP,
+            approved_pulls=[],
+        )
+    if force_rebase:
+        return RebaseDecision(
+            should_rebase=True,
+            reason=RebaseReason.FORCED,
+            approved_pulls=[],
+        )
+
+    # All live PRs in the stack (excluding already-merged ones). A rebase
+    # force-pushes every branch in the stack, not just the ones whose local
+    # commit currently differs from the remote head — `skip-up-to-date` PRs
+    # become `update` once the stack gets rebased, and their approvals would
+    # be dismissed too.
+    stack_pulls = [
+        change.pull
+        for change in planned_changes.locals
+        if change.action != "skip-merged" and change.pull is not None
+    ]
+
+    approved_numbers = await fetch_approved_pull_numbers(
+        client,
+        user,
+        repo,
+        stack_pulls,
+    )
+    approved_pulls = [p for p in stack_pulls if int(p["number"]) in approved_numbers]
+
+    # Bottom PR = first live (non-merged) change in the stack. If it's a new
+    # `create`, there's no existing PR to check. Otherwise its pull is what
+    # can force a rebase via a dirty mergeable state.
+    bottom_pull: github_types.PullRequest | None = None
+    for change in planned_changes.locals:
+        if change.action == "skip-merged":
+            continue
+        bottom_pull = change.pull
+        break
+    has_conflict = await bottom_pull_has_conflict(client, user, repo, bottom_pull)
+
+    if approved_pulls and has_conflict:
+        return RebaseDecision(
+            should_rebase=True,
+            reason=RebaseReason.CONFLICT_OVERRIDE,
+            approved_pulls=approved_pulls,
+        )
+    if approved_pulls:
+        return RebaseDecision(
+            should_rebase=False,
+            reason=RebaseReason.SKIPPED_FOR_APPROVALS,
+            approved_pulls=approved_pulls,
+        )
+    return RebaseDecision(
+        should_rebase=True,
+        reason=RebaseReason.NO_APPROVALS,
+        approved_pulls=[],
+    )

--- a/mergify_cli/stack/cli.py
+++ b/mergify_cli/stack/cli.py
@@ -71,6 +71,8 @@ async def get_default_token() -> str:
 
 
 def token_to_context(ctx: click.Context, _param: click.Parameter, value: str) -> None:
+    if ctx.obj is None:
+        ctx.obj = {}
     ctx.obj["token"] = value
 
 
@@ -79,6 +81,8 @@ def github_server_to_context(
     _param: click.Parameter,
     value: str,
 ) -> None:
+    if ctx.obj is None:
+        ctx.obj = {}
     ctx.obj["github_server"] = value
 
 
@@ -315,7 +319,13 @@ async def new(
     )
 
 
-@stack.command(help="Push/sync the pull requests stack")
+@stack.command(
+    help=(
+        "Push/sync the pull requests stack. "
+        "By default, `stack push` skips the rebase when any PR in the stack "
+        "has approvals; use --force-rebase to rebase anyway."
+    ),
+)
 @click.pass_context
 @click.option(
     "--setup",
@@ -339,6 +349,12 @@ async def new(
     "-R",
     is_flag=True,
     help="Skip stack rebase",
+)
+@click.option(
+    "--force-rebase",
+    is_flag=True,
+    help="Rebase the stack even if PRs have approvals "
+    "(mutually exclusive with --skip-rebase)",
 )
 @click.option(
     "--draft",
@@ -408,6 +424,7 @@ async def push(
     dry_run: bool,
     next_only: bool,
     skip_rebase: bool,
+    force_rebase: bool,
     draft: bool,
     keep_pull_request_title_and_body: bool,
     author: str,
@@ -417,6 +434,10 @@ async def push(
     no_revision_history: bool,
     no_verify: bool,
 ) -> None:
+    if skip_rebase and force_rebase:
+        msg = "--skip-rebase and --force-rebase are mutually exclusive"
+        raise click.UsageError(msg)
+
     if setup:
         # backward compat
         await stack_setup_mod.stack_setup()
@@ -430,6 +451,7 @@ async def push(
         github_server=ctx.obj["github_server"],
         token=ctx.obj["token"],
         skip_rebase=skip_rebase,
+        force_rebase=force_rebase,
         next_only=next_only,
         branch_prefix=branch_prefix,
         dry_run=dry_run,

--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -28,6 +28,7 @@ from mergify_cli import console
 from mergify_cli import console_error
 from mergify_cli import utils
 from mergify_cli.exit_codes import ExitCode
+from mergify_cli.stack import approvals as approvals_mod
 from mergify_cli.stack import changes
 from mergify_cli.stack.note import NOTES_REF
 
@@ -36,6 +37,7 @@ if typing.TYPE_CHECKING:
     import httpx
 
     from mergify_cli import github_types
+    from mergify_cli.stack import sync
 
 DEPENDS_ON_RE = re.compile(r"Depends-On: (#[0-9]*)")
 _SLUG_SUFFIX_RE = re.compile(r"--[0-9a-f]{8}$")
@@ -295,6 +297,99 @@ async def _process_change_task(
     task.pull_ready.set()
 
 
+def _log_rebase_performed(
+    dest_branch: str,
+    remote: str,
+    base_branch: str,
+    sync_status: sync.SyncStatus,
+    decision: approvals_mod.RebaseDecision,
+) -> None:
+    dropped = (
+        f" (dropped {len(sync_status.merged)} merged commit(s))"
+        if sync_status.merged
+        else ""
+    )
+    if decision.reason is approvals_mod.RebaseReason.CONFLICT_OVERRIDE:
+        numbers = ", ".join(f"#{p['number']}" for p in decision.approved_pulls)
+        console.log(
+            f"branch `{dest_branch}` rebased on `{remote}/{base_branch}`{dropped} "
+            f"(bottom PR has conflicts; approvals on PR(s) {numbers} may be dismissed)",
+        )
+    elif decision.reason is approvals_mod.RebaseReason.FORCED:
+        console.log(
+            f"branch `{dest_branch}` rebased on `{remote}/{base_branch}`{dropped} "
+            f"(--force-rebase; approvals may be dismissed)",
+        )
+    else:
+        console.log(
+            f"branch `{dest_branch}` rebased on `{remote}/{base_branch}`{dropped}",
+        )
+
+
+def _log_rebase_skipped(
+    dest_branch: str,
+    decision: approvals_mod.RebaseDecision,
+) -> None:
+    if decision.reason is approvals_mod.RebaseReason.EXPLICIT_SKIP:
+        console.log(f"branch `{dest_branch}` rebase skipped (--skip-rebase)")
+    elif decision.reason is approvals_mod.RebaseReason.SKIPPED_FOR_APPROVALS:
+        n = len(decision.approved_pulls)
+        plural = "s" if n != 1 else ""
+        verb = "have" if n != 1 else "has"
+        console.log(
+            f"branch `{dest_branch}` rebase skipped: {n} PR{plural} {verb} approvals "
+            f"(use --force-rebase to rebase anyway)",
+        )
+
+
+def _log_rebase_dry_run(
+    dest_branch: str,
+    remote: str,
+    base_branch: str,
+    commits_behind: int,
+    decision: approvals_mod.RebaseDecision,
+) -> None:
+    if decision.reason is approvals_mod.RebaseReason.EXPLICIT_SKIP:
+        console.log(f"branch `{dest_branch}` rebase skipped (--skip-rebase)")
+        return
+
+    if decision.reason is approvals_mod.RebaseReason.SKIPPED_FOR_APPROVALS:
+        n = len(decision.approved_pulls)
+        plural = "s" if n != 1 else ""
+        console.log(
+            f"[orange]branch `{dest_branch}` rebase would be skipped: "
+            f"approvals detected on {n} PR{plural}[/]",
+        )
+        for pull in decision.approved_pulls:
+            console.log(f'  - PR #{pull["number"]} — "{pull["title"]}"')
+        console.log("  Use --force-rebase to rebase anyway.")
+        return
+
+    if decision.reason is approvals_mod.RebaseReason.CONFLICT_OVERRIDE:
+        numbers = ", ".join(f"#{p['number']}" for p in decision.approved_pulls)
+        console.log(
+            f"[orange]branch `{dest_branch}` would be rebased on `{remote}/{base_branch}` "
+            f"(bottom PR has conflicts; approvals on PR(s) {numbers} would be dismissed)[/]",
+        )
+        return
+
+    if decision.reason is approvals_mod.RebaseReason.FORCED:
+        console.log(
+            f"[orange]branch `{dest_branch}` would be rebased on `{remote}/{base_branch}` "
+            f"(--force-rebase; approvals may be dismissed)[/]",
+        )
+        return
+
+    # NO_APPROVALS: preserve existing dry-run behavior (only warn if behind).
+    if commits_behind > 0:
+        plural = "commit" if commits_behind == 1 else "commits"
+        console.log(
+            f"[orange]branch `{dest_branch}` is behind `{remote}/{base_branch}` "
+            f"by {commits_behind} {plural}, "
+            f"commit SHAs will differ after rebase[/]",
+        )
+
+
 # TODO(charly): fix code to conform to linter (number of arguments, local
 # variables, statements, positional arguments, branches)
 async def stack_push(
@@ -302,6 +397,7 @@ async def stack_push(
     token: str,
     *,
     skip_rebase: bool,
+    force_rebase: bool = False,
     next_only: bool,
     branch_prefix: str | None,
     dry_run: bool,
@@ -354,61 +450,22 @@ async def stack_push(
 
     stack_prefix = f"{branch_prefix}/{dest_branch}" if branch_prefix else dest_branch
 
-    if not dry_run:
-        if skip_rebase:
-            console.log(f"branch `{dest_branch}` rebase skipped (--skip-rebase)")
-        else:
-            from mergify_cli.stack import sync as stack_sync_mod
-
-            with console.status(
-                f"Rebasing branch `{dest_branch}` on `{remote}/{base_branch}`...",
-            ):
-                await utils.git("fetch", remote, base_branch)
-                sync_status = await stack_sync_mod.smart_rebase(
-                    github_server,
-                    token,
-                    trunk=trunk,
-                    branch_prefix=branch_prefix,
-                    author=author,
-                )
-            if sync_status.merged:
-                console.log(
-                    f"branch `{dest_branch}` rebased on `{remote}/{base_branch}` "
-                    f"(dropped {len(sync_status.merged)} merged commit(s))",
-                )
-            else:
-                console.log(
-                    f"branch `{dest_branch}` rebased on `{remote}/{base_branch}`",
-                )
-
-    rebase_required = False
-    if dry_run and not skip_rebase:
-        commits_behind = int(
-            await utils.git("rev-list", "--count", f"HEAD..{remote}/{base_branch}"),
-        )
-        rebase_required = commits_behind > 0
-
-        if rebase_required:
-            console.log(
-                f"[orange]branch `{dest_branch}` is behind `{remote}/{base_branch}` "
-                f"by {commits_behind} {'commit' if commits_behind == 1 else 'commits'}, "
-                f"commit SHAs will differ after rebase[/]",
-            )
-
-    base_commit_sha = await utils.git(
-        "merge-base",
-        "--fork-point",
-        f"{remote}/{base_branch}",
-    )
-    if not base_commit_sha:
-        console_error(
-            f"common commit between `{remote}/{base_branch}` and `{dest_branch}` branches not found",
-        )
-        sys.exit(ExitCode.STACK_NOT_FOUND)
-
-    notes_ref_fetched = await fetch_notes_ref(remote)
-
     async with utils.get_github_http_client(github_server, token) as client:
+        # Always fetch base branch — needed for merge-base and for any eventual rebase.
+        await utils.git("fetch", remote, base_branch)
+        notes_ref_fetched = await fetch_notes_ref(remote)
+
+        base_commit_sha = await utils.git(
+            "merge-base",
+            "--fork-point",
+            f"{remote}/{base_branch}",
+        )
+        if not base_commit_sha:
+            console_error(
+                f"common commit between `{remote}/{base_branch}` and `{dest_branch}` branches not found",
+            )
+            sys.exit(ExitCode.STACK_NOT_FOUND)
+
         with console.status("Retrieving latest pushed stacks"):
             remote_changes = await changes.get_remote_changes(
                 client,
@@ -430,11 +487,79 @@ async def stack_push(
                 next_only=next_only,
             )
 
-        if rebase_required:
-            # If the branch is behind, we know for sure that all the existing
-            # pull requests will need to be updated, so we can directly plan
-            # them as "update" instead of "skip-up-to-date".
-            planned_changes.replace_local_action(old="skip-up-to-date", new="update")
+        rebase_decision = await approvals_mod.decide_rebase(
+            client,
+            user,
+            repo,
+            planned_changes=planned_changes,
+            skip_rebase=skip_rebase,
+            force_rebase=force_rebase,
+        )
+
+        if not dry_run:
+            if rebase_decision.should_rebase:
+                from mergify_cli.stack import sync as stack_sync_mod
+
+                with console.status(
+                    f"Rebasing branch `{dest_branch}` on `{remote}/{base_branch}`...",
+                ):
+                    sync_status = await stack_sync_mod.smart_rebase(
+                        github_server,
+                        token,
+                        trunk=trunk,
+                        branch_prefix=branch_prefix,
+                        author=author,
+                    )
+                _log_rebase_performed(
+                    dest_branch,
+                    remote,
+                    base_branch,
+                    sync_status,
+                    rebase_decision,
+                )
+                # Rebase changed local SHAs; recompute base and planned changes.
+                base_commit_sha = await utils.git(
+                    "merge-base",
+                    "--fork-point",
+                    f"{remote}/{base_branch}",
+                )
+                if not base_commit_sha:
+                    console_error(
+                        f"common commit between `{remote}/{base_branch}` and "
+                        f"`{dest_branch}` branches not found after rebase",
+                    )
+                    sys.exit(ExitCode.STACK_NOT_FOUND)
+                planned_changes = await changes.get_changes(
+                    base_commit_sha=base_commit_sha,
+                    stack_prefix=stack_prefix,
+                    base_branch=base_branch,
+                    dest_branch=dest_branch,
+                    remote_changes=remote_changes,
+                    only_update_existing_pulls=only_update_existing_pulls,
+                    next_only=next_only,
+                )
+            else:
+                _log_rebase_skipped(dest_branch, rebase_decision)
+        else:
+            # Dry-run: always compute commits_behind (cheap), then delegate display.
+            commits_behind = int(
+                await utils.git("rev-list", "--count", f"HEAD..{remote}/{base_branch}"),
+            )
+            _log_rebase_dry_run(
+                dest_branch,
+                remote,
+                base_branch,
+                commits_behind,
+                rebase_decision,
+            )
+            if rebase_decision.should_rebase and commits_behind > 0:
+                # If the branch is behind, we know for sure that all the existing
+                # pull requests will need to be updated, so we can directly plan
+                # them as "update" instead of "skip-up-to-date".
+                planned_changes.replace_local_action(
+                    old="skip-up-to-date",
+                    new="update",
+                )
 
         await read_reasons(planned_changes.locals)
 

--- a/mergify_cli/tests/stack/test_approvals.py
+++ b/mergify_cli/tests/stack/test_approvals.py
@@ -1,0 +1,713 @@
+#
+#  Copyright © 2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import httpx
+import pytest
+
+from mergify_cli.stack import approvals
+from mergify_cli.stack import changes
+
+
+if TYPE_CHECKING:
+    import respx
+
+
+def _pull(number: int) -> dict[str, object]:
+    return {
+        "html_url": f"https://github.com/user/repo/pull/{number}",
+        "number": str(number),
+        "title": f"Pull {number}",
+        "body": "",
+        "base": {"sha": "base_sha", "ref": "main"},
+        "head": {"sha": f"head_{number}_sha", "ref": f"branch-{number}"},
+        "state": "open",
+        "draft": False,
+        "node_id": f"node_{number}",
+        "merged_at": None,
+        "merge_commit_sha": None,
+        "mergeable": True,
+        "mergeable_state": "clean",
+    }
+
+
+@pytest.fixture(autouse=True)
+def _patch_retry_delay(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(approvals, "_MERGEABLE_RETRY_DELAY_SECONDS", 0.0)
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_fetch_approved_pull_numbers_empty_input(
+    respx_mock: respx.MockRouter,  # noqa: ARG001
+) -> None:
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        result = await approvals.fetch_approved_pull_numbers(
+            client,
+            "user",
+            "repo",
+            [],
+        )
+    assert result == set()
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_fetch_approved_pull_numbers_single_approved(
+    respx_mock: respx.MockRouter,
+) -> None:
+    respx_mock.get("/repos/user/repo/pulls/1/reviews").respond(
+        200,
+        json=[
+            {"state": "APPROVED", "user": {"login": "alice"}},
+        ],
+    )
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        result = await approvals.fetch_approved_pull_numbers(
+            client,
+            "user",
+            "repo",
+            [_pull(1)],  # type: ignore[list-item]
+        )
+    assert result == {1}
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_fetch_approved_pull_numbers_dismissed_overrides_approval(
+    respx_mock: respx.MockRouter,
+) -> None:
+    respx_mock.get("/repos/user/repo/pulls/1/reviews").respond(
+        200,
+        json=[
+            {"state": "APPROVED", "user": {"login": "alice"}},
+            {"state": "DISMISSED", "user": {"login": "alice"}},
+        ],
+    )
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        result = await approvals.fetch_approved_pull_numbers(
+            client,
+            "user",
+            "repo",
+            [_pull(1)],  # type: ignore[list-item]
+        )
+    assert result == set()
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_fetch_approved_pull_numbers_changes_requested_overrides_approval(
+    respx_mock: respx.MockRouter,
+) -> None:
+    respx_mock.get("/repos/user/repo/pulls/1/reviews").respond(
+        200,
+        json=[
+            {"state": "APPROVED", "user": {"login": "alice"}},
+            {"state": "CHANGES_REQUESTED", "user": {"login": "alice"}},
+        ],
+    )
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        result = await approvals.fetch_approved_pull_numbers(
+            client,
+            "user",
+            "repo",
+            [_pull(1)],  # type: ignore[list-item]
+        )
+    assert result == set()
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_fetch_approved_pull_numbers_commented_ignored_in_state_collapse(
+    respx_mock: respx.MockRouter,
+) -> None:
+    respx_mock.get("/repos/user/repo/pulls/1/reviews").respond(
+        200,
+        json=[
+            {"state": "APPROVED", "user": {"login": "alice"}},
+            {"state": "COMMENTED", "user": {"login": "alice"}},
+        ],
+    )
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        result = await approvals.fetch_approved_pull_numbers(
+            client,
+            "user",
+            "repo",
+            [_pull(1)],  # type: ignore[list-item]
+        )
+    assert result == {1}
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_fetch_approved_pull_numbers_multi_reviewer_any_approved(
+    respx_mock: respx.MockRouter,
+) -> None:
+    respx_mock.get("/repos/user/repo/pulls/1/reviews").respond(
+        200,
+        json=[
+            {"state": "CHANGES_REQUESTED", "user": {"login": "alice"}},
+            {"state": "APPROVED", "user": {"login": "bob"}},
+        ],
+    )
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        result = await approvals.fetch_approved_pull_numbers(
+            client,
+            "user",
+            "repo",
+            [_pull(1)],  # type: ignore[list-item]
+        )
+    assert result == {1}
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_fetch_approved_pull_numbers_multiple_pulls_parallel(
+    respx_mock: respx.MockRouter,
+) -> None:
+    respx_mock.get("/repos/user/repo/pulls/1/reviews").respond(
+        200,
+        json=[{"state": "APPROVED", "user": {"login": "alice"}}],
+    )
+    respx_mock.get("/repos/user/repo/pulls/2/reviews").respond(
+        200,
+        json=[],
+    )
+    respx_mock.get("/repos/user/repo/pulls/3/reviews").respond(
+        200,
+        json=[{"state": "APPROVED", "user": {"login": "carol"}}],
+    )
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        result = await approvals.fetch_approved_pull_numbers(
+            client,
+            "user",
+            "repo",
+            [_pull(1), _pull(2), _pull(3)],  # type: ignore[list-item]
+        )
+    assert result == {1, 3}
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_fetch_approved_pull_numbers_pending_ignored_in_state_collapse(
+    respx_mock: respx.MockRouter,
+) -> None:
+    respx_mock.get("/repos/user/repo/pulls/1/reviews").respond(
+        200,
+        json=[
+            {"state": "APPROVED", "user": {"login": "alice"}},
+            {"state": "PENDING", "user": {"login": "alice"}},
+        ],
+    )
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        result = await approvals.fetch_approved_pull_numbers(
+            client,
+            "user",
+            "repo",
+            [_pull(1)],  # type: ignore[list-item]
+        )
+    assert result == {1}
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_fetch_approved_pull_numbers_http_error_propagates(
+    respx_mock: respx.MockRouter,
+) -> None:
+    respx_mock.get("/repos/user/repo/pulls/1/reviews").respond(500)
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        with pytest.raises(httpx.HTTPStatusError):
+            await approvals.fetch_approved_pull_numbers(
+                client,
+                "user",
+                "repo",
+                [_pull(1)],  # type: ignore[list-item]
+            )
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_bottom_pull_has_conflict_none_input(
+    respx_mock: respx.MockRouter,  # noqa: ARG001
+) -> None:
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        assert (
+            await approvals.bottom_pull_has_conflict(
+                client,
+                "user",
+                "repo",
+                None,
+            )
+            is False
+        )
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_bottom_pull_has_conflict_dirty(
+    respx_mock: respx.MockRouter,
+) -> None:
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={**_pull(1), "mergeable": False, "mergeable_state": "dirty"},
+    )
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        assert (
+            await approvals.bottom_pull_has_conflict(
+                client,
+                "user",
+                "repo",
+                _pull(1),  # type: ignore[arg-type]
+            )
+            is True
+        )
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_bottom_pull_has_conflict_behind_is_not_conflict(
+    respx_mock: respx.MockRouter,
+) -> None:
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={**_pull(1), "mergeable": True, "mergeable_state": "behind"},
+    )
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        assert (
+            await approvals.bottom_pull_has_conflict(
+                client,
+                "user",
+                "repo",
+                _pull(1),  # type: ignore[arg-type]
+            )
+            is False
+        )
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_bottom_pull_has_conflict_clean(
+    respx_mock: respx.MockRouter,
+) -> None:
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={**_pull(1), "mergeable": True, "mergeable_state": "clean"},
+    )
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        assert (
+            await approvals.bottom_pull_has_conflict(
+                client,
+                "user",
+                "repo",
+                _pull(1),  # type: ignore[arg-type]
+            )
+            is False
+        )
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_bottom_pull_has_conflict_null_then_resolves(
+    respx_mock: respx.MockRouter,
+) -> None:
+    route = respx_mock.get("/repos/user/repo/pulls/1")
+    route.side_effect = [
+        httpx.Response(
+            200,
+            json={**_pull(1), "mergeable": None, "mergeable_state": "unknown"},
+        ),
+        httpx.Response(
+            200,
+            json={**_pull(1), "mergeable": False, "mergeable_state": "dirty"},
+        ),
+    ]
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        assert (
+            await approvals.bottom_pull_has_conflict(
+                client,
+                "user",
+                "repo",
+                _pull(1),  # type: ignore[arg-type]
+            )
+            is True
+        )
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_bottom_pull_has_conflict_stays_null(
+    respx_mock: respx.MockRouter,
+) -> None:
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={**_pull(1), "mergeable": None, "mergeable_state": "unknown"},
+    )
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        assert (
+            await approvals.bottom_pull_has_conflict(
+                client,
+                "user",
+                "repo",
+                _pull(1),  # type: ignore[arg-type]
+            )
+            is False
+        )
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_bottom_pull_has_conflict_http_error_is_non_conflict(
+    respx_mock: respx.MockRouter,
+) -> None:
+    respx_mock.get("/repos/user/repo/pulls/1").respond(500)
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        assert (
+            await approvals.bottom_pull_has_conflict(
+                client,
+                "user",
+                "repo",
+                _pull(1),  # type: ignore[arg-type]
+            )
+            is False
+        )
+
+
+def _local_change(
+    change_id: str,
+    pull: dict[str, object] | None,
+    *,
+    action: str,
+    base_branch: str = "main",
+    dest_branch: str = "branch",
+) -> changes.LocalChange:
+    return changes.LocalChange(
+        id=changes.ChangeId(change_id),
+        pull=pull,  # type: ignore[arg-type]
+        commit_sha="abc",
+        title="T",
+        message="M",
+        base_branch=base_branch,
+        dest_branch=dest_branch,
+        action=action,  # type: ignore[arg-type]
+    )
+
+
+def _planned_changes(locals_: list[changes.LocalChange]) -> changes.Changes:
+    return changes.Changes(stack_prefix="", locals=locals_)
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_decide_rebase_skip_rebase_flag_wins(
+    respx_mock: respx.MockRouter,  # noqa: ARG001
+) -> None:
+    planned = _planned_changes(
+        [_local_change("Iaa", _pull(1), action="update")],
+    )
+    with (
+        mock.patch.object(
+            approvals,
+            "fetch_approved_pull_numbers",
+        ) as fetch_mock,
+        mock.patch.object(
+            approvals,
+            "bottom_pull_has_conflict",
+        ) as conflict_mock,
+    ):
+        async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+            decision = await approvals.decide_rebase(
+                client,
+                "user",
+                "repo",
+                planned_changes=planned,
+                skip_rebase=True,
+                force_rebase=False,
+            )
+    assert decision.should_rebase is False
+    assert decision.reason is approvals.RebaseReason.EXPLICIT_SKIP
+    fetch_mock.assert_not_called()
+    conflict_mock.assert_not_called()
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_decide_rebase_force_flag_wins(
+    respx_mock: respx.MockRouter,  # noqa: ARG001
+) -> None:
+    planned = _planned_changes(
+        [_local_change("Iaa", _pull(1), action="update")],
+    )
+    with (
+        mock.patch.object(
+            approvals,
+            "fetch_approved_pull_numbers",
+        ) as fetch_mock,
+        mock.patch.object(
+            approvals,
+            "bottom_pull_has_conflict",
+        ) as conflict_mock,
+    ):
+        async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+            decision = await approvals.decide_rebase(
+                client,
+                "user",
+                "repo",
+                planned_changes=planned,
+                skip_rebase=False,
+                force_rebase=True,
+            )
+    assert decision.should_rebase is True
+    assert decision.reason is approvals.RebaseReason.FORCED
+    fetch_mock.assert_not_called()
+    conflict_mock.assert_not_called()
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_decide_rebase_no_approvals_no_conflict_rebases(
+    respx_mock: respx.MockRouter,  # noqa: ARG001
+) -> None:
+    planned = _planned_changes(
+        [_local_change("Iaa", _pull(1), action="update")],
+    )
+    with (
+        mock.patch.object(
+            approvals,
+            "fetch_approved_pull_numbers",
+            return_value=set(),
+        ),
+        mock.patch.object(
+            approvals,
+            "bottom_pull_has_conflict",
+            return_value=False,
+        ),
+    ):
+        async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+            decision = await approvals.decide_rebase(
+                client,
+                "user",
+                "repo",
+                planned_changes=planned,
+                skip_rebase=False,
+                force_rebase=False,
+            )
+    assert decision.should_rebase is True
+    assert decision.reason is approvals.RebaseReason.NO_APPROVALS
+    assert decision.approved_pulls == []
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_decide_rebase_approvals_clean_bottom_skips(
+    respx_mock: respx.MockRouter,  # noqa: ARG001
+) -> None:
+    pull1 = _pull(1)
+    planned = _planned_changes(
+        [_local_change("Iaa", pull1, action="update")],
+    )
+    with (
+        mock.patch.object(
+            approvals,
+            "fetch_approved_pull_numbers",
+            return_value={1},
+        ),
+        mock.patch.object(
+            approvals,
+            "bottom_pull_has_conflict",
+            return_value=False,
+        ),
+    ):
+        async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+            decision = await approvals.decide_rebase(
+                client,
+                "user",
+                "repo",
+                planned_changes=planned,
+                skip_rebase=False,
+                force_rebase=False,
+            )
+    assert decision.should_rebase is False
+    assert decision.reason is approvals.RebaseReason.SKIPPED_FOR_APPROVALS
+    assert [p["number"] for p in decision.approved_pulls] == [pull1["number"]]
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_decide_rebase_approvals_with_dirty_bottom_overrides(
+    respx_mock: respx.MockRouter,  # noqa: ARG001
+) -> None:
+    pull1 = _pull(1)
+    planned = _planned_changes(
+        [_local_change("Iaa", pull1, action="update")],
+    )
+    with (
+        mock.patch.object(
+            approvals,
+            "fetch_approved_pull_numbers",
+            return_value={1},
+        ),
+        mock.patch.object(
+            approvals,
+            "bottom_pull_has_conflict",
+            return_value=True,
+        ),
+    ):
+        async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+            decision = await approvals.decide_rebase(
+                client,
+                "user",
+                "repo",
+                planned_changes=planned,
+                skip_rebase=False,
+                force_rebase=False,
+            )
+    assert decision.should_rebase is True
+    assert decision.reason is approvals.RebaseReason.CONFLICT_OVERRIDE
+    assert [p["number"] for p in decision.approved_pulls] == [pull1["number"]]
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_decide_rebase_no_approvals_dirty_bottom_rebases_no_approvals_reason(
+    respx_mock: respx.MockRouter,  # noqa: ARG001
+) -> None:
+    planned = _planned_changes(
+        [_local_change("Iaa", _pull(1), action="update")],
+    )
+    with (
+        mock.patch.object(
+            approvals,
+            "fetch_approved_pull_numbers",
+            return_value=set(),
+        ),
+        mock.patch.object(
+            approvals,
+            "bottom_pull_has_conflict",
+            return_value=True,
+        ),
+    ):
+        async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+            decision = await approvals.decide_rebase(
+                client,
+                "user",
+                "repo",
+                planned_changes=planned,
+                skip_rebase=False,
+                force_rebase=False,
+            )
+    assert decision.should_rebase is True
+    assert decision.reason is approvals.RebaseReason.NO_APPROVALS
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_decide_rebase_ignores_create_action_pulls(
+    respx_mock: respx.MockRouter,  # noqa: ARG001
+) -> None:
+    # Mixed stack: a create (no pull) and an update (with pull).
+    pull2 = _pull(2)
+    planned = _planned_changes(
+        [
+            _local_change("Iaa", None, action="create"),
+            _local_change("Ibb", pull2, action="update"),
+        ],
+    )
+    with (
+        mock.patch.object(
+            approvals,
+            "fetch_approved_pull_numbers",
+            return_value=set(),
+        ) as fetch_mock,
+        mock.patch.object(
+            approvals,
+            "bottom_pull_has_conflict",
+            return_value=False,
+        ) as conflict_mock,
+    ):
+        async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+            await approvals.decide_rebase(
+                client,
+                "user",
+                "repo",
+                planned_changes=planned,
+                skip_rebase=False,
+                force_rebase=False,
+            )
+    # fetch receives only the update's pull
+    fetched_pulls = fetch_mock.call_args.args[3]
+    assert [p["number"] for p in fetched_pulls] == [pull2["number"]]
+    # bottom conflict check sees None (bottom is a create with no pull)
+    assert conflict_mock.call_args.args[3] is None
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_decide_rebase_skip_merged_bottom_resolves_to_next_live_pull(
+    respx_mock: respx.MockRouter,  # noqa: ARG001
+) -> None:
+    # locals[0] is skip-merged (already merged PR). The "bottom" for conflict
+    # purposes must resolve to the next live change — not be silently skipped.
+    pull1 = _pull(1)
+    pull2 = _pull(2)
+    planned = _planned_changes(
+        [
+            _local_change("Iaa", pull1, action="skip-merged"),
+            _local_change("Ibb", pull2, action="update"),
+        ],
+    )
+    with (
+        mock.patch.object(
+            approvals,
+            "fetch_approved_pull_numbers",
+            return_value=set(),
+        ) as fetch_mock,
+        mock.patch.object(
+            approvals,
+            "bottom_pull_has_conflict",
+            return_value=False,
+        ) as conflict_mock,
+    ):
+        async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+            await approvals.decide_rebase(
+                client,
+                "user",
+                "repo",
+                planned_changes=planned,
+                skip_rebase=False,
+                force_rebase=False,
+            )
+    # Approval check excludes the merged pull but includes the live update.
+    fetched_pulls = fetch_mock.call_args.args[3]
+    assert [p["number"] for p in fetched_pulls] == [pull2["number"]]
+    # Bottom conflict check resolves to pull2, not pull1 (merged) and not None.
+    assert conflict_mock.call_args.args[3] is pull2
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_decide_rebase_checks_skip_up_to_date_pulls(
+    respx_mock: respx.MockRouter,  # noqa: ARG001
+) -> None:
+    # `skip-up-to-date` PRs get promoted to `update` when the stack is
+    # rebased, so their approvals must be considered too.
+    pull1 = _pull(1)
+    planned = _planned_changes(
+        [_local_change("Iaa", pull1, action="skip-up-to-date")],
+    )
+    with (
+        mock.patch.object(
+            approvals,
+            "fetch_approved_pull_numbers",
+            return_value={1},
+        ) as fetch_mock,
+        mock.patch.object(
+            approvals,
+            "bottom_pull_has_conflict",
+            return_value=False,
+        ) as conflict_mock,
+    ):
+        async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+            decision = await approvals.decide_rebase(
+                client,
+                "user",
+                "repo",
+                planned_changes=planned,
+                skip_rebase=False,
+                force_rebase=False,
+            )
+    # The skip-up-to-date pull is included in both checks.
+    fetched_pulls = fetch_mock.call_args.args[3]
+    assert [p["number"] for p in fetched_pulls] == [pull1["number"]]
+    assert conflict_mock.call_args.args[3] is pull1
+    assert decision.should_rebase is False
+    assert decision.reason is approvals.RebaseReason.SKIPPED_FOR_APPROVALS

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -509,8 +509,11 @@ async def test_stack_update(
             "merged_at": None,
             "draft": False,
             "node_id": "",
+            "mergeable": True,
+            "mergeable_state": "clean",
         },
     )
+    respx_mock.get("/repos/user/repo/pulls/123/reviews").respond(200, json=[])
     patch_pull_mock = respx_mock.patch("/repos/user/repo/pulls/123").respond(
         200,
         json={},
@@ -603,8 +606,11 @@ async def test_stack_update_keep_title_and_body(
             "draft": False,
             "node_id": "",
             "body": "DONT TOUCH ME\n\nDepends-On: #12345\n",
+            "mergeable": True,
+            "mergeable_state": "clean",
         },
     )
+    respx_mock.get("/repos/user/repo/pulls/123/reviews").respond(200, json=[])
     patch_pull_mock = respx_mock.patch("/repos/user/repo/pulls/123").respond(
         200,
         json={},
@@ -721,6 +727,7 @@ async def test_stack_dry_run_behind_flips_up_to_date_to_update(
         200,
         json={
             "html_url": "",
+            "number": "42",
             "head": {
                 "sha": "commit1_sha",
                 "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
@@ -728,8 +735,11 @@ async def test_stack_dry_run_behind_flips_up_to_date_to_update(
             "state": "open",
             "merged_at": None,
             "draft": False,
+            "mergeable": True,
+            "mergeable_state": "clean",
         },
     )
+    respx_mock.get("/repos/user/repo/pulls/42/reviews").respond(200, json=[])
 
     with pytest.raises(SystemExit, match="0"):
         await push.stack_push(
@@ -760,6 +770,7 @@ async def test_stack_dry_run_skip_rebase(
         ),
     )
     git_mock.finalize()
+    git_mock.mock("rev-list", "--count", "HEAD..origin/main", output="0")
 
     respx_mock.get("/user").respond(200, json={"login": "author"})
     respx_mock.get("/search/issues").respond(200, json={"items": []})
@@ -775,8 +786,7 @@ async def test_stack_dry_run_skip_rebase(
             trunk=("origin", "main"),
         )
 
-    # Rebase check is skipped when --skip-rebase is passed.
-    assert not git_mock.has_been_called_with("rev-list", "--count", "HEAD..origin/main")
+    # Dry-run never rebases even when --skip-rebase is passed.
     assert not git_mock.has_been_called_with("pull", "--rebase", "origin", "main")
 
 
@@ -812,6 +822,14 @@ async def test_stack_without_common_commit_raises_an_error(
     respx_mock: respx.MockRouter,
 ) -> None:
     respx_mock.get("/user").respond(200, json={"login": "author"})
+    git_mock.mock_error("rev-parse", "--verify", "refs/notes/mergify/stack")
+    git_mock.mock(
+        "fetch",
+        "origin",
+        "--no-write-fetch-head",
+        "refs/notes/mergify/stack:refs/notes/mergify/stack",
+        output="",
+    )
     git_mock.mock("merge-base", "--fork-point", "origin/main", output="")
 
     with pytest.raises(SystemExit, match=str(ExitCode.STACK_NOT_FOUND)):
@@ -1236,8 +1254,11 @@ async def test_create_revision_comment_on_update(
             "merged_at": None,
             "draft": False,
             "node_id": "",
+            "mergeable": True,
+            "mergeable_state": "clean",
         },
     )
+    respx_mock.get("/repos/user/repo/pulls/123/reviews").respond(200, json=[])
     respx_mock.patch("/repos/user/repo/pulls/123").respond(200, json={})
     # Stack comment (existing)
     respx_mock.get("/repos/user/repo/issues/123/comments").respond(
@@ -1379,8 +1400,11 @@ async def test_no_revision_history_flag_skips_revision_comments(
             "merged_at": None,
             "draft": False,
             "node_id": "",
+            "mergeable": True,
+            "mergeable_state": "clean",
         },
     )
+    respx_mock.get("/repos/user/repo/pulls/123/reviews").respond(200, json=[])
     respx_mock.patch("/repos/user/repo/pulls/123").respond(200, json={})
     respx_mock.get("/repos/user/repo/issues/123/comments").respond(
         200,
@@ -1461,8 +1485,11 @@ async def test_revision_comment_updated_on_second_push(
             "merged_at": None,
             "draft": False,
             "node_id": "",
+            "mergeable": True,
+            "mergeable_state": "clean",
         },
     )
+    respx_mock.get("/repos/user/repo/pulls/123/reviews").respond(200, json=[])
     respx_mock.patch("/repos/user/repo/pulls/123").respond(200, json={})
 
     # Existing comments: stack comment + existing revision comment
@@ -2074,8 +2101,11 @@ async def test_revision_comment_includes_reason_from_local_change(
             "merged_at": None,
             "draft": False,
             "node_id": "",
+            "mergeable": True,
+            "mergeable_state": "clean",
         },
     )
+    respx_mock.get("/repos/user/repo/pulls/123/reviews").respond(200, json=[])
     respx_mock.patch("/repos/user/repo/pulls/123").respond(200, json={})
     respx_mock.get("/repos/user/repo/issues/123/comments").respond(200, json=[])
     post_comment_mock = respx_mock.post(
@@ -2436,3 +2466,192 @@ def test_stack_comment_body_json_marker_is_single_line_compact() -> None:
     )
     assert '", ' not in marker_line
     assert '": ' not in marker_line
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_stack_push_auto_skips_rebase_when_approved(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    # One commit, updating an existing PR that is APPROVED.
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit_sha",
+            title="Title",
+            message="Message",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            head_ref="current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize(
+        remote_shas={
+            "I29617d37762fd69809c255d7e7073cb11f8fbf50": "old_head_sha",
+        },
+    )
+    git_mock.mock("fetch", "origin", "refs/pull/1/head", output="")
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/1",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/1",
+            "number": "1",
+            "title": "Title",
+            "body": "",
+            "base": {"sha": "base_sha", "ref": "main"},
+            "head": {
+                "sha": "old_head_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "state": "open",
+            "draft": False,
+            "node_id": "node1",
+            "merged_at": None,
+            "merge_commit_sha": None,
+            "mergeable": True,
+            "mergeable_state": "clean",
+        },
+    )
+    # This PR is approved by @alice.
+    respx_mock.get("/repos/user/repo/pulls/1/reviews").respond(
+        200,
+        json=[{"state": "APPROVED", "user": {"login": "alice"}}],
+    )
+    respx_mock.patch("/repos/user/repo/pulls/1").respond(200, json={})
+    respx_mock.get("/repos/user/repo/issues/1/comments").respond(200, json=[])
+    respx_mock.post("/repos/user/repo/issues/1/comments").respond(200, json={})
+
+    from mergify_cli.stack import sync as stack_sync_mod
+
+    with (
+        mock.patch.object(push, "detect_change_type", return_value="content"),
+        mock.patch.object(stack_sync_mod, "smart_rebase") as smart_rebase_mock,
+    ):
+        await push.stack_push(
+            github_server="https://api.github.com/",
+            token="",
+            skip_rebase=False,
+            force_rebase=False,
+            next_only=False,
+            branch_prefix="",
+            dry_run=False,
+            trunk=("origin", "main"),
+        )
+
+    smart_rebase_mock.assert_not_called()
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_stack_push_force_rebase_bypasses_approvals(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    git_mock.commit(
+        test_utils.Commit(
+            sha="commit_sha",
+            title="Title",
+            message="Message",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize()
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(200, json={"items": []})
+    respx_mock.post("/repos/user/repo/pulls").respond(
+        200,
+        json={
+            "html_url": "https://github.com/repo/user/pull/1",
+            "number": "1",
+            "title": "Title",
+            "head": {"sha": "commit_sha"},
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    respx_mock.get("/repos/user/repo/issues/1/comments").respond(200, json=[])
+
+    from mergify_cli.stack import sync as stack_sync_mod
+
+    mock_sync_status = stack_sync_mod.SyncStatus(
+        branch="current-branch",
+        trunk="origin/main",
+        merged=[],
+        remaining=[],
+    )
+
+    with mock.patch.object(
+        stack_sync_mod,
+        "smart_rebase",
+        return_value=mock_sync_status,
+    ):
+        await push.stack_push(
+            github_server="https://api.github.com/",
+            token="",
+            skip_rebase=False,
+            force_rebase=True,
+            next_only=False,
+            branch_prefix="",
+            dry_run=False,
+            trunk=("origin", "main"),
+        )
+
+    # With --force-rebase, decide_rebase short-circuits before calling
+    # fetch_approved_pull_numbers. Verify no /reviews endpoint was hit:
+    # if it had been called, respx would have raised an unmatched-route error
+    # (no route registered for it). Additionally, confirm via call inspection.
+    reviews_calls = [
+        call for call in respx_mock.calls if "/reviews" in str(call.request.url)
+    ]
+    assert reviews_calls == []
+
+
+def test_push_cli_rejects_skip_and_force_rebase_together(
+    git_mock: test_utils.GitMock,
+) -> None:
+    from click.testing import CliRunner
+
+    from mergify_cli.stack import cli as stack_cli
+
+    # Mock git commands that are called during option processing
+    git_mock.mock("rev-parse", "--abbrev-ref", "HEAD", output="my-branch")
+    # Mock all git config calls that happen during option default processing
+    for config_key in [
+        "mergify-cli.stack-create-as-draft",
+        "mergify-cli.stack-revision-history",
+        "mergify-cli.stack-keep-pr-title-body",
+    ]:
+        git_mock.mock("config", "--get", config_key, output="")
+    git_mock.finalize()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        stack_cli.stack,
+        [
+            "--token",
+            "x",
+            "--github-server",
+            "https://api.github.com/",
+            "push",
+            "--trunk",
+            "origin/main",
+            "--skip-rebase",
+            "--force-rebase",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output.lower()


### PR DESCRIPTION
`mergify stack push` now auto-skips the stack rebase when any PR in
the stack has an APPROVED review, preventing GitHub's "dismiss stale
approvals" branch protection from wiping reviews on a routine push.

Use `--force-rebase` (mutually exclusive with `--skip-rebase`) to
rebase anyway and accept the approval loss. If the bottom PR has a
merge conflict (mergeable_state == "dirty"), the rebase runs
regardless — the stack cannot merge without it, so preserving
approvals is moot.

The rebase decision lives in a new `mergify_cli/stack/approvals.py`
module: `fetch_approved_pull_numbers` collapses review timelines
per-reviewer (ignoring COMMENTED/PENDING, with DISMISSED and
CHANGES_REQUESTED overriding earlier APPROVED); `bottom_pull_has_conflict`
checks the bottom PR with one retry for GitHub's lazy mergeable
computation; `decide_rebase` combines both into a typed
RebaseDecision. `stack_push` consults it once per invocation, and
the dry-run preview shows which PRs would keep their approvals.