### PR TITLE
fix(utils): decode CommandError stdout safely so __str__ never raises

### DIFF
--- a/mergify_cli/tests/test_utils.py
+++ b/mergify_cli/tests/test_utils.py
@@ -31,6 +31,13 @@ if TYPE_CHECKING:
     import pathlib
 
 
+def test_command_error_str_handles_non_utf8_stdout() -> None:
+    # Some git invocations (e.g. legacy locales) can emit non-UTF-8 bytes;
+    # str(CommandError) must not raise — error paths depend on it.
+    error = utils.CommandError(("git", "show", "abc"), 1, b"\xff\xfe broken")
+    assert "failed to run `git show abc`" in str(error)
+
+
 @pytest.mark.usefixtures("_git_repo")
 async def test_get_branch_name() -> None:
     assert await utils.git_get_branch_name() == "main"

--- a/mergify_cli/utils.py
+++ b/mergify_cli/utils.py
@@ -92,7 +92,13 @@ class CommandError(Exception):
     stdout: bytes
 
     def __str__(self) -> str:
-        return f"failed to run `{' '.join(self.command_args)}`: {self.stdout.decode()}"
+        # ``errors="replace"`` so str(CommandError) never raises on
+        # non-UTF-8 process output — callers in error paths (warnings,
+        # CLI top-level handler) rely on this being safe.
+        return (
+            f"failed to run `{' '.join(self.command_args)}`: "
+            f"{self.stdout.decode(errors='replace')}"
+        )
 
 
 class MergifyError(click.ClickException):


### PR DESCRIPTION
`CommandError.__str__` decoded captured stdout as strict UTF-8, so any
non-UTF-8 bytes from a subprocess (legacy locales, binary diff fragments,
truncated multi-byte sequences) would turn `str(error)` into a
`UnicodeDecodeError`. Every error-formatting site is affected — the
top-level CLI handler in `cli.py:104`, log messages, etc. — converting
the failure into an unhandled traceback instead of a clean message.

Switch to `decode(errors="replace")`. Invalid bytes become the U+FFFD
replacement character; all other formatting is preserved.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>