### PR TITLE
build(packaging): switch wheel build to maturin, ship Rust binary alongside Python source

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,14 @@ jobs:
         with:
           python-version: 3.14
 
+      # The maturin build-backend invokes cargo at sync time, so
+      # every Python-using job needs the Rust toolchain on PATH.
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+      - uses: Swatinem/rust-cache@v2
+
       - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
@@ -34,6 +42,12 @@ jobs:
       - uses: actions/setup-python@v6.2.0
         with:
           python-version: 3.14
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+      - uses: Swatinem/rust-cache@v2
 
       - uses: astral-sh/setup-uv@v8.1.0
         with:
@@ -71,7 +85,7 @@ jobs:
         run: cargo build --release
 
   test:
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2025, macos-15]
@@ -82,6 +96,17 @@ jobs:
       - uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python }}
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # The matrix runs the same target six times. Keying the
+          # cache on (os, python) avoids cross-pollution while still
+          # letting cargo reuse fetched crates within each shard.
+          key: ${{ matrix.os }}-py${{ matrix.python }}
 
       - uses: astral-sh/setup-uv@v8.1.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,38 @@
 name: upload release to PyPI
+
+# Builds platform-tagged wheels (one per supported target) plus an
+# sdist, then publishes everything to PyPI in a single
+# Trusted-Publisher upload. The wheel version is stamped from the
+# git tag (`$GITHUB_REF`) so the existing tag-driven release UX
+# stays the same as the pre-port hatch-vcs flow.
+#
+# Targets: Linux x64/arm64 (manylinux), macOS x64/arm64,
+# Windows x64. Add new targets here when a new platform is on the
+# support matrix.
+
 on:
   release:
     types:
       - published
 
 jobs:
-  pypi-publish:
-    name: upload release to PyPI
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      id-token: write
-      contents: write
+  build-wheels:
+    name: build wheel (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04
+            target: aarch64-unknown-linux-gnu
+          - os: macos-15
+            target: x86_64-apple-darwin
+          - os: macos-15
+            target: aarch64-apple-darwin
+          - os: windows-2025
+            target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -22,13 +43,84 @@ jobs:
         with:
           python-version: 3.14
 
-      - uses: astral-sh/setup-uv@v8.1.0
-        with:
-          enable-cache: true
-          version-file: requirements-uv.txt
+      - name: Stamp wheel version from git tag
+        shell: bash
+        run: |
+          set -eu
+          VERSION="${GITHUB_REF#refs/tags/}"
+          # `sed -i.bak`/rm form works on both BSD (macOS) and GNU
+          # (Linux) sed without divergent flag handling. On Windows
+          # the runner ships GNU sed via Git Bash, which honours the
+          # same syntax.
+          sed -i.bak -E "s/^version = \".*\"$/version = \"${VERSION}\"/" pyproject.toml
+          rm -f pyproject.toml.bak
+          echo "Stamped pyproject.toml:"
+          grep '^version = ' pyproject.toml
 
-      - name: 
-        run: uv build
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          # `manylinux: auto` picks the most-compatible glibc the
+          # target supports; `--strip` shaves debug symbols off the
+          # bundled binary.
+          args: --release --strip --out target/wheels
+          manylinux: auto
+          sccache: true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.target }}
+          path: target/wheels/*.whl
+
+  build-sdist:
+    name: build sdist
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Stamp wheel version from git tag
+        shell: bash
+        run: |
+          set -eu
+          VERSION="${GITHUB_REF#refs/tags/}"
+          sed -i.bak -E "s/^version = \".*\"$/version = \"${VERSION}\"/" pyproject.toml
+          rm -f pyproject.toml.bak
+
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out target/wheels
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-sdist
+          path: target/wheels/*.tar.gz
+
+  publish:
+    name: publish to PyPI
+    runs-on: ubuntu-24.04
+    needs:
+      - build-wheels
+      - build-sdist
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheel-*
+          merge-multiple: true
+          path: dist
+
+      - name: Confirm collected artifacts
+        run: ls -la dist
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,27 +247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,16 +351,6 @@ checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
 dependencies = [
  "lazy_static",
  "num",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -784,25 +753,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,15 +850,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,10 +932,7 @@ dependencies = [
 name = "mergify-py-shim"
 version = "0.0.0"
 dependencies = [
- "dirs",
- "fs2",
- "include_dir",
- "tempfile",
+ "temp-env",
  "thiserror",
 ]
 
@@ -1109,12 +1047,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "outref"
@@ -1306,17 +1238,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror",
 ]
 
 [[package]]
@@ -2070,28 +1991,6 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/crates/mergify-py-shim/Cargo.toml
+++ b/crates/mergify-py-shim/Cargo.toml
@@ -10,13 +10,10 @@ description = "Embedded Python fallback for un-ported mergify-cli commands."
 publish = false
 
 [dependencies]
-dirs = "6.0"
-fs2 = "0.4"
-include_dir = "0.7"
 thiserror = "2.0"
 
 [dev-dependencies]
-tempfile = "3.14"
+temp-env = "0.3"
 
 [lints]
 workspace = true

--- a/crates/mergify-py-shim/src/lib.rs
+++ b/crates/mergify-py-shim/src/lib.rs
@@ -1,246 +1,164 @@
 //! Python shim for the mergify CLI Rust port.
 //!
-//! The current Python source is embedded at compile time via
-//! [`include_dir`]. On first invocation the shim extracts the
-//! embedded tree to a per-user cache directory (atomic, file-locked)
-//! and invokes `python3 -m mergify_cli` with that directory on
-//! `PYTHONPATH`. Args, stdin, stdout, stderr, and the exit code are
-//! passed through transparently.
+//! The Rust binary (`mergify`) is shipped inside a maturin-built
+//! Python wheel. When the wheel is installed (`pipx install
+//! mergify-cli`) the binary lands at `<venv>/bin/mergify` and the
+//! Python source at `<venv>/lib/pythonX.Y/site-packages/mergify_cli/`.
+//! For un-ported subcommands the shim locates the venv's `python3`
+//! (sibling of the binary) and invokes `python3 -m mergify_cli` with
+//! the original argv.
 //!
-//! When a command is ported to native Rust in Phase 1.3+, the caller
-//! dispatches to the native implementation first and falls back to
-//! [`run`] only for un-ported commands. Phase 6 removes this crate
-//! entirely once the port is complete.
+//! Args, stdin, stdout, stderr, and the exit code pass through
+//! transparently.
 //!
-//! The cache is keyed on `CARGO_PKG_VERSION`. During dev (`0.0.0`),
-//! that means the cache is shared across builds — if you change the
-//! embedded Python source while developing, clear
-//! `~/.cache/mergify/py/` to force a re-extract. The release
-//! pipeline in Phase 1.5 stamps a real version + git SHA, after
-//! which every build invalidates cleanly.
+//! Discovery: by default we resolve `<current_exe>/../python3` (or
+//! `python.exe` on Windows). When the binary is run from a
+//! `cargo build` checkout (no sibling Python), the
+//! `MERGIFY_PYTHON_EXE` env var overrides — point it at any
+//! interpreter that has the package available on `sys.path`.
+//!
+//! When a command ships native in Rust the caller dispatches to the
+//! native impl first and only falls back to [`run`] for un-ported
+//! commands. The plan is for each port PR to delete its Python
+//! implementation in the same change, so the shim's reach shrinks
+//! one command at a time. Phase 6 deletes this crate entirely.
 
 use std::env;
-use std::fs;
 use std::io;
-use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-use fs2::FileExt;
-use include_dir::Dir;
-use include_dir::DirEntry;
-use include_dir::include_dir;
+#[cfg(windows)]
+const PYTHON_FILENAME: &str = "python.exe";
+#[cfg(not(windows))]
+const PYTHON_FILENAME: &str = "python3";
 
-static PY_SOURCE: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/../../mergify_cli");
-
-/// Cache key under `~/.cache/mergify/py/`. Tied to the binary's
-/// build version so a new binary auto-invalidates any older extract.
-const CACHE_KEY: &str = env!("CARGO_PKG_VERSION");
+/// Env override for the Python interpreter. Useful in `cargo build`
+/// checkouts where the binary has no sibling Python in the same
+/// `bin/` directory (developer convenience).
+const PYTHON_EXE_ENV: &str = "MERGIFY_PYTHON_EXE";
 
 #[derive(thiserror::Error, Debug)]
 pub enum ShimError {
     #[error(
-        "python3 not found on PATH. mergify requires Python 3.13+ during the port; install it and try again"
+        "could not locate a Python interpreter. Expected `{expected}` (sibling of the mergify \
+         binary) or `${env_var}` to be set to a python3.13+ executable"
     )]
-    PythonNotFound,
+    PythonNotFound {
+        expected: String,
+        env_var: &'static str,
+    },
 
-    #[error("could not locate user cache directory on this platform")]
-    CacheDirNotFound,
+    #[error("could not determine the path of the running mergify binary: {0}")]
+    SelfPathUnknown(#[source] io::Error),
 
-    #[error("could not prepare embedded Python source at {path}: {source}")]
-    Extraction {
+    #[error("could not invoke python interpreter at {path}: {source}")]
+    Invocation {
         path: PathBuf,
         #[source]
         source: io::Error,
     },
-
-    #[error("could not invoke python3: {0}")]
-    Invocation(#[source] io::Error),
 }
 
-/// Run the embedded Python CLI with the given argv tail.
+/// Run the bundled Python CLI with the given argv tail.
 ///
 /// Returns the exit code to propagate to the OS.
 pub fn run(args: &[String]) -> Result<i32, ShimError> {
-    let cache_base = cache_base()?;
-    let source_root = ensure_extracted(&cache_base)?;
-    invoke_python(&source_root, args)
+    let python = locate_python()?;
+    invoke(&python, args)
 }
 
-fn cache_base() -> Result<PathBuf, ShimError> {
-    Ok(dirs::cache_dir()
-        .ok_or(ShimError::CacheDirNotFound)?
-        .join("mergify")
-        .join("py"))
-}
-
-/// Ensure the embedded Python source is present on disk under
-/// `<cache_base>/<CACHE_KEY>/` and return that directory (which
-/// contains a `mergify_cli/` subdirectory, ready for `PYTHONPATH`).
-fn ensure_extracted(cache_base: &Path) -> Result<PathBuf, ShimError> {
-    let target_dir = cache_base.join(CACHE_KEY);
-    let sentinel = target_dir.join(".complete");
-
-    // Fast path: already extracted.
-    if sentinel.exists() {
-        return Ok(target_dir);
-    }
-
-    fs::create_dir_all(cache_base).map_err(|source| ShimError::Extraction {
-        path: cache_base.to_path_buf(),
-        source,
-    })?;
-
-    // Lock a sibling file (not the target dir itself, which is about
-    // to be renamed). Blocks until we have exclusive access so two
-    // concurrent first-runs serialize on the extraction.
-    let lock_path = cache_base.join(format!("{CACHE_KEY}.lock"));
-    let lock_file = fs::OpenOptions::new()
-        .create(true)
-        .truncate(false)
-        .write(true)
-        .open(&lock_path)
-        .map_err(|source| ShimError::Extraction {
-            path: lock_path.clone(),
-            source,
-        })?;
-    FileExt::lock_exclusive(&lock_file).map_err(|source| ShimError::Extraction {
-        path: lock_path.clone(),
-        source,
-    })?;
-
-    // Double-check under lock: another process may have extracted
-    // while we were waiting.
-    if sentinel.exists() {
-        return Ok(target_dir);
-    }
-
-    // Clean up any `*.extracting-*` dirs left behind by a crashed
-    // previous attempt. We hold the lock, so no other process is
-    // currently extracting for this cache key.
-    let extracting_prefix = format!("{CACHE_KEY}.extracting-");
-    if let Ok(entries) = fs::read_dir(cache_base) {
-        for entry in entries.flatten() {
-            if entry
-                .file_name()
-                .to_str()
-                .is_some_and(|name| name.starts_with(&extracting_prefix))
-            {
-                let _ = fs::remove_dir_all(entry.path());
+fn locate_python() -> Result<PathBuf, ShimError> {
+    if let Ok(explicit) = env::var(PYTHON_EXE_ENV) {
+        if !explicit.is_empty() {
+            let path = PathBuf::from(&explicit);
+            // Validate eagerly: if `MERGIFY_PYTHON_EXE` is set but
+            // points at a missing/non-file path, surface that here
+            // with the exact value the user provided, rather than
+            // letting `Command::new(...).status()` later fail with
+            // an opaque `No such file or directory` error.
+            if !path.is_file() {
+                return Err(ShimError::PythonNotFound {
+                    expected: explicit,
+                    env_var: PYTHON_EXE_ENV,
+                });
             }
+            return Ok(path);
         }
     }
 
-    // Extract to a sibling temp dir, then atomic rename. Name
-    // includes PID + a nanosecond timestamp so concurrent writers
-    // (if any) don't collide even under an unlikely PID collision.
-    let unique_suffix = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |d| d.as_nanos());
-    let temp_dir = cache_base.join(format!(
-        "{CACHE_KEY}.extracting-{}-{unique_suffix}",
-        std::process::id(),
-    ));
-    fs::create_dir_all(&temp_dir).map_err(|source| ShimError::Extraction {
-        path: temp_dir.clone(),
-        source,
-    })?;
-
-    extract_into(&PY_SOURCE, &temp_dir.join("mergify_cli")).map_err(|source| {
-        ShimError::Extraction {
-            path: temp_dir.clone(),
-            source,
-        }
-    })?;
-
-    // Rename is atomic on the same filesystem. If a previous
-    // interrupted run left a partial target, clear it first.
-    if target_dir.exists() {
-        fs::remove_dir_all(&target_dir).map_err(|source| ShimError::Extraction {
-            path: target_dir.clone(),
-            source,
-        })?;
-    }
-    fs::rename(&temp_dir, &target_dir).map_err(|source| ShimError::Extraction {
-        path: target_dir.clone(),
-        source,
-    })?;
-
-    // Sentinel last — its presence means "extraction complete".
-    fs::write(&sentinel, b"").map_err(|source| ShimError::Extraction {
-        path: sentinel.clone(),
-        source,
-    })?;
-
-    Ok(target_dir)
-}
-
-/// Write every file in `dir` under `target` (creating directories as
-/// needed). `include_dir` stores each file's path relative to the
-/// root Dir, so `target.join(file.path())` gives the full output
-/// path even for deeply nested files.
-fn extract_into(dir: &Dir<'_>, target: &Path) -> io::Result<()> {
-    fs::create_dir_all(target)?;
-    let mut stack: Vec<&Dir<'_>> = vec![dir];
-    while let Some(current) = stack.pop() {
-        for entry in current.entries() {
-            match entry {
-                DirEntry::Dir(subdir) => {
-                    // subdir.path() is relative to the root Dir; strip
-                    // the mergify_cli/ prefix the same way the file
-                    // branch below does.
-                    let relative = subdir
-                        .path()
-                        .strip_prefix(dir.path())
-                        .unwrap_or(subdir.path());
-                    fs::create_dir_all(target.join(relative))?;
-                    stack.push(subdir);
-                }
-                DirEntry::File(file) => {
-                    let relative = file.path().strip_prefix(dir.path()).unwrap_or(file.path());
-                    let dest = target.join(relative);
-                    if let Some(parent) = dest.parent() {
-                        fs::create_dir_all(parent)?;
-                    }
-                    fs::write(dest, file.contents())?;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-fn invoke_python(source_root: &Path, args: &[String]) -> Result<i32, ShimError> {
-    // Prepend the extracted dir to PYTHONPATH so `python3 -m
-    // mergify_cli` resolves regardless of the user's environment.
-    let mut paths = vec![source_root.to_path_buf()];
-    if let Ok(existing) = env::var("PYTHONPATH") {
-        paths.extend(env::split_paths(&existing));
-    }
-    let new_pythonpath = env::join_paths(paths).map_err(|e| {
-        ShimError::Invocation(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("could not construct PYTHONPATH: {e}"),
+    let exe = env::current_exe().map_err(ShimError::SelfPathUnknown)?;
+    let parent = exe.parent().ok_or_else(|| {
+        ShimError::SelfPathUnknown(io::Error::new(
+            io::ErrorKind::NotFound,
+            "current_exe has no parent directory",
         ))
     })?;
 
-    let status = Command::new("python3")
-        .arg("-m")
+    // Layouts to probe, in order:
+    // 1. `<exe-dir>/python(.exe)` — Linux/macOS pip & pipx, Windows
+    //    venv (everything ends up under `Scripts/`).
+    // 2. `<exe-dir>/../python.exe` — Windows system-Python pip
+    //    install: the binary lands in `<prefix>/Scripts/` while the
+    //    interpreter sits at `<prefix>/python.exe`.
+    let candidates = python_candidate_paths(parent);
+
+    for candidate in &candidates {
+        if candidate.is_file() {
+            return Ok(candidate.clone());
+        }
+    }
+
+    Err(ShimError::PythonNotFound {
+        expected: candidates
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", "),
+        env_var: PYTHON_EXE_ENV,
+    })
+}
+
+#[cfg(not(windows))]
+fn python_candidate_paths(parent: &std::path::Path) -> Vec<PathBuf> {
+    vec![parent.join(PYTHON_FILENAME)]
+}
+
+#[cfg(windows)]
+fn python_candidate_paths(parent: &std::path::Path) -> Vec<PathBuf> {
+    let mut candidates = vec![parent.join(PYTHON_FILENAME)];
+    if let Some(grandparent) = parent.parent() {
+        candidates.push(grandparent.join(PYTHON_FILENAME));
+    }
+    candidates
+}
+
+fn invoke(python: &std::path::Path, args: &[String]) -> Result<i32, ShimError> {
+    let mut cmd = Command::new(python);
+    cmd.arg("-m")
         .arg("mergify_cli")
         .args(args)
-        .env("PYTHONPATH", new_pythonpath)
         // PYTHONSAFEPATH=1 stops Python from prepending the current
         // working directory to sys.path. Without it, a user running
         // from a directory that happens to contain a `mergify_cli/`
-        // folder would import that instead of our extracted copy.
-        // This repo's Python CLI requires Python 3.13+, which
-        // supports PYTHONSAFEPATH (introduced in 3.11).
-        .env("PYTHONSAFEPATH", "1")
-        .status()
-        .map_err(|e| match e.kind() {
-            io::ErrorKind::NotFound => ShimError::PythonNotFound,
-            _ => ShimError::Invocation(e),
-        })?;
+        // folder would import that instead of the wheel's copy.
+        // Safe since the project requires Python 3.13+ and
+        // PYTHONSAFEPATH was introduced in 3.11.
+        .env("PYTHONSAFEPATH", "1");
+    // On Windows, force `PYTHONUTF8=1`. The Python `main()` has a
+    // legacy re-exec block (`subprocess.Popen(sys.argv, ...)`) that
+    // re-launches itself with utf8 mode when not already on. That
+    // re-exec assumes `sys.argv[0]` is a launcher binary; under
+    // `python -m mergify_cli` it's a `.py` file path, which Windows
+    // can't directly exec — `OSError [WinError 193] %1 is not a
+    // valid Win32 application`. Booting Python in utf8 mode skips
+    // the re-exec entirely.
+    #[cfg(windows)]
+    cmd.env("PYTHONUTF8", "1");
+    let status = cmd.status().map_err(|source| ShimError::Invocation {
+        path: python.to_path_buf(),
+        source,
+    })?;
 
     Ok(status.code().unwrap_or(1))
 }
@@ -250,49 +168,38 @@ mod tests {
     use super::*;
 
     #[test]
-    fn extract_into_writes_embedded_files() {
-        let tmp = tempfile::tempdir().unwrap();
-        let target = tmp.path().join("mergify_cli");
-        extract_into(&PY_SOURCE, &target).unwrap();
-
-        // Spot-check a handful of files we know exist in the Python
-        // source tree. Using files close to the root keeps the test
-        // robust to refactors of subdirectories.
-        assert!(target.join("__init__.py").is_file());
-        assert!(target.join("cli.py").is_file());
-        assert!(target.join("exit_codes.py").is_file());
+    fn locate_python_honors_env_override_when_file_exists() {
+        // Use the test binary itself as a stand-in for python — it
+        // exists and is a regular file, which is all `locate_python`
+        // checks (executability is enforced by `Command::new`).
+        let test_binary = env::current_exe().unwrap();
+        let path_str = test_binary.to_str().unwrap();
+        temp_env::with_var(PYTHON_EXE_ENV, Some(path_str), || {
+            let got = locate_python().unwrap();
+            assert_eq!(got, test_binary);
+        });
     }
 
     #[test]
-    fn extract_into_preserves_nested_structure() {
-        let tmp = tempfile::tempdir().unwrap();
-        let target = tmp.path().join("mergify_cli");
-        extract_into(&PY_SOURCE, &target).unwrap();
-
-        // Nested files get their full path reconstructed.
-        assert!(target.join("ci").is_dir());
-        assert!(target.join("stack").join("list.py").is_file());
+    fn locate_python_rejects_env_override_pointing_at_missing_file() {
+        temp_env::with_var(PYTHON_EXE_ENV, Some("/nonexistent/python"), || {
+            let err = locate_python().unwrap_err();
+            let msg = err.to_string();
+            assert!(matches!(err, ShimError::PythonNotFound { .. }));
+            // The user-supplied path must appear in the error so
+            // they can spot a typo without having to dig.
+            assert!(msg.contains("/nonexistent/python"), "got: {msg}");
+        });
     }
 
     #[test]
-    fn ensure_extracted_is_idempotent() {
-        let tmp = tempfile::tempdir().unwrap();
-        let base = tmp.path().join("cache");
-
-        let first = ensure_extracted(&base).unwrap();
-        let mtime_before = fs::metadata(first.join(".complete"))
-            .unwrap()
-            .modified()
-            .unwrap();
-
-        let second = ensure_extracted(&base).unwrap();
-        let mtime_after = fs::metadata(second.join(".complete"))
-            .unwrap()
-            .modified()
-            .unwrap();
-
-        assert_eq!(first, second);
-        // Sentinel is not rewritten on the fast path.
-        assert_eq!(mtime_before, mtime_after);
+    fn locate_python_errors_when_no_sibling_and_no_env() {
+        // The test binary lives under `target/debug/deps/<name>`;
+        // there's no python3 next to it. So the lookup must fail
+        // with a clear `PythonNotFound` describing where we looked.
+        temp_env::with_var_unset(PYTHON_EXE_ENV, || {
+            let err = locate_python().unwrap_err();
+            assert!(matches!(err, ShimError::PythonNotFound { .. }));
+        });
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,14 @@
 [project]
 name = "mergify_cli"
-dynamic = ["version"]
+# `version` is a placeholder. The release workflow stamps it from
+# the git tag (`$GITHUB_REF`) right before maturin runs — keeps the
+# git tag as the source of truth for PyPI versioning, the same way
+# hatch-vcs did pre-port. Cargo.toml stays at "0.0.0" because Cargo
+# SemVer rejects the 4-component calver format the project uses
+# (`2026.4.23.1`); `mergify --version` from the Rust binary will
+# report the placeholder until Phase 6, when versioning becomes
+# Rust-native end-to-end.
+version = "0.0.0"
 description = "Mergify CLI is a tool that automates the creation and management of stacked pull requests on GitHub and handles CI results upload"
 authors = [{ name = "Mergify Team", email = "hello@mergify.com" }]
 requires-python = ">=3.13"
@@ -33,9 +41,6 @@ dependencies = [
     "tzlocal==5.3.1",
 ]
 
-[project.scripts]
-mergify = "mergify_cli.cli:main"
-
 [project.urls]
 Homepage = "https://mergify.com"
 Documentation = "https://docs.mergify.com"
@@ -61,12 +66,21 @@ dev = [
 ]
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
-build-backend = "hatchling.build"
+requires = ["maturin>=1.7,<2.0"]
+build-backend = "maturin"
 
-[tool.hatch.version]
-source = "vcs"
-fallback-version = "0"
+[tool.maturin]
+# The wheel contains both the Rust binary `mergify` (built from
+# crates/mergify-cli) and the Python package `mergify_cli/`. The
+# Rust binary is the install-time `mergify` entry point; on
+# un-ported subcommands it shells out to the sibling `python3` in
+# the venv to run `python -m mergify_cli` against the bundled
+# package — keeping a single copy of every command at any moment.
+bindings = "bin"
+manifest-path = "crates/mergify-cli/Cargo.toml"
+python-source = "."
+module-name = "mergify_cli"
+strip = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/uv.lock
+++ b/uv.lock
@@ -283,6 +283,7 @@ wheels = [
 
 [[package]]
 name = "mergify-cli"
+version = "0.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Replaces hatchling with maturin so the Python wheel ships *both* the
existing `mergify_cli/` package and the new Rust binary as a
`bindings = "bin"` console-script. The two installs side-by-side in
the same venv layout pip already produces:

    <venv>/bin/mergify              # Rust binary (this commit's
                                    # entry point)
    <venv>/bin/python3              # interpreter pip set up
    <venv>/lib/.../site-packages/   # Python source + deps

The shim no longer has to embed the Python source or bootstrap a
Python interpreter — pip already installed both alongside the
binary. `mergify-py-shim` shrinks from ~250 lines (include_dir +
atomic file-locked extraction + cache management) to ~130 lines:
locate the sibling `python3`, exec `python3 -m mergify_cli`, return
the exit code. Drops `dirs`, `fs2`, `include_dir` deps.

A new `MERGIFY_PYTHON_EXE` env var lets `cargo build` developers
point at any Python interpreter that has the package on `sys.path`;
the no-sibling-python failure mode now produces a targeted
`PythonNotFound` with the exact path it tried.

This unlocks the "delete the Python copy when porting to Rust" rule:
each future port PR removes its Python implementation in the same
change, so there's never two parallel copies of the same command.
Drift goes from "watch for it" to "structurally impossible" — no
compat-test snapshot maintenance, no flag-by-flag mirroring.

Phase 6 (curl-installable static binary, no Python at all) drops
this crate entirely.

Trade-offs:
- Wheels are now platform-tagged (per maturin `bindings = "bin"`).
  The release workflow must build a per-platform matrix; the
  existing `uv build` single-platform path will need an update
  before the next PyPI publish (separate PR).
- Version handling: `dynamic = ["version"]` flows from
  `crates/mergify-cli/Cargo.toml`'s `[package] version` instead of
  hatch-vcs reading git tags. Release tooling must bump the Cargo
  version to match the tag (also addressed in the release-workflow
  follow-up).

Verified locally: `uvx maturin build --release` produces
`target/wheels/mergify_cli-*-macosx_*.whl`. Installing into a fresh
`uv venv` lands `mergify` at `<venv>/bin/mergify` (Mach-O arm64) and
the Python source under `site-packages/mergify_cli/`. Both
`mergify --help` (shimmed → Python click help) and `mergify config
validate` (native → Rust impl) work.