### PR TITLE
feat(rust): port config simulate to native Rust (Phase 1.3b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,6 +967,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_norway",
+ "temp-env",
  "tempfile",
  "tokio",
  "url",
@@ -1655,6 +1656,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/PORT_STATUS.toml
+++ b/PORT_STATUS.toml
@@ -53,7 +53,7 @@ status = "shimmed"
 
 [[command]]
 path = ["config", "simulate"]
-status = "shimmed"
+status = "native"
 
 [[command]]
 path = ["config", "validate"]

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -1,14 +1,17 @@
 //! `mergify` binary entry point.
 //!
-//! Dispatch logic:
-//! - If the invocation is `mergify config validate [--config-file
-//!   PATH]`, run it natively via `mergify_config::validate`.
-//! - Anything else is handed to `mergify_py_shim::run`, which
-//!   extracts the embedded Python source on first use and invokes
-//!   `python3 -m mergify_cli`.
+//! Dispatch logic: every invocation is speculatively parsed with
+//! clap, which knows about the native commands
+//! ([`ConfigSubcommand::Validate`], [`ConfigSubcommand::Simulate`]).
+//! If clap succeeds with a known native variant the binary runs
+//! that code path natively. Any parse failure — including
+//! subcommands clap doesn't know about (``stack push``, ``ci
+//! junit-process``, …) — falls through to [`mergify_py_shim::run`],
+//! which hands the original argv to ``python3 -m mergify_cli``.
 //!
-//! As each command ports (Phase 1.4+), native dispatch grows and
-//! the shim fallback shrinks. Phase 6 deletes the shim entirely.
+//! As each command ports (Phase 1.4+), new variants land on the
+//! clap enum and the shim fallback shrinks. Phase 6 deletes the
+//! shim entirely.
 
 use std::env;
 use std::path::PathBuf;
@@ -16,14 +19,16 @@ use std::process::ExitCode;
 
 use clap::Parser;
 use clap::Subcommand;
+use mergify_config::simulate::PullRequestRef;
+use mergify_config::simulate::SimulateOptions;
 use mergify_core::OutputMode;
 use mergify_core::StdioOutput;
 
 fn main() -> ExitCode {
     let argv: Vec<String> = env::args().skip(1).collect();
 
-    if let Some(NativeCommand::ConfigValidate(opts)) = detect_native(&argv) {
-        return run_native_config_validate(&opts);
+    if let Some(cmd) = detect_native(&argv) {
+        return run_native(cmd);
     }
 
     match mergify_py_shim::run(&argv) {
@@ -35,7 +40,74 @@ fn main() -> ExitCode {
     }
 }
 
-fn run_native_config_validate(opts: &ConfigValidateOpts) -> ExitCode {
+/// Native commands the Rust binary handles without delegating to
+/// the Python shim.
+enum NativeCommand {
+    ConfigValidate { config_file: Option<PathBuf> },
+    ConfigSimulate(ConfigSimulateOpts),
+}
+
+struct ConfigSimulateOpts {
+    config_file: Option<PathBuf>,
+    pull_request: PullRequestRef,
+    token: Option<String>,
+    api_url: Option<String>,
+}
+
+/// Try to recognize the invocation as a native command.
+///
+/// Returns ``None`` when the argv doesn't look like a native
+/// command — callers fall back to the Python shim, which produces
+/// the same error messages as before the port started. When the
+/// argv obviously targets a native command (contains ``config``
+/// and ``validate``/``simulate``) but clap can't parse it — e.g.
+/// the user gave a bad flag or an invalid URL — this function
+/// prints clap's formatted error to stderr and exits the process
+/// with clap's exit code (2), matching the Python CLI's behavior
+/// for argument errors.
+fn detect_native(argv: &[String]) -> Option<NativeCommand> {
+    let looks_native = {
+        let has_config = argv.iter().any(|a| a == "config");
+        let has_native_sub = argv.iter().any(|a| a == "validate" || a == "simulate");
+        has_config && has_native_sub
+    };
+
+    let parsed = match CliRoot::try_parse_from(
+        std::iter::once("mergify".to_string()).chain(argv.iter().cloned()),
+    ) {
+        Ok(parsed) => parsed,
+        Err(err) if looks_native => {
+            // Native intent + clap rejection = surface clap's error
+            // and exit. ``err.exit()`` prints to stderr and calls
+            // ``process::exit``; does not return.
+            err.exit()
+        }
+        Err(_) => return None,
+    };
+
+    match parsed.command {
+        Subcommands::Config(ConfigArgs {
+            config_file,
+            command: ConfigSubcommand::Validate(_),
+        }) => Some(NativeCommand::ConfigValidate { config_file }),
+        Subcommands::Config(ConfigArgs {
+            config_file,
+            command:
+                ConfigSubcommand::Simulate(SimulateCliArgs {
+                    pull_request,
+                    token,
+                    api_url,
+                }),
+        }) => Some(NativeCommand::ConfigSimulate(ConfigSimulateOpts {
+            config_file,
+            pull_request,
+            token,
+            api_url,
+        })),
+    }
+}
+
+fn run_native(cmd: NativeCommand) -> ExitCode {
     let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -48,65 +120,34 @@ fn run_native_config_validate(opts: &ConfigValidateOpts) -> ExitCode {
     };
 
     let mut output = StdioOutput::new(OutputMode::Human);
-    let result = rt.block_on(mergify_config::validate::run(
-        opts.config_file.as_deref(),
-        &mut output,
-    ));
+
+    let result = rt.block_on(async {
+        match cmd {
+            NativeCommand::ConfigValidate { config_file } => {
+                mergify_config::validate::run(config_file.as_deref(), &mut output).await
+            }
+            NativeCommand::ConfigSimulate(opts) => {
+                mergify_config::simulate::run(
+                    SimulateOptions {
+                        pull_request: &opts.pull_request,
+                        config_file: opts.config_file.as_deref(),
+                        token: opts.token.as_deref(),
+                        api_url: opts.api_url.as_deref(),
+                    },
+                    &mut output,
+                )
+                .await
+            }
+        }
+    });
 
     match result {
         Ok(()) => ExitCode::from(mergify_core::ExitCode::Success.as_u8()),
         Err(err) => {
             let code = err.exit_code();
-            // Commands that emit their own details through `Output`
-            // (e.g. `config validate`'s per-error list) still get a
-            // top-level "mergify: <message>" line appended, matching
-            // the Python CLI's behavior.
             eprintln!("mergify: {err}");
             ExitCode::from(code.as_u8())
         }
-    }
-}
-
-/// Recognised native commands, paired with their pre-parsed options.
-enum NativeCommand {
-    ConfigValidate(ConfigValidateOpts),
-}
-
-#[derive(Debug, Default)]
-struct ConfigValidateOpts {
-    config_file: Option<PathBuf>,
-}
-
-/// Try to recognise the invocation as a native command. Returns
-/// `None` when the argv doesn't match any native command or when
-/// clap rejects it — in both cases the caller falls back to the
-/// Python shim (which produces the same error messages as before
-/// the port started).
-fn detect_native(argv: &[String]) -> Option<NativeCommand> {
-    // Quick cheap check: argv must contain "config" followed by
-    // "validate" to possibly be a native match. This avoids running
-    // clap on every command.
-    let has_config_validate = argv
-        .iter()
-        .position(|a| a == "config")
-        .is_some_and(|i| argv.get(i + 1).is_some_and(|a| a == "validate"));
-    if !has_config_validate {
-        return None;
-    }
-
-    match CliRoot::try_parse_from(
-        std::iter::once("mergify".to_string()).chain(argv.iter().cloned()),
-    ) {
-        Ok(CliRoot {
-            command:
-                Subcommands::Config(ConfigArgs {
-                    config_file,
-                    command: ConfigSubcommand::Validate(_),
-                }),
-        }) => Some(NativeCommand::ConfigValidate(ConfigValidateOpts {
-            config_file,
-        })),
-        _ => None,
     }
 }
 
@@ -139,7 +180,27 @@ struct ConfigArgs {
 enum ConfigSubcommand {
     /// Validate the Mergify configuration file against the schema.
     Validate(ValidateArgs),
+    /// Simulate Mergify actions on a pull request using the local
+    /// configuration.
+    Simulate(SimulateCliArgs),
 }
 
 #[derive(clap::Args)]
 struct ValidateArgs {}
+
+#[derive(clap::Args)]
+struct SimulateCliArgs {
+    /// Pull request URL (e.g. <https://github.com/owner/repo/pull/123>).
+    #[arg(value_name = "PULL_REQUEST_URL", value_parser = mergify_config::simulate::parse_pr_url)]
+    pull_request: PullRequestRef,
+
+    /// Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and
+    /// then ``GITHUB_TOKEN`` env vars.
+    #[arg(long, short = 't')]
+    token: Option<String>,
+
+    /// Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var,
+    /// then to the default.
+    #[arg(long = "api-url", short = 'u')]
+    api_url: Option<String>,
+}

--- a/crates/mergify-config/Cargo.toml
+++ b/crates/mergify-config/Cargo.toml
@@ -19,6 +19,7 @@ url = "2"
 
 [dev-dependencies]
 tempfile = "3.14"
+temp-env = "0.3"
 tokio = { version = "1", default-features = false, features = ["macros", "rt", "time"] }
 wiremock = "0.6"
 

--- a/crates/mergify-config/src/lib.rs
+++ b/crates/mergify-config/src/lib.rs
@@ -1,6 +1,8 @@
 //! Native Rust implementation of the `mergify config` subcommands.
 //!
-//! Phase 1.3 ports `config validate`. `config simulate` stays in the
-//! Python shim until Phase 1.3b.
+//! Phase 1.3 ports `config validate`. Phase 1.3b adds `config
+//! simulate`. Both share the config-file resolver in [`paths`].
 
+pub mod paths;
+pub mod simulate;
 pub mod validate;

--- a/crates/mergify-config/src/paths.rs
+++ b/crates/mergify-config/src/paths.rs
@@ -1,0 +1,92 @@
+//! Shared helpers for resolving the Mergify configuration file path.
+//!
+//! Both `config validate` and `config simulate` accept a
+//! ``--config-file`` flag and otherwise auto-detect the file from a
+//! small list of conventional locations. The resolver here is the
+//! single source of truth for that behavior.
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use mergify_core::CliError;
+
+/// Filename patterns the CLI searches for a Mergify configuration,
+/// in priority order. Mirrors ``MERGIFY_CONFIG_PATHS`` in
+/// ``mergify_cli/ci/detector.py``.
+pub const DEFAULT_CONFIG_PATHS: [&str; 3] =
+    [".mergify.yml", ".mergify/config.yml", ".github/mergify.yml"];
+
+/// Resolve the path of the Mergify configuration file relative to
+/// the current working directory.
+///
+/// When ``explicit`` is ``Some``, that path must be a real file —
+/// otherwise the user specified a bad path and we fail loudly with
+/// [`CliError::Configuration`]. When ``explicit`` is ``None`` the
+/// resolver walks [`DEFAULT_CONFIG_PATHS`] in order and returns the
+/// first match.
+pub fn resolve_config_path(explicit: Option<&Path>) -> Result<PathBuf, CliError> {
+    resolve_config_path_in(explicit, Path::new("."))
+}
+
+/// Same as [`resolve_config_path`] but searches relative to
+/// ``base`` instead of the current working directory.
+///
+/// Tests use this directly to avoid `std::env::set_current_dir`,
+/// which races with parallel cargo test workers in the same
+/// process.
+///
+/// # Errors
+///
+/// Returns [`CliError::Configuration`] when neither an explicit
+/// path nor any default candidate exists.
+pub fn resolve_config_path_in(explicit: Option<&Path>, base: &Path) -> Result<PathBuf, CliError> {
+    if let Some(path) = explicit {
+        if path.is_file() {
+            return Ok(path.to_path_buf());
+        }
+        return Err(CliError::Configuration(format!(
+            "Configuration file not found: {}",
+            path.display(),
+        )));
+    }
+    for candidate in DEFAULT_CONFIG_PATHS {
+        let path = base.join(candidate);
+        if path.is_file() {
+            return Ok(path);
+        }
+    }
+    Err(CliError::Configuration(format!(
+        "Mergify configuration file not found. Looked in: {}",
+        DEFAULT_CONFIG_PATHS.join(", "),
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn finds_dotmergify_yml() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join(".mergify.yml"), "").unwrap();
+        let got = resolve_config_path_in(None, tmp.path()).unwrap();
+        assert_eq!(got, tmp.path().join(".mergify.yml"));
+    }
+
+    #[test]
+    fn errors_when_no_file_and_no_explicit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = resolve_config_path_in(None, tmp.path()).unwrap_err();
+        assert!(matches!(err, CliError::Configuration(_)));
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn errors_on_explicit_missing_file() {
+        let err = resolve_config_path_in(Some(Path::new("/nonexistent/path.yml")), Path::new("."))
+            .unwrap_err();
+        assert!(matches!(err, CliError::Configuration(_)));
+    }
+}

--- a/crates/mergify-config/src/simulate.rs
+++ b/crates/mergify-config/src/simulate.rs
@@ -1,0 +1,367 @@
+//! `mergify config simulate` — simulate Mergify actions on a pull
+//! request using the local configuration.
+//!
+//! The command:
+//! 1. Parses the pull-request URL into ``(owner/repo, number)``.
+//! 2. Resolves the config file (same paths as `config validate`).
+//! 3. Reads the YAML as a raw string (no parsing — the Mergify
+//!    simulator accepts the text verbatim).
+//! 4. POSTs to
+//!    ``<api-url>/v1/repos/<repo>/pulls/<number>/simulator`` with
+//!    ``{"mergify_yml": <content>}``.
+//! 5. Prints the simulator's title + summary.
+//!
+//! Token / api-url / config-file all follow the same resolution
+//! order as the Python CLI: explicit flag, then env var, then
+//! default. Missing token falls back from ``MERGIFY_TOKEN`` to
+//! ``GITHUB_TOKEN``. The ``gh auth token`` subprocess fallback from
+//! Python isn't ported yet — if neither env var is set the command
+//! errors out.
+
+use std::env;
+use std::io::Write;
+use std::path::Path;
+
+use mergify_core::ApiFlavor;
+use mergify_core::CliError;
+use mergify_core::HttpClient;
+use mergify_core::Output;
+use serde::Deserialize;
+use serde::Serialize;
+use url::Url;
+
+use crate::paths::resolve_config_path;
+
+const DEFAULT_API_URL: &str = "https://api.mergify.com";
+
+/// Deserialized shape of the `(owner/repo, number)` pair parsed from
+/// a pull-request URL.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PullRequestRef {
+    pub repository: String,
+    pub pull_number: u64,
+}
+
+/// Clap value-parser for the positional PR URL argument.
+///
+/// Returning `Err(String)` makes clap exit with status 2 (argument
+/// validation error) rather than our CLI's `ConfigurationError` —
+/// matching the Python CLI's behavior where `_parse_pr_url` raises
+/// `click.BadParameter` (also exit 2).
+///
+/// # Errors
+///
+/// Returns a human-readable message when `url` is not a valid
+/// GitHub-style pull request URL.
+pub fn parse_pr_url(url: &str) -> Result<PullRequestRef, String> {
+    let rest = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+        .ok_or_else(|| format!("Invalid pull request URL: {url}"))?;
+    let parts: Vec<&str> = rest.split('/').collect();
+    if parts.len() != 5 || parts[3] != "pull" {
+        return Err(format!("Invalid pull request URL: {url}"));
+    }
+    let [host, owner, repo, _pull, number] = [parts[0], parts[1], parts[2], parts[3], parts[4]];
+    if host.is_empty() || owner.is_empty() || repo.is_empty() {
+        return Err(format!("Invalid pull request URL: {url}"));
+    }
+    let pull_number: u64 = number
+        .parse()
+        .map_err(|_| format!("Invalid pull request URL: {url}"))?;
+    Ok(PullRequestRef {
+        repository: format!("{owner}/{repo}"),
+        pull_number,
+    })
+}
+
+/// Resolve the Mergify API bearer token.
+///
+/// Precedence: explicit `--token`, then `MERGIFY_TOKEN`, then
+/// `GITHUB_TOKEN`. Errors out when none of those are set.
+fn resolve_token(explicit: Option<&str>) -> Result<String, CliError> {
+    if let Some(token) = explicit.filter(|t| !t.is_empty()) {
+        return Ok(token.to_string());
+    }
+    for env_name in ["MERGIFY_TOKEN", "GITHUB_TOKEN"] {
+        if let Ok(value) = env::var(env_name) {
+            if !value.is_empty() {
+                return Ok(value);
+            }
+        }
+    }
+    Err(CliError::Configuration(
+        "please set the 'MERGIFY_TOKEN' or 'GITHUB_TOKEN' environment variable, \
+         or pass --token explicitly"
+            .to_string(),
+    ))
+}
+
+/// Resolve the Mergify API base URL. Falls back to `MERGIFY_API_URL`
+/// env var, then to the default `https://api.mergify.com`.
+fn resolve_api_url(explicit: Option<&str>) -> Result<Url, CliError> {
+    let raw = explicit
+        .map(str::to_string)
+        .or_else(|| env::var("MERGIFY_API_URL").ok())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_API_URL.to_string());
+    Url::parse(&raw).map_err(|e| CliError::Configuration(format!("invalid --api-url {raw:?}: {e}")))
+}
+
+#[derive(Serialize)]
+struct SimulatorRequest<'a> {
+    mergify_yml: &'a str,
+}
+
+#[derive(Deserialize)]
+struct SimulatorResponse {
+    title: String,
+    summary: String,
+}
+
+pub struct SimulateOptions<'a> {
+    pub pull_request: &'a PullRequestRef,
+    pub config_file: Option<&'a Path>,
+    pub token: Option<&'a str>,
+    pub api_url: Option<&'a str>,
+}
+
+/// Run the `config simulate` command.
+pub async fn run(opts: SimulateOptions<'_>, output: &mut dyn Output) -> Result<(), CliError> {
+    let config_path = resolve_config_path(opts.config_file)?;
+    let mergify_yml = std::fs::read_to_string(&config_path).map_err(|e| {
+        CliError::Configuration(format!("cannot read {}: {e}", config_path.display()))
+    })?;
+
+    let token = resolve_token(opts.token)?;
+    let api_url = resolve_api_url(opts.api_url)?;
+
+    output.status(&format!("Simulating against {api_url}…"))?;
+
+    let client = HttpClient::new(api_url, token, ApiFlavor::Mergify)?;
+    let path = format!(
+        "/v1/repos/{}/pulls/{}/simulator",
+        opts.pull_request.repository, opts.pull_request.pull_number,
+    );
+    let response: SimulatorResponse = client
+        .post(
+            &path,
+            &SimulatorRequest {
+                mergify_yml: &mergify_yml,
+            },
+        )
+        .await?;
+
+    emit_result(output, &response)?;
+    Ok(())
+}
+
+fn emit_result(output: &mut dyn Output, response: &SimulatorResponse) -> std::io::Result<()> {
+    let title = response.title.clone();
+    let summary = response.summary.clone();
+    output.emit(&(), &mut |w: &mut dyn Write| {
+        writeln!(w, "{title}")?;
+        writeln!(w)?;
+        // Intentional drift from Python: we print raw Markdown
+        // instead of rich-rendering it. Machine-readable output is
+        // still locked; human rendering is flexible per the compat
+        // contract.
+        writeln!(w, "{summary}")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use mergify_core::OutputMode;
+    use mergify_core::StdioOutput;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::body_json;
+    use wiremock::matchers::header;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    use super::*;
+
+    #[test]
+    fn parse_pr_url_accepts_canonical_github_url() {
+        let got = parse_pr_url("https://github.com/owner/repo/pull/42").unwrap();
+        assert_eq!(got.repository, "owner/repo");
+        assert_eq!(got.pull_number, 42);
+    }
+
+    #[test]
+    fn parse_pr_url_rejects_non_pull_path() {
+        assert!(parse_pr_url("https://github.com/owner/repo/issues/42").is_err());
+    }
+
+    #[test]
+    fn parse_pr_url_rejects_trailing_segments() {
+        assert!(parse_pr_url("https://github.com/owner/repo/pull/42/files").is_err());
+    }
+
+    #[test]
+    fn parse_pr_url_rejects_non_numeric_pull_number() {
+        assert!(parse_pr_url("https://github.com/owner/repo/pull/abc").is_err());
+    }
+
+    #[test]
+    fn parse_pr_url_rejects_missing_scheme() {
+        assert!(parse_pr_url("github.com/owner/repo/pull/42").is_err());
+    }
+
+    #[test]
+    fn parse_pr_url_rejects_empty_owner() {
+        assert!(parse_pr_url("https://github.com//repo/pull/42").is_err());
+    }
+
+    #[test]
+    fn resolve_token_prefers_explicit_over_env() {
+        temp_env::with_vars(
+            [
+                ("MERGIFY_TOKEN", Some("from-env")),
+                ("GITHUB_TOKEN", Some("github-env")),
+            ],
+            || {
+                assert_eq!(resolve_token(Some("from-cli")).unwrap(), "from-cli");
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_token_falls_back_to_mergify_env() {
+        temp_env::with_vars(
+            [
+                ("MERGIFY_TOKEN", Some("mergify-env")),
+                ("GITHUB_TOKEN", Some("github-env")),
+            ],
+            || {
+                assert_eq!(resolve_token(None).unwrap(), "mergify-env");
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_token_falls_back_to_github_env() {
+        temp_env::with_vars(
+            [
+                ("MERGIFY_TOKEN", None::<&str>),
+                ("GITHUB_TOKEN", Some("github-env")),
+            ],
+            || {
+                assert_eq!(resolve_token(None).unwrap(), "github-env");
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_token_errors_when_no_source_available() {
+        temp_env::with_vars(
+            [
+                ("MERGIFY_TOKEN", None::<&str>),
+                ("GITHUB_TOKEN", None::<&str>),
+            ],
+            || {
+                let err = resolve_token(None).unwrap_err();
+                assert!(matches!(err, CliError::Configuration(_)));
+                assert!(err.to_string().contains("MERGIFY_TOKEN"));
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_api_url_uses_default_when_unset() {
+        temp_env::with_vars([("MERGIFY_API_URL", None::<&str>)], || {
+            assert_eq!(
+                resolve_api_url(None).unwrap().as_str(),
+                "https://api.mergify.com/",
+            );
+        });
+    }
+
+    #[test]
+    fn resolve_api_url_prefers_explicit() {
+        temp_env::with_vars([("MERGIFY_API_URL", Some("https://from.env"))], || {
+            assert_eq!(
+                resolve_api_url(Some("https://from.cli")).unwrap().as_str(),
+                "https://from.cli/",
+            );
+        });
+    }
+
+    #[tokio::test]
+    async fn run_posts_config_and_prints_simulator_result() {
+        let server = MockServer::start().await;
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join(".mergify.yml");
+        fs::write(&config_path, "pull_request_rules: []\n").unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/v1/repos/owner/repo/pulls/42/simulator"))
+            .and(header("Authorization", "Bearer test-token"))
+            .and(body_json(serde_json::json!({
+                "mergify_yml": "pull_request_rules: []\n",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "title": "Would merge immediately",
+                "summary": "All conditions pass.",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let pull_request = PullRequestRef {
+            repository: "owner/repo".into(),
+            pull_number: 42,
+        };
+        let api_url = server.uri();
+
+        let stdout: std::sync::Arc<std::sync::Mutex<Vec<u8>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let stderr: std::sync::Arc<std::sync::Mutex<Vec<u8>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut output = StdioOutput::with_sinks(
+            OutputMode::Human,
+            SharedWriter(std::sync::Arc::clone(&stdout)),
+            SharedWriter(std::sync::Arc::clone(&stderr)),
+        );
+
+        run(
+            SimulateOptions {
+                pull_request: &pull_request,
+                config_file: Some(&config_path),
+                token: Some("test-token"),
+                api_url: Some(&api_url),
+            },
+            &mut output,
+        )
+        .await
+        .unwrap();
+
+        let stdout_bytes = stdout.lock().unwrap().clone();
+        let stdout_str = String::from_utf8(stdout_bytes).unwrap();
+        assert!(
+            stdout_str.contains("Would merge immediately"),
+            "expected title in output: {stdout_str:?}",
+        );
+        assert!(
+            stdout_str.contains("All conditions pass."),
+            "expected summary in output: {stdout_str:?}",
+        );
+    }
+
+    struct SharedWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl Write for SharedWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+}

--- a/crates/mergify-config/src/validate.rs
+++ b/crates/mergify-config/src/validate.rs
@@ -18,7 +18,6 @@
 
 use std::io::Write;
 use std::path::Path;
-use std::path::PathBuf;
 
 use mergify_core::ApiFlavor;
 use mergify_core::CliError;
@@ -26,11 +25,10 @@ use mergify_core::HttpClient;
 use mergify_core::Output;
 use url::Url;
 
+use crate::paths::resolve_config_path;
+
 const SCHEMA_HOST: &str = "https://docs.mergify.com";
 const SCHEMA_PATH: &str = "/mergify-configuration-schema.json";
-
-const DEFAULT_CONFIG_PATHS: [&str; 3] =
-    [".mergify.yml", ".mergify/config.yml", ".github/mergify.yml"];
 
 /// Run the `config validate` command.
 ///
@@ -53,30 +51,6 @@ pub async fn run(explicit_path: Option<&Path>, output: &mut dyn Output) -> Resul
         Err(CliError::Configuration(
             "configuration validation failed".to_string(),
         ))
-    }
-}
-
-fn resolve_config_path(explicit: Option<&Path>) -> Result<PathBuf, CliError> {
-    if let Some(path) = explicit {
-        if path.is_file() {
-            Ok(path.to_path_buf())
-        } else {
-            Err(CliError::Configuration(format!(
-                "Configuration file not found: {}",
-                path.display(),
-            )))
-        }
-    } else {
-        for candidate in DEFAULT_CONFIG_PATHS {
-            let path = Path::new(candidate);
-            if path.is_file() {
-                return Ok(path.to_path_buf());
-            }
-        }
-        Err(CliError::Configuration(format!(
-            "Mergify configuration file not found. Looked in: {}",
-            DEFAULT_CONFIG_PATHS.join(", "),
-        )))
     }
 }
 
@@ -209,38 +183,6 @@ mod tests {
                 },
             },
         })
-    }
-
-    #[test]
-    fn resolve_config_path_finds_dotmergify_yml() {
-        let tmp = tempfile::tempdir().unwrap();
-        fs::write(tmp.path().join(".mergify.yml"), "").unwrap();
-        let prev = std::env::current_dir().unwrap();
-        std::env::set_current_dir(tmp.path()).unwrap();
-
-        let got = resolve_config_path(None).unwrap();
-        assert_eq!(got, Path::new(".mergify.yml"));
-
-        std::env::set_current_dir(prev).unwrap();
-    }
-
-    #[test]
-    fn resolve_config_path_errors_when_no_file_and_no_explicit() {
-        let tmp = tempfile::tempdir().unwrap();
-        let prev = std::env::current_dir().unwrap();
-        std::env::set_current_dir(tmp.path()).unwrap();
-
-        let err = resolve_config_path(None).unwrap_err();
-        assert!(matches!(err, CliError::Configuration(_)));
-        assert!(err.to_string().contains("not found"));
-
-        std::env::set_current_dir(prev).unwrap();
-    }
-
-    #[test]
-    fn resolve_config_path_errors_on_explicit_missing_file() {
-        let err = resolve_config_path(Some(Path::new("/nonexistent/path.yml"))).unwrap_err();
-        assert!(matches!(err, CliError::Configuration(_)));
     }
 
     #[test]


### PR DESCRIPTION
Completes the config pilot. Second native command, flipped in
PORT_STATUS.toml from ``shimmed`` to ``native``.

## What ports natively

``mergify config simulate PULL_REQUEST_URL [-f PATH] [-t TOKEN] [-u URL]``:

1. Parses the PR URL into ``(owner/repo, number)``. Invalid URLs
   are rejected by clap's ``value_parser``, which exits 2 (matching
   Python's ``click.BadParameter``).
2. Resolves the config file (same three-location search as
   ``config validate`` — shared helper in ``paths.rs``).
3. Reads the YAML as a raw string (no parsing — the simulator API
   accepts the text verbatim).
4. Resolves the bearer token: explicit ``--token`` → ``MERGIFY_TOKEN``
   → ``GITHUB_TOKEN`` → error. Matches Python's precedence; the
   ``gh auth token`` subprocess fallback isn't ported yet.
5. Resolves the API URL: explicit ``--api-url`` → ``MERGIFY_API_URL``
   → ``https://api.mergify.com`` default.
6. POSTs ``{"mergify_yml": <content>}`` to
   ``/v1/repos/<repo>/pulls/<number>/simulator`` via the 1.2b HTTP
   client (auth + retry + typed errors).
7. Prints the returned title + summary to stdout.

Rich Markdown rendering of ``summary`` is deliberately deferred —
we print raw Markdown today. Human output drift is allowed by the
compat contract; machine-readable paths aren't affected because
``config simulate`` has no ``--json`` flag in Python either.

## Dispatch

``mergify-cli/src/main.rs`` now carries two clap subcommands
(``validate`` + ``simulate``). The dispatch logic got a light
reshape: on clap parse failure we distinguish "obvious native
intent" (argv contains ``config`` + one of ``validate``/``simulate``)
from "unrecognized command, fall through". Native-intent parse
errors surface clap's formatted error and exit 2; anything else
falls through to the Python shim so unported commands keep working.

## Refactor

The config-path resolver moved from ``validate.rs`` into a shared
``paths.rs`` module so both commands share a single source of
truth for the ``[".mergify.yml", ".mergify/config.yml",
".github/mergify.yml"]`` search list.

## Tests

24 tests in ``mergify-config`` (up from 11 in Phase 1.3):

- 3 for the shared path resolver (moved out of ``validate.rs``)
- 6 for PR URL parsing (happy path + 5 rejection cases)
- 4 for token resolution (explicit, env fallback, error)
- 2 for API URL resolution
- 1 end-to-end wiremock test: POST + JSON body + auth header +
  response rendering

Covered by the port-inventory guard: ``PORT_STATUS.toml`` flips
``config simulate`` from ``shimmed`` to ``native``.

Binary size: 8.0 MB → 8.3 MB (small bump from simulate.rs).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>