### PR TITLE
fix(stack): anchor old PR head SHAs in local refs for revision history

### DIFF
--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -218,12 +218,19 @@ async def detect_change_type(old_sha: str, new_sha: str) -> str:
     return "rebase" if old_patch_id == new_patch_id else "content"
 
 
+OLD_PR_HEADS_REF_PREFIX = "refs/mergify/stack/old-pr-heads"
+
+
 async def fetch_old_pr_heads(remote: str, pr_numbers: list[int]) -> None:
-    """Fetch current PR head refs so old SHAs are available locally for patch-id comparison."""
+    """Fetch current PR head refs into local refs so the old SHAs stay
+    anchored (and survive any background ``gc``) for the patch-id
+    comparison performed after the force-push."""
     if not pr_numbers:
         return
-    refspecs = [f"refs/pull/{n}/head" for n in pr_numbers]
-    await utils.git("fetch", remote, *refspecs)
+    refspecs = [
+        f"+refs/pull/{n}/head:{OLD_PR_HEADS_REF_PREFIX}/{n}" for n in pr_numbers
+    ]
+    await utils.git("fetch", remote, "--no-write-fetch-head", *refspecs)
 
 
 @dataclasses.dataclass

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -424,7 +424,13 @@ async def test_stack_update_no_rebase(
         "/repos/user/repo/issues/comments/456",
     ).respond(200)
     respx_mock.post("/repos/user/repo/issues/123/comments").respond(200)
-    git_mock.mock("fetch", "origin", "refs/pull/123/head", output="")
+    git_mock.mock(
+        "fetch",
+        "origin",
+        "--no-write-fetch-head",
+        "+refs/pull/123/head:refs/mergify/stack/old-pr-heads/123",
+        output="",
+    )
 
     with mock.patch.object(push, "detect_change_type", return_value="content"):
         await push.stack_push(
@@ -529,7 +535,13 @@ async def test_stack_update(
     )
     respx_mock.patch("/repos/user/repo/issues/comments/456").respond(200)
     respx_mock.post("/repos/user/repo/issues/123/comments").respond(200)
-    git_mock.mock("fetch", "origin", "refs/pull/123/head", output="")
+    git_mock.mock(
+        "fetch",
+        "origin",
+        "--no-write-fetch-head",
+        "+refs/pull/123/head:refs/mergify/stack/old-pr-heads/123",
+        output="",
+    )
 
     with mock.patch.object(push, "detect_change_type", return_value="content"):
         await push.stack_push(
@@ -626,7 +638,13 @@ async def test_stack_update_keep_title_and_body(
     )
     respx_mock.patch("/repos/user/repo/issues/comments/456").respond(200)
     respx_mock.post("/repos/user/repo/issues/123/comments").respond(200)
-    git_mock.mock("fetch", "origin", "refs/pull/123/head", output="")
+    git_mock.mock(
+        "fetch",
+        "origin",
+        "--no-write-fetch-head",
+        "+refs/pull/123/head:refs/mergify/stack/old-pr-heads/123",
+        output="",
+    )
 
     with mock.patch.object(push, "detect_change_type", return_value="content"):
         await push.stack_push(
@@ -964,8 +982,9 @@ async def test_fetch_old_pr_heads(
     git_mock.mock(
         "fetch",
         "origin",
-        "refs/pull/1/head",
-        "refs/pull/2/head",
+        "--no-write-fetch-head",
+        "+refs/pull/1/head:refs/mergify/stack/old-pr-heads/1",
+        "+refs/pull/2/head:refs/mergify/stack/old-pr-heads/2",
         output="",
     )
     await push.fetch_old_pr_heads("origin", [1, 2])
@@ -1222,7 +1241,8 @@ async def test_create_revision_comment_on_update(
     git_mock.mock(
         "fetch",
         "origin",
-        "refs/pull/123/head",
+        "--no-write-fetch-head",
+        "+refs/pull/123/head:refs/mergify/stack/old-pr-heads/123",
         output="",
     )
 
@@ -1429,7 +1449,12 @@ async def test_no_revision_history_flag_skips_revision_comments(
     )
 
     # No fetch of PR heads
-    assert not git_mock.has_been_called_with("fetch", "origin", "refs/pull/123/head")
+    assert not git_mock.has_been_called_with(
+        "fetch",
+        "origin",
+        "--no-write-fetch-head",
+        "+refs/pull/123/head:refs/mergify/stack/old-pr-heads/123",
+    )
     # No revision comment posted
     for call in respx_mock.calls:
         if call.request.method == "POST" and "/comments" in str(call.request.url):
@@ -1455,7 +1480,13 @@ async def test_revision_comment_updated_on_second_push(
     git_mock.finalize(
         remote_shas={"I29617d37762fd69809c255d7e7073cb11f8fbf50": "second_sha"},
     )
-    git_mock.mock("fetch", "origin", "refs/pull/123/head", output="")
+    git_mock.mock(
+        "fetch",
+        "origin",
+        "--no-write-fetch-head",
+        "+refs/pull/123/head:refs/mergify/stack/old-pr-heads/123",
+        output="",
+    )
 
     respx_mock.get("/user").respond(200, json={"login": "author"})
     respx_mock.get("/search/issues").respond(
@@ -2071,7 +2102,13 @@ async def test_revision_comment_includes_reason_from_local_change(
         "third_sha",
         output="fixed typo in sql",
     )
-    git_mock.mock("fetch", "origin", "refs/pull/123/head", output="")
+    git_mock.mock(
+        "fetch",
+        "origin",
+        "--no-write-fetch-head",
+        "+refs/pull/123/head:refs/mergify/stack/old-pr-heads/123",
+        output="",
+    )
 
     respx_mock.get("/user").respond(200, json={"login": "author"})
     respx_mock.get("/search/issues").respond(
@@ -2488,7 +2525,13 @@ async def test_stack_push_auto_skips_rebase_when_approved(
             "I29617d37762fd69809c255d7e7073cb11f8fbf50": "old_head_sha",
         },
     )
-    git_mock.mock("fetch", "origin", "refs/pull/1/head", output="")
+    git_mock.mock(
+        "fetch",
+        "origin",
+        "--no-write-fetch-head",
+        "+refs/pull/1/head:refs/mergify/stack/old-pr-heads/1",
+        output="",
+    )
 
     respx_mock.get("/user").respond(200, json={"login": "author"})
     respx_mock.get("/search/issues").respond(


### PR DESCRIPTION
`fetch_old_pr_heads` previously fetched `refs/pull/N/head` with no
destination refspec, leaving the SHA reachable only via FETCH_HEAD —
which any subsequent fetch (or background `gc`) can drop. When the
SHA is no longer locally reachable, `git show <old_sha>` fails inside
`_git_patch_id`, and `detect_change_type` falls back to the
"unknown" classification in the PR's revision-history comment.

Fetch into a stable per-PR ref under `refs/mergify/stack/old-pr-heads/<N>`
(forced refspec, with `--no-write-fetch-head` to avoid touching the
shared FETCH_HEAD pointer). The SHA is then anchored by a real ref
for the lifetime of the patch-id comparison and beyond, so future
runs can compare even after a long gap.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>