### PR TITLE
ci(renovate): group cargo / github-actions updates and enable lockFileMaintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,48 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "lockFileMaintenance": {
+    "enabled": false
+  },
+  "packageRules": [
+    {
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "enabled": true,
+      "schedule": [
+        "before 5am on monday"
+      ]
+    },
+    {
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "Cargo minor/patch updates",
+      "schedule": [
+        "before 5am on monday"
+      ]
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "GitHub Actions minor/patch updates",
+      "schedule": [
+        "before 5am on monday"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
The Rust workspace is growing fast — 5 crates already, more landing as
the port progresses. Without grouping, every minor/patch bump from
crates.io produces its own PR; with two managers (`cargo` and
`github-actions`) on a stack of stacked PRs that quickly drowns review.

- Group `cargo` minor/patch updates into a single weekly PR.
- Group `github-actions` minor/patch updates the same way.
- Enable `lockFileMaintenance` for `Cargo.lock` (Monday morning) so
  indirect dep drift doesn't accumulate between explicit Cargo.toml
  changes.

Major bumps still get their own PR (default behaviour kept) so they
stay easy to triage individually.