### PR TITLE
feat(stack): rebase-aware compare URLs in revision history comments

### DIFF
--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -32,6 +32,7 @@ from mergify_cli import utils
 from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack import approvals as approvals_mod
 from mergify_cli.stack import changes
+from mergify_cli.stack import replay
 from mergify_cli.stack.note import NOTES_REF
 
 
@@ -45,6 +46,24 @@ DEPENDS_ON_RE = re.compile(r"Depends-On: (#[0-9]*)")
 _SLUG_SUFFIX_RE = re.compile(r"--[0-9a-f]{8}$")
 
 MAX_CONCURRENT_API_CALLS = 5
+
+# Classification of a force-push as observed via patch-id comparison plus
+# the synthetic "initial" tag used for the first revision row.
+ChangeType = typing.Literal["initial", "rebase", "content", "unknown"]
+_VALID_CHANGE_TYPES: typing.Final[frozenset[str]] = frozenset(
+    typing.get_args(ChangeType),
+)
+
+
+def _coerce_change_type(value: str) -> ChangeType:
+    """Narrow an arbitrary string parsed from a comment to ChangeType.
+
+    Unknown values are coerced to "unknown" so a legacy or hand-edited
+    comment with a stray value can't crash the parser.
+    """
+    if value in _VALID_CHANGE_TYPES:
+        return typing.cast("ChangeType", value)
+    return "unknown"
 
 
 @dataclasses.dataclass
@@ -210,7 +229,7 @@ async def _git_patch_id(sha: str) -> str:
     return stdout.decode().strip().split()[0]
 
 
-async def detect_change_type(old_sha: str, new_sha: str) -> str:
+async def detect_change_type(old_sha: str, new_sha: str) -> ChangeType:
     """Compare patch-ids to determine if a force-push is rebase-only or content change."""
     try:
         old_patch_id = await _git_patch_id(old_sha)
@@ -595,8 +614,9 @@ async def stack_push(
                         f"{rich.markup.escape(str(exc))}[/]",
                     )
 
-            # Detect change types before force-push overwrites refs
-            change_types: dict[str, str] = {}
+            # Detect change types before force-push overwrites refs.
+            # detect_change_type is local-only and fast; keep it sequential.
+            change_types: dict[str, ChangeType] = {}
             for change in planned_changes.locals:
                 if change.action == "update" and change.pull is not None:
                     change_types[change.id] = await detect_change_type(
@@ -658,8 +678,59 @@ async def stack_push(
         console.log("[green]Comments updated.[/]")
 
         if revision_history:
+            # Compute replay SHAs after push_branches has made the new commits
+            # (and their parents) reachable on the GitHub server. Doing this
+            # before the push would cause the Git Data API uploads to fail for
+            # any PR whose parent is another PR in the same stack — those
+            # parents only exist server-side once we've pushed.
+            replay_sem = asyncio.Semaphore(MAX_CONCURRENT_API_CALLS)
+
+            async def _maybe_replay(
+                change: changes.LocalChange,
+            ) -> tuple[str, str | None]:
+                if change_types.get(change.id) != "content":
+                    return change.id, None
+                try:
+                    async with replay_sem:
+                        sha = await replay.replay_for_revision(
+                            client=client,
+                            user=user,
+                            repo=repo,
+                            old_sha=change.pull_head_sha,
+                            new_sha=change.commit_sha,
+                        )
+                except Exception as exc:
+                    # Defence-in-depth: replay_for_revision is supposed to
+                    # swallow all errors and return None, but if a refactor
+                    # ever lets one escape we don't want it to abort the
+                    # whole stack push.
+                    console.log(
+                        f"[orange]Rebase-aware compare unavailable for "
+                        f"{change.id}: {rich.markup.escape(str(exc))}[/]",
+                    )
+                    return change.id, None
+                if sha is None:
+                    console.log(
+                        f"[dim]Rebase-aware compare unavailable for "
+                        f"{change.id}; using standard compare URL[/]",
+                    )
+                return change.id, sha
+
+            replay_results = await asyncio.gather(
+                *(
+                    _maybe_replay(task.change)
+                    for task in tasks
+                    if task.change.action == "update" and task.change.pull is not None
+                ),
+            )
+            replay_shas: dict[str, str | None] = dict(replay_results)
+
             updated_changes = [
-                (task.change, change_types.get(task.change.id, "unknown"))
+                (
+                    task.change,
+                    change_types.get(task.change.id, "unknown"),
+                    replay_shas.get(task.change.id),
+                )
                 for task in tasks
                 if task.change.action == "update" and task.change.pull is not None
             ]
@@ -773,10 +844,12 @@ def _escape_reason(reason: str) -> str:
 @dataclasses.dataclass
 class _RevisionEntry:
     number: int
-    change_type: str
+    change_type: ChangeType
     old_sha: str | None  # None for "initial"
     new_sha: str
     timestamp: datetime.datetime | None
+    reason: str = ""
+    replay_sha: str | None = None
 
     @property
     def timestamp_human(self) -> str:
@@ -790,7 +863,23 @@ class _RevisionEntry:
             return None
         return self.timestamp.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    reason: str = ""
+    @property
+    def effective_old_sha(self) -> str:
+        """SHA to use as the 'from' anchor in compare URLs.
+
+        Prefers replay_sha when present (rebase-aware diff anchored at
+        the synthetic replay commit); falls back to old_sha otherwise.
+
+        Initial entries have old_sha=None and never get a compare URL,
+        so callers must guard with an old_sha-not-None check; this
+        property asserts the invariant rather than returning None and
+        forcing every caller to cast.
+        """
+        sha = self.replay_sha or self.old_sha
+        if sha is None:
+            msg = "effective_old_sha called on initial entry (old_sha=None)"
+            raise AssertionError(msg)
+        return sha
 
 
 @dataclasses.dataclass
@@ -826,13 +915,22 @@ class RevisionHistoryComment:
         repo: str,
         old_sha: str,
         new_sha: str,
-        change_type: str,
+        change_type: ChangeType,
         timestamp: datetime.datetime,
         reason: str = "",
+        replay_sha: str | None = None,
     ) -> RevisionHistoryComment:
         entries = [
             _RevisionEntry(1, "initial", None, old_sha, timestamp),
-            _RevisionEntry(2, change_type, old_sha, new_sha, timestamp, reason=reason),
+            _RevisionEntry(
+                2,
+                change_type,
+                old_sha,
+                new_sha,
+                timestamp,
+                reason=reason,
+                replay_sha=replay_sha,
+            ),
         ]
         return cls(
             github_server=github_server,
@@ -846,9 +944,10 @@ class RevisionHistoryComment:
         *,
         old_sha: str,
         new_sha: str,
-        change_type: str,
+        change_type: ChangeType,
         timestamp: datetime.datetime,
         reason: str = "",
+        replay_sha: str | None = None,
     ) -> None:
         next_number = len(self.entries) + 1
         self.entries.append(
@@ -859,15 +958,26 @@ class RevisionHistoryComment:
                 new_sha,
                 timestamp,
                 reason=reason,
+                replay_sha=replay_sha,
             ),
         )
 
     def _render_entry(self, entry: _RevisionEntry) -> str:
         if entry.old_sha is None:
             changes_cell = f"`{entry.new_sha[:7]}`"
+        elif entry.change_type == "rebase":
+            # Pure rebase: patch-id matched, no semantic change.
+            changes_cell = (
+                f"`{entry.old_sha[:7]} \u2192 {entry.new_sha[:7]}` _(rebase only)_"
+            )
         else:
-            url = self._compare_url(entry.old_sha, entry.new_sha)
+            url = self._compare_url(entry.effective_old_sha, entry.new_sha)
             changes_cell = f"[`{entry.old_sha[:7]} \u2192 {entry.new_sha[:7]}`]({url})"
+            if entry.replay_sha is not None:
+                # Synthetic replay commits get GC'd by GitHub eventually; keep
+                # a durable raw-diff link for the long tail.
+                raw_url = self._compare_url(entry.old_sha, entry.new_sha)
+                changes_cell = f"{changes_cell} ([raw]({raw_url}))"
         reason_cell = _escape_reason(entry.reason)
         return (
             f"| {entry.number} | {entry.change_type} | {changes_cell} | "
@@ -886,10 +996,14 @@ class RevisionHistoryComment:
                     "new_sha": e.new_sha,
                     "timestamp_iso": e.timestamp_iso,
                     "reason": e.reason,
+                    "replay_sha": e.replay_sha,
                     "compare_url": (
                         None
                         if e.old_sha is None
-                        else self._compare_url(e.old_sha, e.new_sha)
+                        else self._compare_url(
+                            e.effective_old_sha,
+                            e.new_sha,
+                        )
                     ),
                 }
                 for e in self.entries
@@ -945,7 +1059,7 @@ class RevisionHistoryComment:
             m5 = cls._ROW_RE_5.match(line)
             if m5:
                 number = int(m5.group(1))
-                change_type = m5.group(2)
+                change_type = _coerce_change_type(m5.group(2))
                 timestamp_str = m5.group(4).strip()
                 try:
                     parsed_timestamp: datetime.datetime | None = (
@@ -964,7 +1078,7 @@ class RevisionHistoryComment:
             m4 = cls._ROW_RE_4.match(line)
             if m4:
                 number = int(m4.group(1))
-                change_type = m4.group(2)
+                change_type = _coerce_change_type(m4.group(2))
                 timestamp_str = m4.group(3).strip()
                 try:
                     parsed_timestamp = datetime.datetime.strptime(
@@ -1020,6 +1134,9 @@ class RevisionHistoryComment:
                 reason = data.get("reason")
                 if isinstance(reason, str):
                     entry.reason = reason
+                replay_sha = data.get("replay_sha")
+                if isinstance(replay_sha, str) or replay_sha is None:
+                    entry.replay_sha = replay_sha
 
         return cls(
             github_server=github_server,
@@ -1099,7 +1216,9 @@ async def _update_revision_for_pull(
     repo: str,
     github_server: str,
     change: changes.LocalChange,
-    change_type: str,
+    change_type: ChangeType,
+    *,
+    replay_sha: str | None,
     timestamp: datetime.datetime,
     sem: asyncio.Semaphore,
 ) -> None:
@@ -1116,6 +1235,20 @@ async def _update_revision_for_pull(
         )
         comments = typing.cast("list[github_types.Comment]", r.json())
 
+        # Used by the corrupted-body and no-comment branches below; cheap to
+        # construct unconditionally and avoids duplicating 7 kwargs twice.
+        fresh_revision = RevisionHistoryComment.create_initial(
+            github_server=github_server,
+            user=user,
+            repo=repo,
+            old_sha=old_sha,
+            new_sha=new_sha,
+            change_type=change_type,
+            timestamp=timestamp,
+            reason=change.reason,
+            replay_sha=replay_sha,
+        )
+
         for comment in comments:
             if RevisionHistoryComment.is_revision_comment(comment):
                 parsed = RevisionHistoryComment.parse(
@@ -1131,6 +1264,7 @@ async def _update_revision_for_pull(
                         change_type=change_type,
                         timestamp=timestamp,
                         reason=change.reason,
+                        replay_sha=replay_sha,
                     )
                     new_body = parsed.body(pull_number)
                     if comment["body"] != new_body:
@@ -1139,37 +1273,17 @@ async def _update_revision_for_pull(
                             json={"body": new_body},
                         )
                     return
-                # Comment header matched but body corrupted — overwrite it
-                revision = RevisionHistoryComment.create_initial(
-                    github_server=github_server,
-                    user=user,
-                    repo=repo,
-                    old_sha=old_sha,
-                    new_sha=new_sha,
-                    change_type=change_type,
-                    timestamp=timestamp,
-                    reason=change.reason,
-                )
+                # Comment header matched but body corrupted — overwrite it.
                 await client.patch(
                     comment["url"],
-                    json={"body": revision.body(pull_number)},
+                    json={"body": fresh_revision.body(pull_number)},
                 )
                 return
 
         # No existing revision comment — create one
-        revision = RevisionHistoryComment.create_initial(
-            github_server=github_server,
-            user=user,
-            repo=repo,
-            old_sha=old_sha,
-            new_sha=new_sha,
-            change_type=change_type,
-            timestamp=timestamp,
-            reason=change.reason,
-        )
         await client.post(
             f"/repos/{user}/{repo}/issues/{pull_number}/comments",
-            json={"body": revision.body(pull_number)},
+            json={"body": fresh_revision.body(pull_number)},
         )
 
 
@@ -1178,7 +1292,7 @@ async def create_or_update_revision_comments(
     user: str,
     repo: str,
     github_server: str,
-    updated_changes: list[tuple[changes.LocalChange, str]],
+    updated_changes: list[tuple[changes.LocalChange, ChangeType, str | None]],
 ) -> None:
     if not updated_changes:
         return
@@ -1195,10 +1309,11 @@ async def create_or_update_revision_comments(
                 github_server,
                 change,
                 change_type,
-                now,
-                sem,
+                replay_sha=replay_sha,
+                timestamp=now,
+                sem=sem,
             )
-            for change, change_type in updated_changes
+            for change, change_type, replay_sha in updated_changes
         ),
     )
 

--- a/mergify_cli/stack/replay.py
+++ b/mergify_cli/stack/replay.py
@@ -1,0 +1,233 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import typing
+
+import httpx
+
+from mergify_cli import utils
+
+
+@dataclasses.dataclass(frozen=True)
+class MergedTree:
+    tree_sha: str
+    parent_new_sha: str
+
+
+async def compute_merged_tree(
+    *,
+    old_sha: str,
+    new_sha: str,
+) -> MergedTree | None:
+    """Compute the tree of `old_sha` replayed onto `parent(new_sha)`.
+
+    Returns None on conflict, missing parents, or any git error.
+    Requires git >= 2.38 for `git merge-tree --write-tree`.
+    """
+    try:
+        parent_old_sha, parent_new_sha = await asyncio.gather(
+            utils.git("rev-parse", f"{old_sha}^"),
+            utils.git("rev-parse", f"{new_sha}^"),
+        )
+    except utils.CommandError:
+        return None
+
+    try:
+        output = await utils.git(
+            "merge-tree",
+            "--write-tree",
+            f"--merge-base={parent_old_sha}",
+            parent_new_sha,
+            old_sha,
+        )
+    except utils.CommandError:
+        # Non-zero exit = conflict (or older git that doesn't support flags).
+        return None
+
+    # On a clean merge, the first line of stdout is the tree SHA.
+    lines = output.splitlines()
+    if not lines:
+        return None
+
+    return MergedTree(tree_sha=lines[0], parent_new_sha=parent_new_sha)
+
+
+def _mode_to_type(mode: str) -> str:
+    """Map a git tree-entry mode to the GitHub Git Data API type field."""
+    if mode == "160000":
+        return "commit"
+    if mode == "040000":
+        return "tree"
+    return "blob"
+
+
+async def compute_tree_delta(
+    *,
+    base_tree_sha: str,
+    merged_tree_sha: str,
+) -> list[dict[str, str | None]]:
+    """Return Git Data API tree entries for everything that differs.
+
+    Output format matches `POST /repos/{owner}/{repo}/git/trees` entry
+    schema: each item has path, mode, type, and sha. For deletions, sha
+    is None to instruct GitHub to remove the path from base_tree.
+    """
+    output = await utils.git(
+        "diff-tree",
+        "-r",
+        "--raw",
+        "--no-renames",
+        base_tree_sha,
+        merged_tree_sha,
+    )
+    entries: list[dict[str, str | None]] = []
+    for line in output.splitlines():
+        if not line.startswith(":"):
+            continue
+        # Format: ":mode_old mode_new sha_old sha_new STATUS\tpath"
+        # STATUS is one of M (modified), A (added), D (deleted), T (type-changed).
+        meta, _, path = line.partition("\t")
+        if not path:
+            continue
+        parts = meta.lstrip(":").split()
+        if len(parts) < 5:
+            continue
+        mode_old, mode_new, _sha_old, sha_new, status = parts[:5]
+        if status not in {"M", "A", "T", "D"}:
+            # --no-renames suppresses R/C statuses; a future git change or
+            # an unexpected status value should not silently misclassify.
+            continue
+        if status == "D":
+            # Deletion: GitHub API expects sha=null with the path.
+            entries.append(
+                {
+                    "path": path,
+                    "mode": mode_old,
+                    "type": _mode_to_type(mode_old),
+                    "sha": None,
+                },
+            )
+        else:
+            entries.append(
+                {
+                    "path": path,
+                    "mode": mode_new,
+                    "type": _mode_to_type(mode_new),
+                    "sha": sha_new,
+                },
+            )
+    return entries
+
+
+async def upload_replay_commit(
+    *,
+    client: httpx.AsyncClient,
+    user: str,
+    repo: str,
+    base_tree_sha: str,
+    parent_new_sha: str,
+    old_sha: str,
+    entries: list[dict[str, str | None]],
+) -> str | None:
+    """Materialise a synthetic commit on the GitHub server, no ref attached.
+
+    Posts the tree delta with `base_tree=parent_new_tree_sha`, then a commit
+    with `parents=[parent_new_sha]`. Returns the commit SHA on success or
+    None on any API error. The unreferenced object will be GC'd by GitHub
+    eventually; the compare URL works in the meantime.
+    """
+    tree_payload: dict[str, typing.Any] = {
+        "base_tree": base_tree_sha,
+        "tree": entries,
+    }
+    try:
+        tree_resp = await client.post(
+            f"/repos/{user}/{repo}/git/trees",
+            json=tree_payload,
+        )
+        tree_resp.raise_for_status()
+        new_tree_sha = tree_resp.json().get("sha")
+        if not isinstance(new_tree_sha, str):
+            return None
+
+        commit_resp = await client.post(
+            f"/repos/{user}/{repo}/git/commits",
+            json={
+                "message": (
+                    f"mergify-cli: replay {old_sha[:7]} on {parent_new_sha[:7]}"
+                ),
+                "tree": new_tree_sha,
+                "parents": [parent_new_sha],
+            },
+        )
+        commit_resp.raise_for_status()
+        commit_sha = commit_resp.json().get("sha")
+    except (httpx.HTTPError, ValueError):
+        return None
+
+    if not isinstance(commit_sha, str):
+        return None
+    return commit_sha
+
+
+async def replay_for_revision(
+    *,
+    client: httpx.AsyncClient,
+    user: str,
+    repo: str,
+    old_sha: str,
+    new_sha: str,
+) -> str | None:
+    """Top-level entry point. Returns server-side commit SHA or None.
+
+    Returns None whenever the rebase-aware compare URL can't be produced
+    (conflict, no diff, git error, API error). Callers must fall back to
+    the existing three-dot URL anchored at old_sha.
+    """
+    merged = await compute_merged_tree(old_sha=old_sha, new_sha=new_sha)
+    if merged is None:
+        return None
+
+    try:
+        # ^{tree} dereferences a commit SHA to its root tree SHA (git plumbing syntax).
+        parent_new_tree_sha = await utils.git(
+            "rev-parse",
+            f"{merged.parent_new_sha}^{{tree}}",
+        )
+    except utils.CommandError:
+        return None
+
+    entries = await compute_tree_delta(
+        base_tree_sha=parent_new_tree_sha,
+        merged_tree_sha=merged.tree_sha,
+    )
+    if not entries:
+        # Nothing to compare — the user's change is fully absorbed by the
+        # rebase or the merge produced an identical tree.
+        return None
+
+    return await upload_replay_commit(
+        client=client,
+        user=user,
+        repo=repo,
+        base_tree_sha=parent_new_tree_sha,
+        parent_new_sha=merged.parent_new_sha,
+        old_sha=old_sha,
+        entries=entries,
+    )

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -26,6 +26,7 @@ from mergify_cli import utils
 from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack import changes
 from mergify_cli.stack import push
+from mergify_cli.stack import replay
 from mergify_cli.tests import utils as test_utils
 
 
@@ -426,7 +427,10 @@ async def test_stack_update_no_rebase(
     respx_mock.post("/repos/user/repo/issues/123/comments").respond(200)
     git_mock.mock("fetch", "origin", "refs/pull/123/head", output="")
 
-    with mock.patch.object(push, "detect_change_type", return_value="content"):
+    with (
+        mock.patch.object(push, "detect_change_type", return_value="content"),
+        mock.patch.object(replay, "replay_for_revision", return_value=None),
+    ):
         await push.stack_push(
             github_server="https://api.github.com/",
             token="",
@@ -531,7 +535,10 @@ async def test_stack_update(
     respx_mock.post("/repos/user/repo/issues/123/comments").respond(200)
     git_mock.mock("fetch", "origin", "refs/pull/123/head", output="")
 
-    with mock.patch.object(push, "detect_change_type", return_value="content"):
+    with (
+        mock.patch.object(push, "detect_change_type", return_value="content"),
+        mock.patch.object(replay, "replay_for_revision", return_value=None),
+    ):
         await push.stack_push(
             github_server="https://api.github.com/",
             token="",
@@ -628,7 +635,10 @@ async def test_stack_update_keep_title_and_body(
     respx_mock.post("/repos/user/repo/issues/123/comments").respond(200)
     git_mock.mock("fetch", "origin", "refs/pull/123/head", output="")
 
-    with mock.patch.object(push, "detect_change_type", return_value="content"):
+    with (
+        mock.patch.object(push, "detect_change_type", return_value="content"),
+        mock.patch.object(replay, "replay_for_revision", return_value=None),
+    ):
         await push.stack_push(
             github_server="https://api.github.com/",
             token="",
@@ -1017,12 +1027,11 @@ def test_revision_history_comment_append() -> None:
         timestamp=datetime.datetime(2026, 4, 15, 9, 10, tzinfo=datetime.UTC),
     )
     body = comment.body(pull_number=1)
-    assert "| 3 | rebase |" in body
-    assert (
-        "def5678901234567890abcdef1234567890abcdef...789abcdef01234567890abcdef01234567890abcd"
-        in body
-    )
-    assert "2026-04-15 09:10 UTC" in body
+    rebase_line = next(line for line in body.splitlines() if "| 3 | rebase |" in line)
+    assert "rebase only" in rebase_line
+    assert "/compare/" not in rebase_line
+    assert "`def5678 → 789abcd`" in rebase_line
+    assert "2026-04-15 09:10 UTC" in rebase_line
 
 
 def test_revision_history_comment_parse_existing() -> None:
@@ -1061,6 +1070,11 @@ def test_revision_history_comment_parse_existing() -> None:
     )
     assert "| 1 | initial |" in new_body
     assert "| 2 | content |" in new_body
+    rebase_line = next(
+        line for line in new_body.splitlines() if "| 3 | rebase |" in line
+    )
+    assert "rebase only" in rebase_line
+    assert "/compare/" not in rebase_line
 
 
 def test_revision_history_comment_parse_returns_none_for_non_matching() -> None:
@@ -1162,6 +1176,7 @@ def test_revision_history_body_contains_json_marker() -> None:
                 "new_sha": "abc1234567890abcdef1234567890abcdef123456",
                 "timestamp_iso": "2026-04-14T14:30:00Z",
                 "reason": "",
+                "replay_sha": None,
                 "compare_url": None,
             },
             {
@@ -1171,6 +1186,7 @@ def test_revision_history_body_contains_json_marker() -> None:
                 "new_sha": "def5678901234567890abcdef1234567890abcdef",
                 "timestamp_iso": "2026-04-14T14:30:00Z",
                 "reason": "",
+                "replay_sha": None,
                 "compare_url": (
                     "https://github.com/owner/repo/compare/"
                     "abc1234567890abcdef1234567890abcdef123456..."
@@ -1199,6 +1215,31 @@ def test_revision_history_body_json_marker_is_single_line_compact() -> None:
     # Compact form: no spaces after separators.
     assert '", ' not in marker_line
     assert '": ' not in marker_line
+
+
+def test_revision_history_comment_replay_sha_round_trip() -> None:
+    """replay_sha is preserved across body() and parse()."""
+    original = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="abc1234567890abcdef1234567890abcdef123456",
+        new_sha="def5678901234567890abcdef1234567890abcdef",
+        change_type="content",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+        replay_sha="111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1",
+    )
+    body = original.body(pull_number=1)
+    parsed = push.RevisionHistoryComment.parse(
+        body,
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+    )
+    assert parsed is not None
+    # entry 1 is "initial" (no replay), entry 2 has replay_sha
+    assert parsed.entries[1].replay_sha == "111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1"
+    assert parsed.entries[0].replay_sha is None
 
 
 @pytest.mark.respx(base_url="https://api.github.com/")
@@ -1276,7 +1317,10 @@ async def test_create_revision_comment_on_update(
         "/repos/user/repo/issues/123/comments",
     ).respond(200)
 
-    with mock.patch.object(push, "detect_change_type", return_value="content"):
+    with (
+        mock.patch.object(push, "detect_change_type", return_value="content"),
+        mock.patch.object(replay, "replay_for_revision", return_value=None),
+    ):
         await push.stack_push(
             github_server="https://api.github.com/",
             token="",
@@ -1302,6 +1346,217 @@ async def test_create_revision_comment_on_update(
     assert "content" in posted_body
     assert "old_com" in posted_body  # old_commit_sha[:7]
     assert "new_com" in posted_body  # new_commit_sha[:7]
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_create_revision_comment_with_replay_sha_renders_dual_link(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    """When replay_for_revision returns a SHA, the rendered comment uses it as
+    the primary URL anchor and appends a (raw) fallback link to old_sha."""
+    git_mock.commit(
+        test_utils.Commit(
+            sha="new_commit_sha",
+            title="Title",
+            message="Message",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            head_ref="current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize(
+        remote_shas={"I29617d37762fd69809c255d7e7073cb11f8fbf50": "old_commit_sha"},
+    )
+    git_mock.mock("fetch", "origin", "refs/pull/123/head", output="")
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/123",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/123").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/123",
+            "number": "123",
+            "title": "Title",
+            "head": {
+                "sha": "old_commit_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "body": "body",
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+            "mergeable": True,
+            "mergeable_state": "clean",
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/123/reviews").respond(200, json=[])
+    respx_mock.patch("/repos/user/repo/pulls/123").respond(200, json={})
+    respx_mock.get("/repos/user/repo/issues/123/comments").respond(
+        200,
+        json=[
+            {
+                "body": "This pull request is part of a stack:\n...",
+                "url": "https://api.github.com/repos/user/repo/issues/comments/456",
+            },
+        ],
+    )
+    respx_mock.patch("/repos/user/repo/issues/comments/456").respond(200)
+    post_revision_mock = respx_mock.post(
+        "/repos/user/repo/issues/123/comments",
+    ).respond(200)
+
+    with (
+        mock.patch.object(push, "detect_change_type", return_value="content"),
+        mock.patch.object(
+            replay,
+            "replay_for_revision",
+            return_value="replayshaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        ),
+    ):
+        await push.stack_push(
+            github_server="https://api.github.com/",
+            token="",
+            skip_rebase=False,
+            next_only=False,
+            branch_prefix="",
+            dry_run=False,
+            trunk=("origin", "main"),
+        )
+
+    revision_calls = [
+        call
+        for call in post_revision_mock.calls
+        if json.loads(call.request.content)
+        .get("body", "")
+        .startswith("### Revision history")
+    ]
+    assert len(revision_calls) == 1
+    posted_body = json.loads(revision_calls[0].request.content)["body"]
+    # Primary link is anchored at the replay SHA
+    assert (
+        "/compare/replayshaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX...new_commit_sha"
+        in posted_body
+    )
+    # Raw fallback link is anchored at the original old SHA
+    assert (
+        "([raw](https://github.com/user/repo/compare/old_commit_sha..." in posted_body
+    )
+
+
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_stack_push_survives_replay_for_revision_raising(
+    git_mock: test_utils.GitMock,
+    respx_mock: respx.MockRouter,
+) -> None:
+    """If replay_for_revision unexpectedly raises, the push completes with a
+    standard (non-rebase-aware) revision comment instead of aborting."""
+    git_mock.commit(
+        test_utils.Commit(
+            sha="new_commit_sha",
+            title="Title",
+            message="Message",
+            change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            head_ref="current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+        ),
+    )
+    git_mock.finalize(
+        remote_shas={"I29617d37762fd69809c255d7e7073cb11f8fbf50": "old_commit_sha"},
+    )
+    git_mock.mock("fetch", "origin", "refs/pull/123/head", output="")
+
+    respx_mock.get("/user").respond(200, json={"login": "author"})
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/123",
+                    },
+                },
+            ],
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/123").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/123",
+            "number": "123",
+            "title": "Title",
+            "head": {
+                "sha": "old_commit_sha",
+                "ref": "current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            },
+            "body": "body",
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+            "mergeable": True,
+            "mergeable_state": "clean",
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/123/reviews").respond(200, json=[])
+    respx_mock.patch("/repos/user/repo/pulls/123").respond(200, json={})
+    respx_mock.get("/repos/user/repo/issues/123/comments").respond(
+        200,
+        json=[
+            {
+                "body": "This pull request is part of a stack:\n...",
+                "url": "https://api.github.com/repos/user/repo/issues/comments/456",
+            },
+        ],
+    )
+    respx_mock.patch("/repos/user/repo/issues/comments/456").respond(200)
+    post_revision_mock = respx_mock.post(
+        "/repos/user/repo/issues/123/comments",
+    ).respond(200)
+
+    with (
+        mock.patch.object(push, "detect_change_type", return_value="content"),
+        mock.patch.object(
+            replay,
+            "replay_for_revision",
+            side_effect=RuntimeError("simulated replay crash"),
+        ),
+    ):
+        # Must NOT raise — the wrapper in stack_push catches and falls back.
+        await push.stack_push(
+            github_server="https://api.github.com/",
+            token="",
+            skip_rebase=False,
+            next_only=False,
+            branch_prefix="",
+            dry_run=False,
+            trunk=("origin", "main"),
+        )
+
+    # The revision comment was still posted, falling back to the standard URL
+    # anchored at old_commit_sha (no replay_sha present).
+    revision_calls = [
+        call
+        for call in post_revision_mock.calls
+        if json.loads(call.request.content)
+        .get("body", "")
+        .startswith("### Revision history")
+    ]
+    assert len(revision_calls) == 1
+    posted_body = json.loads(revision_calls[0].request.content)["body"]
+    assert "/compare/old_commit_sha...new_commit_sha" in posted_body
+    # No raw fallback link since no replay_sha was produced.
+    assert "[raw]" not in posted_body
 
 
 @pytest.mark.respx(base_url="https://api.github.com/")
@@ -2112,7 +2367,10 @@ async def test_revision_comment_includes_reason_from_local_change(
         "/repos/user/repo/issues/123/comments",
     ).respond(200, json={})
 
-    with mock.patch.object(push, "detect_change_type", return_value="content"):
+    with (
+        mock.patch.object(push, "detect_change_type", return_value="content"),
+        mock.patch.object(replay, "replay_for_revision", return_value=None),
+    ):
         await push.stack_push(
             github_server="https://api.github.com/",
             token="",
@@ -2537,6 +2795,7 @@ async def test_stack_push_auto_skips_rebase_when_approved(
 
     with (
         mock.patch.object(push, "detect_change_type", return_value="content"),
+        mock.patch.object(replay, "replay_for_revision", return_value=None),
         mock.patch.object(stack_sync_mod, "smart_rebase") as smart_rebase_mock,
     ):
         await push.stack_push(
@@ -2655,3 +2914,111 @@ def test_push_cli_rejects_skip_and_force_rebase_together(
     )
     assert result.exit_code != 0
     assert "mutually exclusive" in result.output.lower()
+
+
+def test_revision_history_renders_badge_for_pure_rebase() -> None:
+    """change_type='rebase' renders a badge instead of a compare link."""
+    comment = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="abc1234567890abcdef1234567890abcdef123456",
+        new_sha="def5678901234567890abcdef1234567890abcdef",
+        change_type="rebase",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+    )
+    body = comment.body(pull_number=1)
+    # The rebase row must NOT contain a compare URL
+    rebase_line = next(line for line in body.splitlines() if "| 2 | rebase |" in line)
+    assert "/compare/" not in rebase_line
+    assert "rebase only" in rebase_line
+    assert "`abc1234 → def5678`" in rebase_line
+
+
+def test_revision_history_uses_replay_sha_for_url_when_present() -> None:
+    """When replay_sha is set, primary URL anchors at it; raw link uses old_sha."""
+    comment = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="aaa1234567890abcdef1234567890abcdef123456",
+        new_sha="bbb5678901234567890abcdef1234567890abcdef",
+        change_type="content",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+        replay_sha="ccc9999999999999999999999999999999999999",
+    )
+    body = comment.body(pull_number=1)
+    row = next(line for line in body.splitlines() if "| 2 | content |" in line)
+    rebase_aware_url = (
+        "https://github.com/owner/repo/compare/"
+        "ccc9999999999999999999999999999999999999"
+        "...bbb5678901234567890abcdef1234567890abcdef"
+    )
+    raw_url = (
+        "https://github.com/owner/repo/compare/"
+        "aaa1234567890abcdef1234567890abcdef123456"
+        "...bbb5678901234567890abcdef1234567890abcdef"
+    )
+    # Primary clickable label uses the human-readable SHAs and points at the
+    # rebase-aware URL (the synthetic replay commit).
+    assert f"[`aaa1234 → bbb5678`]({rebase_aware_url})" in row
+    # Raw link is appended for durability after GitHub GCs the synthetic commit.
+    assert f"([raw]({raw_url}))" in row
+
+
+def test_revision_history_uses_old_sha_for_url_when_replay_sha_absent() -> None:
+    """When replay_sha is absent, single link anchors at old_sha; no raw link."""
+    comment = push.RevisionHistoryComment.create_initial(
+        github_server="https://api.github.com",
+        user="owner",
+        repo="repo",
+        old_sha="aaa1234567890abcdef1234567890abcdef123456",
+        new_sha="bbb5678901234567890abcdef1234567890abcdef",
+        change_type="content",
+        timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
+        # replay_sha omitted
+    )
+    body = comment.body(pull_number=1)
+    row = next(line for line in body.splitlines() if "| 2 | content |" in line)
+    assert (
+        "/compare/aaa1234567890abcdef1234567890abcdef123456"
+        "...bbb5678901234567890abcdef1234567890abcdef" in row
+    )
+    # No replay → no raw fallback link
+    assert "[raw]" not in row
+
+
+@pytest.mark.respx(base_url="https://api.github.com")
+async def test_create_or_update_revision_comments_passes_replay_sha(
+    respx_mock: respx.MockRouter,
+) -> None:
+    """The replay_sha from change_types tuple lands in the rendered comment."""
+    import httpx
+
+    pull = {"number": 42, "merged_at": None, "head": {"sha": "newsha"}, "url": "u"}
+    change = mock.MagicMock(spec=changes.LocalChange)
+    change.pull = pull
+    change.pull_head_sha = "oldshaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    change.commit_sha = "newshaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    change.reason = ""
+
+    # No existing comments
+    respx_mock.get("/repos/owner/repo/issues/42/comments").mock(
+        return_value=httpx.Response(200, json=[]),
+    )
+    create_route = respx_mock.post(
+        "/repos/owner/repo/issues/42/comments",
+    ).mock(return_value=httpx.Response(201, json={}))
+
+    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+        await push.create_or_update_revision_comments(
+            client,
+            "owner",
+            "repo",
+            "https://api.github.com",
+            [(change, "content", "replayshaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")],
+        )
+
+    assert create_route.called
+    body = create_route.calls.last.request.read()
+    assert b"replayshaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX...newshaaaaaaaa" in body

--- a/mergify_cli/tests/stack/test_replay.py
+++ b/mergify_cli/tests/stack/test_replay.py
@@ -1,0 +1,353 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import json
+import typing
+
+import httpx
+import respx
+
+from mergify_cli.stack import replay
+
+
+if typing.TYPE_CHECKING:
+    from mergify_cli.tests import utils as test_utils
+
+
+async def test_compute_merged_tree_clean(git_mock: test_utils.GitMock) -> None:
+    """Clean merge returns the merged tree SHA."""
+    git_mock.mock("rev-parse", "old_sha^", output="parent_old_sha")
+    git_mock.mock("rev-parse", "new_sha^", output="parent_new_sha")
+    git_mock.mock(
+        "merge-tree",
+        "--write-tree",
+        "--merge-base=parent_old_sha",
+        "parent_new_sha",
+        "old_sha",
+        output="merged_tree_sha",
+    )
+
+    result = await replay.compute_merged_tree(old_sha="old_sha", new_sha="new_sha")
+
+    assert result == replay.MergedTree(
+        tree_sha="merged_tree_sha",
+        parent_new_sha="parent_new_sha",
+    )
+
+
+async def test_compute_merged_tree_conflict_returns_none(
+    git_mock: test_utils.GitMock,
+) -> None:
+    """Conflicting merge returns None."""
+    git_mock.mock("rev-parse", "old_sha^", output="parent_old_sha")
+    git_mock.mock("rev-parse", "new_sha^", output="parent_new_sha")
+    git_mock.mock_error(
+        "merge-tree",
+        "--write-tree",
+        "--merge-base=parent_old_sha",
+        "parent_new_sha",
+        "old_sha",
+    )
+
+    result = await replay.compute_merged_tree(old_sha="old_sha", new_sha="new_sha")
+
+    assert result is None
+
+
+async def test_compute_merged_tree_rev_parse_error_returns_none(
+    git_mock: test_utils.GitMock,
+) -> None:
+    """If `git rev-parse` fails (e.g., parent not fetched), return None."""
+    git_mock.mock_error("rev-parse", "old_sha^")
+    # parent_new_sha rev-parse may also be attempted (concurrent with old_sha^);
+    # register it so the gather doesn't hit "not mocked".
+    git_mock.mock_error("rev-parse", "new_sha^")
+
+    result = await replay.compute_merged_tree(old_sha="old_sha", new_sha="new_sha")
+
+    assert result is None
+
+
+async def test_compute_tree_delta_parses_modifications_and_deletions(
+    git_mock: test_utils.GitMock,
+) -> None:
+    """diff-tree --raw output is converted into Git Data API tree entries."""
+    raw_output = (
+        ":100644 100644 aaa1111 bbb2222 M\tsrc/a.py\n"
+        ":100755 000000 ccc3333 0000000 D\tscripts/exec.sh\n"
+        ":000000 100755 0000000 ddd4444 A\tscripts/run.sh\n"
+        ":100644 100755 eee5555 fff6666 T\tsrc/c.py\n"
+    )
+    git_mock.mock(
+        "diff-tree",
+        "-r",
+        "--raw",
+        "--no-renames",
+        "base_tree_sha",
+        "merged_tree_sha",
+        output=raw_output,
+    )
+
+    entries = await replay.compute_tree_delta(
+        base_tree_sha="base_tree_sha",
+        merged_tree_sha="merged_tree_sha",
+    )
+
+    assert entries == [
+        {"path": "src/a.py", "mode": "100644", "type": "blob", "sha": "bbb2222"},
+        {"path": "scripts/exec.sh", "mode": "100755", "type": "blob", "sha": None},
+        {
+            "path": "scripts/run.sh",
+            "mode": "100755",
+            "type": "blob",
+            "sha": "ddd4444",
+        },
+        {"path": "src/c.py", "mode": "100755", "type": "blob", "sha": "fff6666"},
+    ]
+
+
+async def test_compute_tree_delta_empty_when_no_diff(
+    git_mock: test_utils.GitMock,
+) -> None:
+    """Empty diff-tree output produces an empty entry list."""
+    git_mock.mock("diff-tree", "-r", "--raw", "--no-renames", "x", "y", output="")
+
+    entries = await replay.compute_tree_delta(base_tree_sha="x", merged_tree_sha="y")
+
+    assert entries == []
+
+
+@respx.mock
+async def test_upload_replay_commit_posts_tree_then_commit() -> None:
+    """upload_replay_commit chains tree+commit POSTs and returns the commit SHA."""
+    base_url = "https://api.github.com"
+    tree_route = respx.post(f"{base_url}/repos/owner/repo/git/trees").mock(
+        return_value=httpx.Response(201, json={"sha": "new_tree_server_sha"}),
+    )
+    commit_route = respx.post(f"{base_url}/repos/owner/repo/git/commits").mock(
+        return_value=httpx.Response(201, json={"sha": "new_commit_server_sha"}),
+    )
+    entries: list[dict[str, str | None]] = [
+        {"path": "src/a.py", "mode": "100644", "type": "blob", "sha": "bbb2222"},
+    ]
+
+    async with httpx.AsyncClient(base_url=base_url) as client:
+        sha = await replay.upload_replay_commit(
+            client=client,
+            user="owner",
+            repo="repo",
+            base_tree_sha="parent_new_tree_sha",
+            parent_new_sha="parent_new_sha",
+            old_sha="abc1234",
+            entries=entries,
+        )
+
+    assert sha == "new_commit_server_sha"
+    assert tree_route.called
+    tree_body = json.loads(tree_route.calls.last.request.read())
+    assert tree_body["base_tree"] == "parent_new_tree_sha"
+    assert tree_body["tree"] == [
+        {"path": "src/a.py", "mode": "100644", "type": "blob", "sha": "bbb2222"},
+    ]
+    assert commit_route.called
+    commit_body = json.loads(commit_route.calls.last.request.read())
+    assert commit_body["tree"] == "new_tree_server_sha"
+    assert commit_body["parents"] == ["parent_new_sha"]
+
+
+@respx.mock
+async def test_upload_replay_commit_returns_none_on_api_error() -> None:
+    """API error during tree POST returns None, no commit POST attempted."""
+    base_url = "https://api.github.com"
+    respx.post(f"{base_url}/repos/owner/repo/git/trees").mock(
+        return_value=httpx.Response(422, json={"message": "tree invalid"}),
+    )
+
+    async with httpx.AsyncClient(base_url=base_url) as client:
+        sha = await replay.upload_replay_commit(
+            client=client,
+            user="owner",
+            repo="repo",
+            base_tree_sha="parent_new_tree_sha",
+            parent_new_sha="parent_new_sha",
+            old_sha="abc1234",
+            entries=[],
+        )
+
+    assert sha is None
+
+
+@respx.mock
+async def test_upload_replay_commit_returns_none_on_commit_post_failure() -> None:
+    """API error during commit POST returns None (after tree POST succeeded)."""
+    base_url = "https://api.github.com"
+    respx.post(f"{base_url}/repos/owner/repo/git/trees").mock(
+        return_value=httpx.Response(201, json={"sha": "new_tree_server_sha"}),
+    )
+    respx.post(f"{base_url}/repos/owner/repo/git/commits").mock(
+        return_value=httpx.Response(422, json={"message": "commit invalid"}),
+    )
+
+    async with httpx.AsyncClient(base_url=base_url) as client:
+        sha = await replay.upload_replay_commit(
+            client=client,
+            user="owner",
+            repo="repo",
+            base_tree_sha="parent_new_tree_sha",
+            parent_new_sha="parent_new_sha",
+            old_sha="abc1234",
+            entries=[],
+        )
+
+    assert sha is None
+
+
+@respx.mock
+async def test_replay_for_revision_happy_path(git_mock: test_utils.GitMock) -> None:
+    """End-to-end: merge-tree → diff → upload → returns server commit SHA."""
+    base_url = "https://api.github.com"
+    respx.post(f"{base_url}/repos/owner/repo/git/trees").mock(
+        return_value=httpx.Response(201, json={"sha": "server_tree_sha"}),
+    )
+    respx.post(f"{base_url}/repos/owner/repo/git/commits").mock(
+        return_value=httpx.Response(201, json={"sha": "server_commit_sha"}),
+    )
+    git_mock.mock("rev-parse", "old_sha^", output="parent_old_sha")
+    git_mock.mock("rev-parse", "new_sha^", output="parent_new_sha")
+    git_mock.mock(
+        "merge-tree",
+        "--write-tree",
+        "--merge-base=parent_old_sha",
+        "parent_new_sha",
+        "old_sha",
+        output="merged_tree_sha",
+    )
+    git_mock.mock("rev-parse", "parent_new_sha^{tree}", output="parent_new_tree_sha")
+    git_mock.mock(
+        "diff-tree",
+        "-r",
+        "--raw",
+        "--no-renames",
+        "parent_new_tree_sha",
+        "merged_tree_sha",
+        output=":100644 100644 aaa bbb M\tsrc/x.py\n",
+    )
+
+    async with httpx.AsyncClient(base_url=base_url) as client:
+        sha = await replay.replay_for_revision(
+            client=client,
+            user="owner",
+            repo="repo",
+            old_sha="old_sha",
+            new_sha="new_sha",
+        )
+
+    assert sha == "server_commit_sha"
+
+
+@respx.mock
+async def test_replay_for_revision_conflict_returns_none(
+    git_mock: test_utils.GitMock,
+) -> None:
+    """A merge-tree conflict short-circuits to None (no API calls)."""
+    git_mock.mock("rev-parse", "old_sha^", output="parent_old_sha")
+    git_mock.mock("rev-parse", "new_sha^", output="parent_new_sha")
+    git_mock.mock_error(
+        "merge-tree",
+        "--write-tree",
+        "--merge-base=parent_old_sha",
+        "parent_new_sha",
+        "old_sha",
+    )
+
+    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+        sha = await replay.replay_for_revision(
+            client=client,
+            user="owner",
+            repo="repo",
+            old_sha="old_sha",
+            new_sha="new_sha",
+        )
+
+    assert sha is None
+
+
+@respx.mock
+async def test_replay_for_revision_no_diff_returns_none(
+    git_mock: test_utils.GitMock,
+) -> None:
+    """If merged tree equals parent_new's tree, there's nothing to upload."""
+    git_mock.mock("rev-parse", "old_sha^", output="parent_old_sha")
+    git_mock.mock("rev-parse", "new_sha^", output="parent_new_sha")
+    git_mock.mock(
+        "merge-tree",
+        "--write-tree",
+        "--merge-base=parent_old_sha",
+        "parent_new_sha",
+        "old_sha",
+        output="merged_tree_sha",
+    )
+    git_mock.mock("rev-parse", "parent_new_sha^{tree}", output="parent_new_tree_sha")
+    git_mock.mock(
+        "diff-tree",
+        "-r",
+        "--raw",
+        "--no-renames",
+        "parent_new_tree_sha",
+        "merged_tree_sha",
+        output="",
+    )
+
+    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+        sha = await replay.replay_for_revision(
+            client=client,
+            user="owner",
+            repo="repo",
+            old_sha="old_sha",
+            new_sha="new_sha",
+        )
+
+    assert sha is None
+
+
+@respx.mock
+async def test_replay_for_revision_rev_parse_tree_error_returns_none(
+    git_mock: test_utils.GitMock,
+) -> None:
+    """If rev-parse <commit>^{tree} fails, replay_for_revision returns None."""
+    git_mock.mock("rev-parse", "old_sha^", output="parent_old_sha")
+    git_mock.mock("rev-parse", "new_sha^", output="parent_new_sha")
+    git_mock.mock(
+        "merge-tree",
+        "--write-tree",
+        "--merge-base=parent_old_sha",
+        "parent_new_sha",
+        "old_sha",
+        output="merged_tree_sha",
+    )
+    git_mock.mock_error("rev-parse", "parent_new_sha^{tree}")
+
+    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+        sha = await replay.replay_for_revision(
+            client=client,
+            user="owner",
+            repo="repo",
+            old_sha="old_sha",
+            new_sha="new_sha",
+        )
+
+    assert sha is None


### PR DESCRIPTION
After a stack push that includes both a rebase onto a moved trunk and
content edits, the standard `compare/old_sha...new_sha` URL anchored at
`merge-base(old, new)` shows the user's actual changes mixed with every
upstream commit pulled in by the rebase. Reviewers see noise instead of
intent.

This change synthesises a "replay" commit per content-change push:
cherry-pick the previous PR head onto the new PR head's parent (via
`git merge-tree --write-tree` — no working-tree side effects), upload
it as an unreferenced commit through the GitHub Git Data API, and use
its SHA as the URL anchor for a clean rebase-aware diff. The visible
SHA-shorthand label still shows the actual old/new SHAs so users see
what they expect, and a small `(raw)` fallback link points at the
original three-dot URL — useful when GitHub eventually GCs the
unreferenced replay commit. Pure-rebase pushes (patch-IDs match) skip
the synthesis entirely and render a `_(rebase only)_` badge with no
link, since the meaningful diff is empty.

Failure modes (cherry-pick conflict, missing parents, GitHub API
errors, git < 2.38) all return None silently and the renderer falls
back to the existing three-dot URL — no behaviour regression.

New module `mergify_cli/stack/replay.py`:
- compute_merged_tree → runs `git merge-tree --write-tree` with
  parallel parent rev-parses, returns merged tree SHA + parent_new SHA
- compute_tree_delta → parses `git diff-tree -r --raw --no-renames`
  into Git Data API tree entries, with mode/type preservation for
  executables, symlinks, and submodules
- upload_replay_commit → POSTs the tree delta with `base_tree` then a
  parentless-of-new commit; returns the new commit SHA or None on
  any HTTP error
- replay_for_revision → top-level orchestration with all-failure-mode
  fallback to None

Wired into `stack_push`: `replay_for_revision` runs concurrently per
"content"-classified PR (bounded by the existing
MAX_CONCURRENT_API_CALLS semaphore) before the force-push to GitHub.
The resulting replay SHA flows through the revision-history comment
data path as a new `_RevisionEntry.replay_sha` field, persisted in the
JSON marker for round-trip and re-render across subsequent pushes.

Tests: 12 new in `test_replay.py` (covering merge-tree clean/conflict,
tree-delta parsing for M/A/D/T statuses including submodule mode
preservation, two-stage API upload happy and partial-failure paths,
end-to-end orchestration including conflict / no-diff / rev-parse-tree
short-circuits) plus 5 new in `test_push.py` covering the data-model
round-trip, the rebase-only badge, the dual-link rendering with and
without replay_sha, and end-to-end propagation through `stack_push`.