### PR TITLE
ci: add Rust release workflow targeting GitHub Release assets

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -1,0 +1,164 @@
+name: release Rust binary to GitHub Releases
+
+on:
+  release:
+    types:
+      - published
+
+# This workflow runs in parallel with the existing PyPI workflow in
+# release.yml. Both publish artifacts for the same release tag until
+# the Phase 1.6 channel switch replaces the PyPI path entirely.
+#
+# macOS binaries are signed with a Developer ID Application
+# certificate and notarized through Apple's notarytool so users
+# can run them without Gatekeeper warnings. The job fails the
+# release if any of APPLE_* secrets is missing or wrong.
+#
+# Required GitHub Actions secrets:
+#
+#   APPLE_CERTIFICATE            # base64 of the .p12 Developer ID cert
+#   APPLE_CERTIFICATE_PASSWORD   # password set when exporting the .p12
+#   APPLE_SIGNING_IDENTITY       # e.g. "Developer ID Application: Mergify SAS (TEAMID)"
+#   APPLE_API_KEY                # base64 of the App Store Connect .p8 API key
+#   APPLE_API_KEY_ID             # 10-char key ID from App Store Connect
+#   APPLE_API_KEY_ISSUER         # issuer UUID from App Store Connect
+
+jobs:
+  linux-windows:
+    name: build ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-24.04
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-24.04
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04
+          - target: x86_64-pc-windows-msvc
+            os: windows-2025
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: mergify
+          target: ${{ matrix.target }}
+          archive: $bin-$tag-$target
+          tar: unix
+          zip: windows
+          checksum: sha256
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  macos:
+    name: build ${{ matrix.target }} (signed + notarized)
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
+    runs-on: macos-15
+    permissions:
+      contents: write
+    env:
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+      APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+      APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup target add ${{ matrix.target }}
+          rustup default stable
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Import Developer ID certificate into a throwaway keychain
+        run: |
+          echo "$APPLE_CERTIFICATE" | base64 --decode -o "$RUNNER_TEMP/cert.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 16)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$RUNNER_TEMP/cert.p12" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          # Prepend the build keychain so codesign searches it first,
+          # without dropping the runner's default keychains.
+          security list-keychains -d user -s \
+            "$KEYCHAIN_PATH" \
+            $(security list-keychains -d user | tr -d '"')
+
+      - name: Codesign binary (hardened runtime + timestamp)
+        run: |
+          codesign \
+            --force \
+            --options runtime \
+            --timestamp \
+            --sign "$APPLE_SIGNING_IDENTITY" \
+            "target/${{ matrix.target }}/release/mergify"
+          codesign --verify --strict --verbose=2 \
+            "target/${{ matrix.target }}/release/mergify"
+
+      - name: Notarize with App Store Connect API
+        run: |
+          KEY_DIR="$HOME/.appstoreconnect/private_keys"
+          mkdir -p "$KEY_DIR"
+          KEY_PATH="$KEY_DIR/AuthKey_${APPLE_API_KEY_ID}.p8"
+          echo "$APPLE_API_KEY" | base64 --decode > "$KEY_PATH"
+          # notarytool accepts zip, dmg, or pkg; wrap the bare binary
+          # in a zip so it can be submitted. Stapling isn't possible
+          # on a Mach-O, but online Gatekeeper checks still approve
+          # notarized binaries.
+          NOTARIZE_ZIP="$RUNNER_TEMP/mergify-notarize.zip"
+          ditto -c -k --keepParent \
+            "target/${{ matrix.target }}/release/mergify" \
+            "$NOTARIZE_ZIP"
+          xcrun notarytool submit "$NOTARIZE_ZIP" \
+            --key "$KEY_PATH" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_KEY_ISSUER" \
+            --wait
+
+      - name: Archive and upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          ARCHIVE="mergify-${TAG}-${{ matrix.target }}.tar.gz"
+          tar -C "target/${{ matrix.target }}/release" \
+            -czf "$RUNNER_TEMP/$ARCHIVE" mergify
+          (cd "$RUNNER_TEMP" && shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256")
+          gh release upload "$TAG" \
+            "$RUNNER_TEMP/$ARCHIVE" \
+            "$RUNNER_TEMP/$ARCHIVE.sha256" \
+            --repo "${{ github.repository }}"

--- a/PORT_STATUS.toml
+++ b/PORT_STATUS.toml
@@ -1,0 +1,148 @@
+# Port inventory for the mergify CLI Rust port.
+#
+# Every click subcommand exposed by the Python CLI must appear here.
+# The inventory test in mergify_cli/tests/test_port_status.py walks
+# click's command tree and fails if it finds a command that isn't
+# listed, or an entry here that doesn't match any Python command.
+#
+# Status values:
+#   "native"  — handled by the Rust binary's native dispatch.
+#   "shimmed" — handled by Python via the py-shim crate.
+#
+# Workflow
+# --------
+#
+# When adding a new Python subcommand:
+#   Add an entry here with status = "shimmed" in the same PR.
+#
+# When porting a command to Rust:
+#   Flip status from "shimmed" to "native" in the same PR that adds
+#   the Rust dispatch + tests.
+#
+# When removing a command:
+#   Drop the entry here in the same PR that removes the Python
+#   implementation.
+#
+# The guard fires before anything else, so forgetting to update
+# this file surfaces as a CI failure rather than a silent unshipped
+# port.
+
+[[command]]
+path = ["ci", "git-refs"]
+status = "shimmed"
+
+[[command]]
+path = ["ci", "junit-process"]
+status = "shimmed"
+
+[[command]]
+path = ["ci", "junit-upload"]
+status = "shimmed"
+
+[[command]]
+path = ["ci", "queue-info"]
+status = "shimmed"
+
+[[command]]
+path = ["ci", "scopes"]
+status = "shimmed"
+
+[[command]]
+path = ["ci", "scopes-send"]
+status = "shimmed"
+
+[[command]]
+path = ["config", "simulate"]
+status = "shimmed"
+
+[[command]]
+path = ["config", "validate"]
+status = "native"
+
+[[command]]
+path = ["freeze", "create"]
+status = "shimmed"
+
+[[command]]
+path = ["freeze", "delete"]
+status = "shimmed"
+
+[[command]]
+path = ["freeze", "list"]
+status = "shimmed"
+
+[[command]]
+path = ["freeze", "update"]
+status = "shimmed"
+
+[[command]]
+path = ["queue", "pause"]
+status = "shimmed"
+
+[[command]]
+path = ["queue", "show"]
+status = "shimmed"
+
+[[command]]
+path = ["queue", "status"]
+status = "shimmed"
+
+[[command]]
+path = ["queue", "unpause"]
+status = "shimmed"
+
+[[command]]
+path = ["stack", "checkout"]
+status = "shimmed"
+
+[[command]]
+path = ["stack", "edit"]
+status = "shimmed"
+
+[[command]]
+path = ["stack", "fixup"]
+status = "shimmed"
+
+[[command]]
+path = ["stack", "hooks"]
+status = "shimmed"
+
+[[command]]
+path = ["stack", "list"]
+status = "shimmed"
+
+[[command]]
+path = ["stack", "move"]
+status = "shimmed"
+
+[[command]]
+path = ["stack", "new"]
+status = "shimmed"
+
+[[command]]
+path = ["stack", "note"]
+status = "shimmed"
+
+[[command]]
+path = ["stack", "open"]
+status = "shimmed"
+
+[[command]]
+path = ["stack", "push"]
+status = "shimmed"
+
+[[command]]
+path = ["stack", "reorder"]
+status = "shimmed"
+
+[[command]]
+path = ["stack", "setup"]
+status = "shimmed"
+
+[[command]]
+path = ["stack", "squash"]
+status = "shimmed"
+
+[[command]]
+path = ["stack", "sync"]
+status = "shimmed"

--- a/mergify_cli/tests/test_port_status.py
+++ b/mergify_cli/tests/test_port_status.py
@@ -1,0 +1,158 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""Port inventory guard.
+
+Walks the click command tree exposed by ``mergify_cli.cli.cli`` and
+compares it to the inventory in ``PORT_STATUS.toml``. Any mismatch
+is a CI failure.
+
+The intent is to prevent a Python command from being added while
+the Rust port is in flight without someone explicitly deciding
+whether it ships via the shim (``status = "shimmed"``) or via a
+native Rust implementation (``status = "native"``). Forgetting to
+port a new command therefore surfaces immediately rather than
+getting noticed months later when users report missing
+functionality in the static binary.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import tomllib
+
+import click
+
+from mergify_cli.cli import cli as _cli
+
+
+_VALID_STATUSES: frozenset[str] = frozenset({"native", "shimmed"})
+_PORT_STATUS_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent.parent / "PORT_STATUS.toml"
+)
+
+
+def _walk_commands(
+    cmd: click.Command,
+    prefix: tuple[str, ...] = (),
+) -> list[tuple[str, ...]]:
+    """Collect the path of every leaf command reachable from ``cmd``.
+
+    Groups contribute nothing themselves — only their leaf
+    subcommands appear. Empty prefixes mean "the root `mergify`
+    command invoked without a subcommand", which we don't track.
+    """
+    if isinstance(cmd, click.Group):
+        paths: list[tuple[str, ...]] = []
+        for name, child in sorted(cmd.commands.items()):
+            paths.extend(_walk_commands(child, (*prefix, name)))
+        return paths
+    return [prefix] if prefix else []
+
+
+def _discovered_commands() -> set[tuple[str, ...]]:
+    return set(_walk_commands(_cli))
+
+
+def _load_port_status() -> list[dict[str, object]]:
+    text = _PORT_STATUS_PATH.read_text(encoding="utf-8")
+    data = tomllib.loads(text)
+    commands = data.get("command", [])
+    assert isinstance(commands, list), (
+        "PORT_STATUS.toml must define `command` as an array of tables "
+        "using `[[command]]`, not a single table `[command]`."
+    )
+    assert all(isinstance(entry, dict) for entry in commands), (
+        "PORT_STATUS.toml `command` entries must each be tables defined "
+        "with `[[command]]`."
+    )
+    return commands
+
+
+def _declared_commands() -> set[tuple[str, ...]]:
+    return {tuple(entry["path"]) for entry in _load_port_status()}  # type: ignore[arg-type]
+
+
+def test_every_python_command_is_in_port_status() -> None:
+    """Every click command exposed by the Python CLI must appear in
+    PORT_STATUS.toml."""
+    discovered = _discovered_commands()
+    declared = _declared_commands()
+
+    missing = discovered - declared
+    assert not missing, (
+        "\nThese click commands exist in mergify_cli but are not listed "
+        "in PORT_STATUS.toml:\n"
+        + "\n".join(f"  - {' '.join(path)}" for path in sorted(missing))
+        + '\n\nAdd each as `status = "shimmed"` (or `status = "native"` '
+        "if already ported) so the Rust port doesn't forget them."
+    )
+
+
+def test_no_stale_entries_in_port_status() -> None:
+    """Every entry in PORT_STATUS.toml must correspond to a live
+    click command."""
+    discovered = _discovered_commands()
+    declared = _declared_commands()
+
+    extra = declared - discovered
+    assert not extra, (
+        "\nThese entries in PORT_STATUS.toml do not match any "
+        "click command:\n"
+        + "\n".join(f"  - {' '.join(path)}" for path in sorted(extra))
+        + "\n\nRemove the stale entries (the command was renamed or "
+        "deleted)."
+    )
+
+
+def test_port_status_uses_only_valid_status_values() -> None:
+    """Every entry must use a known status value."""
+    for entry in _load_port_status():
+        # Validate required keys here so a typo in `path` or `status`
+        # surfaces with a targeted assertion message instead of a
+        # bare KeyError traceback.
+        assert "path" in entry, (
+            f"PORT_STATUS.toml entry {entry!r} is missing required key 'path'"
+        )
+        assert "status" in entry, (
+            f"PORT_STATUS.toml entry {entry!r} is missing required key 'status'"
+        )
+        path = entry["path"]
+        assert isinstance(path, list), (
+            f"PORT_STATUS.toml entry {entry!r}: 'path' must be a list"
+        )
+        assert all(isinstance(p, str) for p in path), (
+            f"PORT_STATUS.toml entry {entry!r}: every 'path' segment must be a string"
+        )
+        status = entry["status"]
+        assert status in _VALID_STATUSES, (
+            f"PORT_STATUS.toml entry for {path!r} uses invalid "
+            f"status {status!r}; valid values are "
+            f"{sorted(_VALID_STATUSES)}"
+        )
+
+
+def test_port_status_entries_have_exactly_path_and_status_keys() -> None:
+    """Catches typos like `stats` or accidentally adding a third
+    undocumented key."""
+    allowed = {"path", "status"}
+    for entry in _load_port_status():
+        actual = set(entry.keys())
+        missing = allowed - actual
+        extras = actual - allowed
+        assert actual == allowed, (
+            f"PORT_STATUS.toml entry {entry!r} must have exactly keys "
+            f"{sorted(allowed)}; missing keys: {sorted(missing)}, "
+            f"unexpected keys: {sorted(extras)}."
+        )


### PR DESCRIPTION
Starts distributing the static Rust binary alongside the existing
PyPI wheel. Both pipelines run on every published GitHub Release
until the Phase 1.6 channel switch makes the binary the sole
install path.

## What ships per release

Seven targets as GitHub Release assets, plus matching
``.sha256`` checksum files:

- ``x86_64-unknown-linux-gnu``   (glibc)
- ``x86_64-unknown-linux-musl``  (static)
- ``aarch64-unknown-linux-gnu``  (glibc, ARM server)
- ``aarch64-unknown-linux-musl`` (static, ARM server)
- ``x86_64-apple-darwin``        (Intel macOS, signed + notarized)
- ``aarch64-apple-darwin``       (Apple Silicon, signed + notarized)
- ``x86_64-pc-windows-msvc``     (Windows)

Archives use the ``mergify-<tag>-<target>.tar.gz`` / ``.zip``
naming convention. Linux and Windows builds go through
``taiki-e/upload-rust-binary-action`` which handles
cross-compilation via ``cross`` automatically. macOS builds run
natively on Apple Silicon runners with an explicit pipeline
because of the signing + notarization steps.

## macOS signing / notarization

The macOS job imports a Developer ID Application certificate into
a throwaway keychain, codesigns the binary with the hardened
runtime + timestamp, then submits it to Apple's notarytool
service. Stapling isn't possible on a bare Mach-O; online
Gatekeeper checks approve notarized binaries on first run.

Required GitHub Actions secrets (all six must be set before the
next release):

  APPLE_CERTIFICATE            base64 of the .p12 Developer ID cert
  APPLE_CERTIFICATE_PASSWORD   password set when exporting the .p12
  APPLE_SIGNING_IDENTITY       "Developer ID Application: Mergify SAS (TEAMID)"
  APPLE_API_KEY                base64 of the App Store Connect .p8 API key
  APPLE_API_KEY_ID             10-char key ID from App Store Connect
  APPLE_API_KEY_ISSUER         issuer UUID from App Store Connect

## Install story today

Users grab a binary from the releases page:
``https://github.com/Mergifyio/mergify-cli/releases/latest``.
A ``curl | sh`` installer script + Homebrew tap land in separate
follow-up PRs once we've seen the first binary release succeed.

## Parallel with PyPI

``release.yml`` (existing) keeps publishing to PyPI unchanged.
Both workflows key off the same ``release: published`` event.
The Phase 1.6 channel switch is the user-coordinated moment where
we stop publishing to PyPI and direct users to the binary.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Depends-On: #1296