### PR TITLE
feat(stack): render badge instead of compare link for pure rebase pushes

### DIFF
--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -877,6 +877,11 @@ class RevisionHistoryComment:
     def _render_entry(self, entry: _RevisionEntry) -> str:
         if entry.old_sha is None:
             changes_cell = f"`{entry.new_sha[:7]}`"
+        elif entry.change_type == "rebase":
+            # Pure rebase: patch-id matched, no semantic change.
+            changes_cell = (
+                f"`{entry.old_sha[:7]} \u2192 {entry.new_sha[:7]}` _(rebase only)_"
+            )
         else:
             url = self._compare_url(entry.old_sha, entry.new_sha)
             changes_cell = f"[`{entry.old_sha[:7]} \u2192 {entry.new_sha[:7]}`]({url})"

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -1017,12 +1017,11 @@ def test_revision_history_comment_append() -> None:
         timestamp=datetime.datetime(2026, 4, 15, 9, 10, tzinfo=datetime.UTC),
     )
     body = comment.body(pull_number=1)
-    assert "| 3 | rebase |" in body
-    assert (
-        "def5678901234567890abcdef1234567890abcdef...789abcdef01234567890abcdef01234567890abcd"
-        in body
-    )
-    assert "2026-04-15 09:10 UTC" in body
+    rebase_line = next(line for line in body.splitlines() if "| 3 | rebase |" in line)
+    assert "rebase only" in rebase_line
+    assert "/compare/" not in rebase_line
+    assert "`def5678 → 789abcd`" in rebase_line
+    assert "2026-04-15 09:10 UTC" in rebase_line
 
 
 def test_revision_history_comment_parse_existing() -> None:
@@ -1061,6 +1060,11 @@ def test_revision_history_comment_parse_existing() -> None:
     )
     assert "| 1 | initial |" in new_body
     assert "| 2 | content |" in new_body
+    rebase_line = next(
+        line for line in new_body.splitlines() if "| 3 | rebase |" in line
+    )
+    assert "rebase only" in rebase_line
+    assert "/compare/" not in rebase_line
 
 
 def test_revision_history_comment_parse_returns_none_for_non_matching() -> None:
@@ -2682,3 +2686,22 @@ def test_push_cli_rejects_skip_and_force_rebase_together(
     )
     assert result.exit_code != 0
     assert "mutually exclusive" in result.output.lower()
+
+
+def test_revision_history_renders_badge_for_pure_rebase() -> None:
+    """change_type='rebase' renders a badge instead of a compare link."""
+    comment = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="abc1234567890abcdef1234567890abcdef123456",
+        new_sha="def5678901234567890abcdef1234567890abcdef",
+        change_type="rebase",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+    )
+    body = comment.body(pull_number=1)
+    # The rebase row must NOT contain a compare URL
+    rebase_line = next(line for line in body.splitlines() if "| 2 | rebase |" in line)
+    assert "/compare/" not in rebase_line
+    assert "rebase only" in rebase_line
+    assert "`abc1234 → def5678`" in rebase_line


### PR DESCRIPTION
When change_type is "rebase" (patch-ids matched), _render_entry now emits
a static "`old → new` _(rebase only)_" badge instead of a /compare/ URL,
since the semantic diff is empty and the link adds noise rather than signal.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Depends-On: #1323