### PR TITLE
feat(ci-insights): Expand glob patterns in junit-process FILES

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ metadata.
 
 | Command | Description |
 |---------|-------------|
-| `mergify ci junit-process FILES...` | Upload JUnit XML reports and evaluate quarantine |
+| `mergify ci junit-process FILES...` | Upload JUnit XML reports (literals or quoted glob patterns) and evaluate quarantine |
 | `mergify ci git-refs` | Detect base/head git references for the current PR |
 | `mergify ci scopes` | Detect CI scopes impacted by changed files |
 | `mergify ci scopes-send` | Send scopes tied to a pull request to Mergify |
@@ -99,7 +99,11 @@ mergify stack sync                   # Sync with upstream
 mergify stack checkout my-feature    # Checkout an existing stack from GitHub
 
 # CI insights
-mergify ci junit-process results.xml # Upload test results + quarantine
+mergify ci junit-process results.xml   # Upload test results + quarantine
+mergify ci junit-process 'reports/**/*.xml'
+                                       # Quote globs so Mergify expands them
+                                       # instead of the shell (recommended
+                                       # for large test suites).
 mergify ci scopes                    # Detect impacted scopes
 mergify ci git-refs                  # Detect base/head refs
 mergify ci git-refs --format=shell   # Emit MERGIFY_GIT_REFS_* vars for `eval`

--- a/mergify_cli/ci/cli.py
+++ b/mergify_cli/ci/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import glob
 import json
 import os
 import pathlib
@@ -19,34 +20,57 @@ from mergify_cli.dym import DYMGroup
 from mergify_cli.exit_codes import ExitCode
 
 
-class JUnitFile(click.Path):
-    """Custom Click parameter type for JUnit files with better error messages."""
+def _expand_junit_patterns(
+    ctx: click.Context,
+    param: click.Parameter,
+    value: tuple[str, ...],
+) -> tuple[str, ...]:
+    # Accept raw glob patterns and expand them here so callers don't have to
+    # rely on shell expansion — preferable for large test suites.
+    results: dict[str, None] = {}
+    for entry in value:
+        literal = pathlib.Path(entry)
+        # Existing literal paths take precedence so filenames that happen to
+        # contain glob metacharacters (e.g. `report[1].xml`) keep working.
+        if literal.is_file():
+            results.setdefault(entry, None)
+            continue
 
-    def __init__(self) -> None:
-        super().__init__(exists=True, dir_okay=False)
-
-    def convert(  # type: ignore[override]
-        self,
-        value: str,
-        param: click.Parameter | None,
-        ctx: click.Context | None,
-    ) -> str:
-        try:
-            return super().convert(value, param, ctx)
-        except click.BadParameter as e:
-            if "does not exist" in str(e):
-                # Provide a more helpful error message
-                error_msg = (
-                    f"JUnit XML file '{value}' does not exist. \n\n"
-                    "This usually indicates that a previous CI step failed to generate the test results.\n"
-                    "Please check if your test execution step completed successfully and produced the expected output file."
-                )
+        if glob.has_magic(entry):
+            matches = [
+                match
+                for match in glob.iglob(entry, recursive=True)  # noqa: PTH207
+                if pathlib.Path(match).is_file()
+            ]
+            if not matches:
                 raise click.BadParameter(
-                    error_msg,
+                    f"Pattern '{entry}' did not match any file.\n\n"
+                    "This usually indicates that a previous CI step failed to generate the test results.\n"
+                    "Please check if your test execution step completed successfully and produced the expected output files.",
                     ctx=ctx,
                     param=param,
-                ) from e
-            raise
+                )
+
+            results.update(dict.fromkeys(matches))
+            continue
+
+        if literal.is_dir():
+            raise click.BadParameter(
+                f"'{entry}' is a directory, not a JUnit XML file.\n\n"
+                "Pass a file path or a quoted glob pattern (e.g. 'reports/**/*.xml') instead.",
+                ctx=ctx,
+                param=param,
+            )
+
+        raise click.BadParameter(
+            f"JUnit XML file '{entry}' does not exist.\n\n"
+            "This usually indicates that a previous CI step failed to generate the test results.\n"
+            "Please check if your test execution step completed successfully and produced the expected output file.",
+            ctx=ctx,
+            param=param,
+        )
+
+    return tuple(results)
 
 
 def _process_tests_target_branch(
@@ -122,7 +146,7 @@ def ci(ctx: click.Context) -> None:
     "files",
     nargs=-1,
     required=True,
-    type=JUnitFile(),
+    callback=_expand_junit_patterns,
 )
 @utils.run_with_asyncio
 async def junit_upload(
@@ -149,8 +173,17 @@ async def junit_upload(
 
 
 @ci.command(
-    help="""Upload JUnit XML reports and ignore failed tests with Mergify's CI Insights Quarantine""",
-    short_help="""Upload JUnit XML reports and ignore failed tests with Mergify's CI Insights Quarantine""",
+    help=(
+        "Upload JUnit XML reports and ignore failed tests with Mergify's CI"
+        " Insights Quarantine.\n\nFILES can be literal paths or quoted glob"
+        " patterns (e.g. 'reports/**/*.xml'); quoting lets Mergify expand the"
+        " pattern rather than the shell, which is recommended for large test"
+        " suites."
+    ),
+    short_help=(
+        "Upload JUnit XML reports and ignore failed tests with Mergify's CI"
+        " Insights Quarantine"
+    ),
 )
 @click.option(
     "--api-url",
@@ -204,7 +237,7 @@ async def junit_upload(
     "files",
     nargs=-1,
     required=True,
-    type=JUnitFile(),
+    callback=_expand_junit_patterns,
 )
 @utils.run_with_asyncio
 async def junit_process(

--- a/mergify_cli/tests/ci/test_cli.py
+++ b/mergify_cli/tests/ci/test_cli.py
@@ -314,6 +314,173 @@ def test_junit_file_not_found_error_message() -> None:
         )
 
 
+def test_expand_junit_patterns_literal_path() -> None:
+    result = ci_cli._expand_junit_patterns(
+        mock.Mock(),
+        mock.Mock(),
+        (str(REPORT_XML),),
+    )
+    assert result == (str(REPORT_XML),)
+
+
+def test_expand_junit_patterns_glob_matches_multiple(
+    tmp_path: pathlib.Path,
+) -> None:
+    first = tmp_path / "report_a.xml"
+    second = tmp_path / "report_b.xml"
+    first.write_text("")
+    second.write_text("")
+
+    result = ci_cli._expand_junit_patterns(
+        mock.Mock(),
+        mock.Mock(),
+        (str(tmp_path / "report_*.xml"),),
+    )
+
+    assert set(result) == {str(first), str(second)}
+
+
+def test_expand_junit_patterns_recursive_glob(tmp_path: pathlib.Path) -> None:
+    top = tmp_path / "top.xml"
+    nested = tmp_path / "nested" / "deep" / "inner.xml"
+    nested.parent.mkdir(parents=True)
+    top.write_text("")
+    nested.write_text("")
+
+    result = ci_cli._expand_junit_patterns(
+        mock.Mock(),
+        mock.Mock(),
+        (str(tmp_path / "**" / "*.xml"),),
+    )
+
+    assert set(result) == {str(top), str(nested)}
+
+
+def test_expand_junit_patterns_literal_takes_precedence_over_magic(
+    tmp_path: pathlib.Path,
+) -> None:
+    literal = tmp_path / "report[1].xml"
+    literal.write_text("")
+
+    result = ci_cli._expand_junit_patterns(
+        mock.Mock(),
+        mock.Mock(),
+        (str(literal),),
+    )
+
+    assert result == (str(literal),)
+
+
+def test_expand_junit_patterns_directory_error(tmp_path: pathlib.Path) -> None:
+    directory = tmp_path / "reports"
+    directory.mkdir()
+
+    with pytest.raises(click.BadParameter) as exc_info:
+        ci_cli._expand_junit_patterns(
+            mock.Mock(),
+            mock.Mock(),
+            (str(directory),),
+        )
+
+    assert "is a directory" in exc_info.value.message
+    assert str(directory) in exc_info.value.message
+
+
+def test_expand_junit_patterns_skips_directories(tmp_path: pathlib.Path) -> None:
+    (tmp_path / "subdir").mkdir()
+    only_file = tmp_path / "only.xml"
+    only_file.write_text("")
+
+    result = ci_cli._expand_junit_patterns(
+        mock.Mock(),
+        mock.Mock(),
+        (str(tmp_path / "*"),),
+    )
+
+    assert result == (str(only_file),)
+
+
+def test_expand_junit_patterns_zero_match_error(tmp_path: pathlib.Path) -> None:
+    with pytest.raises(click.BadParameter) as exc_info:
+        ci_cli._expand_junit_patterns(
+            mock.Mock(),
+            mock.Mock(),
+            (str(tmp_path / "nonexistent-*.xml"),),
+        )
+
+    assert "did not match any file" in exc_info.value.message
+    assert "nonexistent-*.xml" in exc_info.value.message
+
+
+def test_expand_junit_patterns_dedupes_literal_and_glob(
+    tmp_path: pathlib.Path,
+) -> None:
+    report = tmp_path / "report.xml"
+    report.write_text("")
+
+    result = ci_cli._expand_junit_patterns(
+        mock.Mock(),
+        mock.Mock(),
+        (str(report), str(tmp_path / "*.xml")),
+    )
+
+    assert result == (str(report),)
+
+
+def test_junit_process_glob_end_to_end(tmp_path: pathlib.Path) -> None:
+    """Confirm the callback is wired on junit-process and expansion reaches the runner."""
+    first = tmp_path / "report_one.xml"
+    second = tmp_path / "report_two.xml"
+    first.write_bytes(REPORT_XML.read_bytes())
+    second.write_bytes(REPORT_XML.read_bytes())
+
+    env = {
+        "MERGIFY_API_URL": "https://api.mergify.com",
+        "MERGIFY_TOKEN": "abc",
+        "GITHUB_REPOSITORY": "user/repo",
+        "GITHUB_BASE_REF": "main",
+    }
+
+    runner = testing.CliRunner()
+    mocked_process = mock.AsyncMock()
+    with mock.patch.object(
+        junit_processing_cli,
+        "process_junit_files",
+        mocked_process,
+    ):
+        result = runner.invoke(
+            ci_cli.junit_process,
+            [str(tmp_path / "report_*.xml")],
+            env=env,
+        )
+
+    assert result.exit_code == 0, result.output
+    assert mocked_process.await_count == 1
+    await_args = mocked_process.await_args
+    assert await_args is not None
+    assert set(await_args.kwargs["files"]) == {str(first), str(second)}
+
+
+def test_junit_process_glob_no_match_error(tmp_path: pathlib.Path) -> None:
+    env = {
+        "MERGIFY_API_URL": "https://api.mergify.com",
+        "MERGIFY_TOKEN": "abc",
+        "GITHUB_REPOSITORY": "user/repo",
+        "GITHUB_BASE_REF": "main",
+    }
+
+    runner = testing.CliRunner()
+    result = runner.invoke(
+        ci_cli.junit_process,
+        [str(tmp_path / "missing-*.xml")],
+        env=env,
+    )
+
+    assert result.exit_code == 2
+    assert "did not match any file" in result.output
+    assert "missing-*.xml" in result.output
+
+
 @pytest.mark.respx(base_url="https://api.github.com/")
 def test_scopes_send(
     respx_mock: respx.MockRouter,

--- a/skills/mergify-ci/SKILL.md
+++ b/skills/mergify-ci/SKILL.md
@@ -32,6 +32,8 @@ mergify ci junit-process \
   path/to/junit-results.xml
 ```
 
+`FILES` can be individual paths or quoted glob patterns (e.g. `'reports/**/*.xml'`). Always quote the pattern so Mergify expands it rather than the shell — this is the recommended approach for large, sharded test suites.
+
 **Key options:**
 - `--token` / `-t` (env: `MERGIFY_TOKEN`) -- CI Insights application key
 - `--repository` / `-r` -- Repository full name (auto-detected in GitHub Actions)


### PR DESCRIPTION
Accept raw, unexpanded glob patterns (e.g. 'reports/**/*.xml') on the
`mergify ci junit-process` and `junit-upload` FILES argument, and expand
them inside Python. Large sharded test suites that exceed the shell's
ARG_MAX limit can now pass a single quoted pattern instead of relying
on shell expansion.

Literal paths keep the existing friendly "file does not exist" error;
zero-match patterns surface an analogous diagnostic.


Fixes: MRGFY-7036