### PR TITLE
fix(ci): align Buildkite trace attributes with other Mergify plugins

### DIFF
--- a/mergify_cli/ci/detector.py
+++ b/mergify_cli/ci/detector.py
@@ -175,7 +175,7 @@ def get_cicd_pipeline_run_attempt() -> int | None:
     if get_ci_provider() == "circleci" and "CIRCLE_BUILD_NUM" in os.environ:
         return int(os.environ["CIRCLE_BUILD_NUM"])
     if get_ci_provider() == "buildkite" and "BUILDKITE_RETRY_COUNT" in os.environ:
-        return int(os.environ["BUILDKITE_RETRY_COUNT"])
+        return int(os.environ["BUILDKITE_RETRY_COUNT"]) + 1
 
     return None
 
@@ -234,6 +234,34 @@ def get_github_repository() -> str | None:
             return _get_github_repository_from_env("GIT_URL")
         case "buildkite":
             return _get_github_repository_from_env("BUILDKITE_REPO")
+        case _:
+            return None
+
+
+def get_cicd_pipeline_run_url() -> str | None:
+    match get_ci_provider():
+        case "buildkite":
+            return os.getenv("BUILDKITE_BUILD_URL")
+        case _:
+            return None
+
+
+def get_base_ref_name() -> str | None:
+    match get_ci_provider():
+        case "buildkite":
+            return os.getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
+        case _:
+            return None
+
+
+def get_repository_url() -> str | None:
+    match get_ci_provider():
+        case "buildkite":
+            return os.getenv("BUILDKITE_REPO")
+        case "circleci":
+            return os.getenv("CIRCLE_REPOSITORY_URL")
+        case "jenkins":
+            return os.getenv("GIT_URL")
         case _:
             return None
 

--- a/mergify_cli/ci/junit_processing/junit.py
+++ b/mergify_cli/ci/junit_processing/junit.py
@@ -107,6 +107,9 @@ async def junit_to_spans(
     if (cicd_run_id := detector.get_cicd_pipeline_run_id()) is not None:
         resource_attributes[cicd_attributes.CICD_PIPELINE_RUN_ID] = cicd_run_id
 
+    if (run_url := detector.get_cicd_pipeline_run_url()) is not None:
+        resource_attributes["cicd.pipeline.run.url"] = run_url
+
     if (run_attempt := detector.get_cicd_pipeline_run_attempt()) is not None:
         resource_attributes["cicd.pipeline.run.attempt"] = run_attempt
 
@@ -115,6 +118,15 @@ async def junit_to_spans(
 
     if (head_ref_name := detector.get_head_ref_name()) is not None:
         resource_attributes[vcs_attributes.VCS_REF_HEAD_NAME] = head_ref_name
+
+    if (base_ref_name := detector.get_base_ref_name()) is not None:
+        resource_attributes[vcs_attributes.VCS_REF_BASE_NAME] = base_ref_name
+
+    if (repo_url := detector.get_repository_url()) is not None:
+        resource_attributes[vcs_attributes.VCS_REPOSITORY_URL_FULL] = repo_url
+
+    if (repo_name := detector.get_github_repository()) is not None:
+        resource_attributes["vcs.repository.name"] = repo_name
 
     if (
         cicd_pipeline_runner_name := detector.get_cicd_pipeline_runner_name()

--- a/mergify_cli/tests/ci/test_detector.py
+++ b/mergify_cli/tests/ci/test_detector.py
@@ -348,7 +348,7 @@ def test_get_cicd_pipeline_run_attempt_buildkite(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("BUILDKITE_RETRY_COUNT", "2")
-    assert detector.get_cicd_pipeline_run_attempt() == 2
+    assert detector.get_cicd_pipeline_run_attempt() == 3
 
 
 @pytest.mark.usefixtures("_buildkite_env")
@@ -454,3 +454,44 @@ def test_get_tests_target_branch_jenkins_git_branch_fallback(
 @pytest.mark.usefixtures("_clear_ci_provider_env")
 def test_get_tests_target_branch_no_provider() -> None:
     assert detector.get_tests_target_branch() is None
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+def test_get_cicd_pipeline_run_url_buildkite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BUILDKITE_BUILD_URL", "https://buildkite.com/x/y/builds/1")
+    assert detector.get_cicd_pipeline_run_url() == "https://buildkite.com/x/y/builds/1"
+
+
+@pytest.mark.usefixtures("_clear_ci_provider_env")
+def test_get_cicd_pipeline_run_url_non_buildkite_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    assert detector.get_cicd_pipeline_run_url() is None
+
+
+@pytest.mark.usefixtures("_buildkite_env")
+def test_get_repository_url_buildkite(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BUILDKITE_REPO", "git@github.com:owner/repo.git")
+    assert detector.get_repository_url() == "git@github.com:owner/repo.git"
+
+
+@pytest.mark.usefixtures("_clear_ci_provider_env")
+def test_get_repository_url_circleci(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CIRCLECI", "true")
+    monkeypatch.setenv("CIRCLE_REPOSITORY_URL", "git@github.com:owner/repo.git")
+    assert detector.get_repository_url() == "git@github.com:owner/repo.git"
+
+
+@pytest.mark.usefixtures("_clear_ci_provider_env")
+def test_get_repository_url_jenkins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JENKINS_URL", "http://jenkins.example.com")
+    monkeypatch.setenv("GIT_URL", "https://github.com/owner/repo.git")
+    assert detector.get_repository_url() == "https://github.com/owner/repo.git"
+
+
+@pytest.mark.usefixtures("_clear_ci_provider_env")
+def test_get_repository_url_no_provider() -> None:
+    assert detector.get_repository_url() is None

--- a/mergify_cli/tests/ci/test_junit.py
+++ b/mergify_cli/tests/ci/test_junit.py
@@ -36,6 +36,10 @@ if TYPE_CHECKING:
     "get_head_ref_name",
     return_value="refs/heads/main",
 )
+@mock.patch.object(detector, "get_cicd_pipeline_run_url", return_value=None)
+@mock.patch.object(detector, "get_base_ref_name", return_value=None)
+@mock.patch.object(detector, "get_repository_url", return_value=None)
+@mock.patch.object(detector, "get_github_repository", return_value=None)
 async def test_parse(
     _get_ci_provider: mock.Mock,
     _get_pipeline_name: mock.Mock,
@@ -45,6 +49,10 @@ async def test_parse(
     _get_cicd_pipeline_run_attempt: mock.Mock,
     _get_head_sha: mock.Mock,
     _get_head_ref_name: mock.Mock,
+    _get_cicd_pipeline_run_url: mock.Mock,
+    _get_base_ref_name: mock.Mock,
+    _get_repository_url: mock.Mock,
+    _get_github_repository: mock.Mock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("MERGIFY_TEST_JOB_NAME", "foobar")
@@ -523,6 +531,10 @@ async def test_parse(
     "get_head_ref_name",
     return_value="refs/heads/main",
 )
+@mock.patch.object(detector, "get_cicd_pipeline_run_url", return_value=None)
+@mock.patch.object(detector, "get_base_ref_name", return_value=None)
+@mock.patch.object(detector, "get_repository_url", return_value=None)
+@mock.patch.object(detector, "get_github_repository", return_value=None)
 async def test_traceparent_injection(
     _get_ci_provider: mock.Mock,
     _get_pipeline_name: mock.Mock,
@@ -532,6 +544,10 @@ async def test_traceparent_injection(
     _get_cicd_pipeline_run_attempt: mock.Mock,
     _get_head_sha: mock.Mock,
     _get_head_ref_name: mock.Mock,
+    _get_cicd_pipeline_run_url: mock.Mock,
+    _get_base_ref_name: mock.Mock,
+    _get_repository_url: mock.Mock,
+    _get_github_repository: mock.Mock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv(
@@ -575,6 +591,10 @@ async def test_traceparent_injection(
     "get_head_ref_name",
     return_value="refs/heads/main",
 )
+@mock.patch.object(detector, "get_cicd_pipeline_run_url", return_value=None)
+@mock.patch.object(detector, "get_base_ref_name", return_value=None)
+@mock.patch.object(detector, "get_repository_url", return_value=None)
+@mock.patch.object(detector, "get_github_repository", return_value=None)
 async def test_parse_single_suite(
     _get_ci_provider: mock.Mock,
     _get_pipeline_name: mock.Mock,
@@ -584,6 +604,10 @@ async def test_parse_single_suite(
     _get_cicd_pipeline_run_attempt: mock.Mock,
     _get_head_sha: mock.Mock,
     _get_head_ref_name: mock.Mock,
+    _get_cicd_pipeline_run_url: mock.Mock,
+    _get_base_ref_name: mock.Mock,
+    _get_repository_url: mock.Mock,
+    _get_github_repository: mock.Mock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("MERGIFY_TEST_JOB_NAME", "foobar")
@@ -855,3 +879,67 @@ def test_junit_empty_file_exits_generic_error(
         ],
     )
     assert result.exit_code == ExitCode.GENERIC_ERROR, result.output
+
+
+@mock.patch.object(detector, "get_ci_provider", return_value="buildkite")
+@mock.patch.object(detector, "get_pipeline_name", return_value="my-pipeline")
+@mock.patch.object(detector, "get_job_name", return_value="Run tests")
+@mock.patch.object(detector, "get_cicd_pipeline_runner_name", return_value="agent-1")
+@mock.patch.object(detector, "get_cicd_pipeline_run_id", return_value="abc-123")
+@mock.patch.object(detector, "get_cicd_pipeline_run_attempt", return_value=1)
+@mock.patch.object(
+    detector,
+    "get_head_sha",
+    return_value="3af96aa24f1d32fcfbb7067793cacc6dc0c6b199",
+)
+@mock.patch.object(detector, "get_head_ref_name", return_value="feature-branch")
+@mock.patch.object(
+    detector,
+    "get_cicd_pipeline_run_url",
+    return_value="https://buildkite.com/org/pipeline/builds/42",
+)
+@mock.patch.object(detector, "get_base_ref_name", return_value="main")
+@mock.patch.object(
+    detector,
+    "get_repository_url",
+    return_value="git@github.com:owner/repo.git",
+)
+@mock.patch.object(detector, "get_github_repository", return_value="owner/repo")
+async def test_parse_buildkite_resource_attributes(
+    _get_ci_provider: mock.Mock,
+    _get_pipeline_name: mock.Mock,
+    _get_job_name: mock.Mock,
+    _get_cicd_pipeline_runner_name: mock.Mock,
+    _get_cicd_pipeline_run_id: mock.Mock,
+    _get_cicd_pipeline_run_attempt: mock.Mock,
+    _get_head_sha: mock.Mock,
+    _get_head_ref_name: mock.Mock,
+    _get_cicd_pipeline_run_url: mock.Mock,
+    _get_base_ref_name: mock.Mock,
+    _get_repository_url: mock.Mock,
+    _get_github_repository: mock.Mock,
+) -> None:
+    filename = pathlib.Path(__file__).parent / "fixtures" / "junit_example.xml"
+    run_id = (32312).to_bytes(8, "big").hex()
+    spans = await junit.junit_to_spans(
+        run_id,
+        filename.read_bytes(),
+        "python",
+        "unittest",
+    )
+
+    attrs = spans[0].resource.attributes
+    assert attrs["cicd.provider.name"] == "buildkite"
+    assert attrs["cicd.pipeline.name"] == "my-pipeline"
+    assert attrs["cicd.pipeline.task.name"] == "Run tests"
+    assert attrs["cicd.pipeline.run.id"] == "abc-123"
+    assert (
+        attrs["cicd.pipeline.run.url"] == "https://buildkite.com/org/pipeline/builds/42"
+    )
+    assert attrs["cicd.pipeline.run.attempt"] == 1
+    assert attrs["cicd.pipeline.runner.name"] == "agent-1"
+    assert attrs["vcs.ref.head.name"] == "feature-branch"
+    assert attrs["vcs.ref.base.name"] == "main"
+    assert attrs["vcs.ref.head.revision"] == "3af96aa24f1d32fcfbb7067793cacc6dc0c6b199"
+    assert attrs["vcs.repository.url.full"] == "git@github.com:owner/repo.git"
+    assert attrs["vcs.repository.name"] == "owner/repo"


### PR DESCRIPTION
Bring the CLI's junit-derived resource attributes in line with what
pytest-mergify, rspec-mergify, and mergify-ci-plugins-ts emit on
Buildkite: 1-based BUILDKITE_RETRY_COUNT, plus cicd.pipeline.run.url,
vcs.ref.base.name, vcs.repository.url.full, and vcs.repository.name.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>