### PR TITLE
fix(cli): show friendly message on network/timeout errors

### DIFF
--- a/mergify_cli/cli.py
+++ b/mergify_cli/cli.py
@@ -24,6 +24,7 @@ import httpx
 
 from mergify_cli import VERSION
 from mergify_cli import console
+from mergify_cli import console_error
 from mergify_cli import utils
 from mergify_cli.ci import cli as ci_cli_mod
 from mergify_cli.config import cli as config_cli_mod
@@ -85,6 +86,18 @@ def main() -> None:
         # Error details already printed by check_for_status.
         # Distinguish Mergify API from GitHub API using the request base URL.
         if str(e.request.url).startswith(utils.get_mergify_api_url()):
+            raise SystemExit(ExitCode.MERGIFY_API_ERROR) from None
+        raise SystemExit(ExitCode.GITHUB_API_ERROR) from None
+    except httpx.RequestError as e:
+        url = str(e.request.url)
+        if isinstance(e, httpx.TimeoutException):
+            console_error(
+                f"timed out contacting {url}. "
+                "Check your network connection or try again later.",
+            )
+        else:
+            console_error(f"network error contacting {url}: {e}")
+        if url.startswith(utils.get_mergify_api_url()):
             raise SystemExit(ExitCode.MERGIFY_API_ERROR) from None
         raise SystemExit(ExitCode.GITHUB_API_ERROR) from None
     except utils.CommandError as e:

--- a/mergify_cli/tests/test_cli.py
+++ b/mergify_cli/tests/test_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest import mock
 
 from click import testing
+import httpx
 import pytest
 
 from mergify_cli import cli as cli_mod
@@ -67,6 +68,60 @@ def test_clirunner_mergify_error_default_is_generic() -> None:
     runner = testing.CliRunner()
     result = runner.invoke(fail_cmd, [])
     assert result.exit_code == ExitCode.GENERIC_ERROR, result.output
+
+
+def test_cli_connect_timeout_shows_clean_message(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """httpx.ConnectTimeout to GitHub produces a friendly message, no traceback."""
+    request = httpx.Request("GET", "https://api.github.com/user")
+    error = httpx.ConnectTimeout("timeout", request=request)
+    with (
+        mock.patch.object(cli_mod, "cli", side_effect=error),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        cli_mod.main()
+
+    assert exc_info.value.code == ExitCode.GITHUB_API_ERROR
+    out = capsys.readouterr().out
+    assert "timed out" in out
+    assert "https://api.github.com/user" in out
+    assert "Traceback" not in out
+    assert "ConnectTimeout" not in out
+
+
+def test_cli_connect_timeout_to_mergify_api(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Timeouts against the Mergify API map to MERGIFY_API_ERROR."""
+    request = httpx.Request("GET", f"{utils.get_mergify_api_url()}/v1/foo")
+    error = httpx.ConnectTimeout("timeout", request=request)
+    with (
+        mock.patch.object(cli_mod, "cli", side_effect=error),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        cli_mod.main()
+
+    assert exc_info.value.code == ExitCode.MERGIFY_API_ERROR
+    assert "timed out" in capsys.readouterr().out
+
+
+def test_cli_connect_error_shows_clean_message(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Non-timeout transport errors also get a friendly message."""
+    request = httpx.Request("GET", "https://api.github.com/user")
+    error = httpx.ConnectError("connection refused", request=request)
+    with (
+        mock.patch.object(cli_mod, "cli", side_effect=error),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        cli_mod.main()
+
+    assert exc_info.value.code == ExitCode.GITHUB_API_ERROR
+    out = capsys.readouterr().out
+    assert "network error" in out
+    assert "connection refused" in out
 
 
 def test_main_entrypoint_handles_mergify_error(


### PR DESCRIPTION
Previously, httpx transport errors (ConnectTimeout, ReadTimeout,
ConnectError, ...) bubbled up from main() as full tracebacks. Catch
httpx.RequestError in the top-level handler and print a one-line
error with the URL — distinguishing timeouts from other transport
failures — and exit with the existing MERGIFY_API_ERROR /
GITHUB_API_ERROR code based on the request URL.