### PR TITLE
fix(ci): auto-detect --tests-target-branch on Buildkite, CircleCI, Jenkins

### DIFF
--- a/mergify_cli/ci/cli.py
+++ b/mergify_cli/ci/cli.py
@@ -130,7 +130,7 @@ def ci(ctx: click.Context) -> None:
     "-ttb",
     help="The branch used to check if failing tests can be ignored with Mergify's Quarantine.",
     required=True,
-    envvar=["GITHUB_BASE_REF", "GITHUB_HEAD_REF", "GITHUB_REF_NAME", "GITHUB_REF"],
+    default=detector.get_tests_target_branch,
     callback=_process_tests_target_branch,
 )
 @click.option(
@@ -221,7 +221,7 @@ async def junit_upload(
     "-ttb",
     help="The branch used to check if failing tests can be ignored with Mergify's Quarantine.",
     required=True,
-    envvar=["GITHUB_BASE_REF", "GITHUB_HEAD_REF", "GITHUB_REF_NAME", "GITHUB_REF"],
+    default=detector.get_tests_target_branch,
     callback=_process_tests_target_branch,
 )
 @click.option(

--- a/mergify_cli/ci/detector.py
+++ b/mergify_cli/ci/detector.py
@@ -238,6 +238,27 @@ def get_github_repository() -> str | None:
             return None
 
 
+def get_tests_target_branch() -> str | None:
+    match get_ci_provider():
+        case "github_actions":
+            return (
+                os.getenv("GITHUB_BASE_REF")
+                or os.getenv("GITHUB_HEAD_REF")
+                or os.getenv("GITHUB_REF_NAME")
+                or os.getenv("GITHUB_REF")
+            )
+        case "buildkite":
+            return os.getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH") or os.getenv(
+                "BUILDKITE_BRANCH",
+            )
+        case "circleci":
+            return os.getenv("CIRCLE_BRANCH")
+        case "jenkins":
+            return os.getenv("CHANGE_TARGET") or get_jenkins_head_ref_name()
+        case _:
+            return None
+
+
 MERGIFY_CONFIG_PATHS = (
     ".mergify.yml",
     ".mergify/config.yml",

--- a/mergify_cli/tests/ci/test_cli.py
+++ b/mergify_cli/tests/ci/test_cli.py
@@ -226,6 +226,76 @@ def test_tests_target_branch_environment_variable_processing(
     assert call_kwargs["tests_target_branch"] == expected_branch
 
 
+@pytest.mark.parametrize(
+    ("env", "expected_branch"),
+    [
+        pytest.param(
+            {
+                "BUILDKITE": "true",
+                "MERGIFY_API_URL": "https://api.mergify.com",
+                "MERGIFY_TOKEN": "abc",
+                "BUILDKITE_REPO": "git@github.com:user/repo.git",
+                "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "main",
+                "BUILDKITE_BRANCH": "feature-branch",
+            },
+            "main",
+            id="BUILDKITE_PULL_REQUEST_BASE_BRANCH takes precedence",
+        ),
+        pytest.param(
+            {
+                "BUILDKITE": "true",
+                "MERGIFY_API_URL": "https://api.mergify.com",
+                "MERGIFY_TOKEN": "abc",
+                "BUILDKITE_REPO": "git@github.com:user/repo.git",
+                "BUILDKITE_BRANCH": "feature-branch",
+            },
+            "feature-branch",
+            id="BUILDKITE_BRANCH fallback when no PR base branch",
+        ),
+    ],
+)
+def test_tests_target_branch_buildkite_environment_variable_processing(
+    env: dict[str, str],
+    expected_branch: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that --tests-target-branch is auto-detected from Buildkite env vars."""
+    for key in [
+        "GITHUB_ACTIONS",
+        "GITHUB_REF",
+        "GITHUB_REF_NAME",
+        "GITHUB_HEAD_REF",
+        "GITHUB_BASE_REF",
+        "JENKINS_URL",
+        "CIRCLECI",
+        "BUILDKITE",
+        "BUILDKITE_PULL_REQUEST_BASE_BRANCH",
+        "BUILDKITE_BRANCH",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    runner = testing.CliRunner()
+
+    with mock.patch.object(
+        junit_processing_cli,
+        "process_junit_files",
+        mock.AsyncMock(),
+    ) as mocked_process_junit_files:
+        result = runner.invoke(
+            ci_cli.junit_process,
+            [str(REPORT_XML)],
+        )
+
+    assert result.exit_code == 0, result.stdout
+
+    assert mocked_process_junit_files.call_count == 1
+    call_kwargs = mocked_process_junit_files.call_args.kwargs
+    assert call_kwargs["tests_target_branch"] == expected_branch
+
+
 def test_process_tests_target_branch_callback() -> None:
     """Test the _process_tests_target_branch callback function directly."""
     context_mock = mock.MagicMock(spec=click.Context)

--- a/mergify_cli/tests/ci/test_detector.py
+++ b/mergify_cli/tests/ci/test_detector.py
@@ -381,3 +381,76 @@ def test_get_github_pull_request_number_buildkite_not_pr(
 ) -> None:
     monkeypatch.setenv("BUILDKITE_PULL_REQUEST", "false")
     assert detector.get_github_pull_request_number() is None
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+def test_get_tests_target_branch_buildkite_pr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "main")
+    monkeypatch.setenv("BUILDKITE_BRANCH", "feature-branch")
+    assert detector.get_tests_target_branch() == "main"
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+def test_get_tests_target_branch_buildkite_push(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH", raising=False)
+    monkeypatch.setenv("BUILDKITE_BRANCH", "feature-branch")
+    assert detector.get_tests_target_branch() == "feature-branch"
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+def test_get_tests_target_branch_buildkite_unset() -> None:
+    assert detector.get_tests_target_branch() is None
+
+
+@pytest.fixture
+def _clear_ci_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear all CI-provider toggle env vars so the test picks the one it sets."""
+    for env in ("GITHUB_ACTIONS", "CIRCLECI", "JENKINS_URL", "BUILDKITE"):
+        monkeypatch.delenv(env, raising=False)
+
+
+@pytest.mark.usefixtures("_clear_ci_provider_env")
+def test_get_tests_target_branch_github_actions_base_ref_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("GITHUB_BASE_REF", "main")
+    monkeypatch.setenv("GITHUB_HEAD_REF", "feature-branch")
+    monkeypatch.setenv("GITHUB_REF", "refs/heads/feature-branch")
+    assert detector.get_tests_target_branch() == "main"
+
+
+@pytest.mark.usefixtures("_clear_ci_provider_env")
+def test_get_tests_target_branch_circleci(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CIRCLECI", "true")
+    monkeypatch.setenv("CIRCLE_BRANCH", "feature-branch")
+    assert detector.get_tests_target_branch() == "feature-branch"
+
+
+@pytest.mark.usefixtures("_clear_ci_provider_env")
+def test_get_tests_target_branch_jenkins_change_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JENKINS_URL", "http://jenkins.example.com")
+    monkeypatch.setenv("CHANGE_TARGET", "main")
+    monkeypatch.setenv("GIT_BRANCH", "origin/feature-branch")
+    assert detector.get_tests_target_branch() == "main"
+
+
+@pytest.mark.usefixtures("_clear_ci_provider_env")
+def test_get_tests_target_branch_jenkins_git_branch_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JENKINS_URL", "http://jenkins.example.com")
+    monkeypatch.delenv("CHANGE_TARGET", raising=False)
+    monkeypatch.setenv("GIT_BRANCH", "origin/feature-branch")
+    assert detector.get_tests_target_branch() == "feature-branch"
+
+
+@pytest.mark.usefixtures("_clear_ci_provider_env")
+def test_get_tests_target_branch_no_provider() -> None:
+    assert detector.get_tests_target_branch() is None

--- a/skills/mergify-ci/SKILL.md
+++ b/skills/mergify-ci/SKILL.md
@@ -37,7 +37,7 @@ mergify ci junit-process \
 **Key options:**
 - `--token` / `-t` (env: `MERGIFY_TOKEN`) -- CI Insights application key
 - `--repository` / `-r` -- Repository full name (auto-detected in GitHub Actions)
-- `--tests-target-branch` / `-ttb` -- Branch used for quarantine evaluation (auto-detected from `GITHUB_BASE_REF`, `GITHUB_HEAD_REF`, `GITHUB_REF_NAME`, `GITHUB_REF`)
+- `--tests-target-branch` / `-ttb` -- Branch used for quarantine evaluation. Auto-detected per CI provider: GitHub Actions (`GITHUB_BASE_REF` → `GITHUB_HEAD_REF` → `GITHUB_REF_NAME` → `GITHUB_REF`), Buildkite (`BUILDKITE_PULL_REQUEST_BASE_BRANCH` → `BUILDKITE_BRANCH`), CircleCI (`CIRCLE_BRANCH`), Jenkins (`CHANGE_TARGET` → `GIT_BRANCH`).
 - `--api-url` / `-u` (env: `MERGIFY_API_URL`) -- Mergify API URL (default: `https://api.mergify.com`)
 - `--test-framework` -- Test framework name (optional metadata)
 - `--test-language` -- Test language (optional metadata)


### PR DESCRIPTION
`mergify ci junit-process` and `junit-upload` previously resolved
`--tests-target-branch` from a hard-coded list of GitHub-Actions env
vars (`GITHUB_BASE_REF`, `GITHUB_HEAD_REF`, `GITHUB_REF_NAME`,
`GITHUB_REF`). On any other CI provider the option came back empty and
click aborted with `Missing option '--tests-target-branch' / '-ttb'`,
even though the equivalent information is exposed by every supported
provider — `BUILDKITE_PULL_REQUEST_BASE_BRANCH` / `BUILDKITE_BRANCH`
on Buildkite, `CIRCLE_BRANCH` on CircleCI, `CHANGE_TARGET` /
`GIT_BRANCH` on Jenkins.

Mirror the `--repository` pattern: a new `detector.get_tests_target_branch`
helper dispatches on `get_ci_provider()` and returns the right env var
per provider. Both options now use `default=detector.get_tests_target_branch`
in place of the GitHub-only `envvar=[...]` list. The existing
`_process_tests_target_branch` callback still strips `refs/heads/` from
whatever value resolves, so behaviour on GitHub Actions is unchanged.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>