### PR TITLE
fix(stack): force C locale on git subprocesses to fix push under non-English locales

### DIFF
--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -217,6 +217,7 @@ async def _git_patch_id(sha: str) -> str:
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
+        env=utils.subprocess_env(),
     )
     stdout, _ = await proc.communicate(input=diff.encode())
     if proc.returncode != 0:

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -946,6 +946,45 @@ async def test_get_default_revision_history_not_set() -> None:
     assert result is True
 
 
+async def test_git_patch_id_forces_c_locale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # `_git_patch_id` bypasses run_command (it needs stdin) so it must
+    # propagate the C locale env independently. Assert that it does.
+    monkeypatch.setenv("LC_ALL", "fr_FR.UTF-8")
+    monkeypatch.setenv("LANG", "fr_FR.UTF-8")
+    monkeypatch.setenv("LANGUAGE", "fr")
+
+    captured_env: dict[str, str] = {}
+
+    async def fake_exec(
+        *args: str,  # noqa: ARG001
+        **kwargs: typing.Any,
+    ) -> typing.Any:
+        captured_env.update(kwargs["env"])
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(
+                self,
+                input: bytes | None = None,  # noqa: A002, ARG002
+            ) -> tuple[bytes, bytes]:
+                return b"abc123 deadbeef", b""
+
+        return _Proc()
+
+    with (
+        mock.patch.object(utils, "git", return_value="dummy diff"),
+        mock.patch("asyncio.subprocess.create_subprocess_exec", fake_exec),
+    ):
+        await push._git_patch_id("deadbeef")
+
+    assert captured_env["LC_ALL"] == "C"
+    assert captured_env["LANG"] == "C"
+    assert captured_env["LANGUAGE"] == "C"
+
+
 async def test_detect_change_type_content() -> None:
     with mock.patch.object(push, "_git_patch_id", side_effect=["aaa", "bbb"]):
         result = await push.detect_change_type("old_sha", "new_sha")

--- a/mergify_cli/tests/test_utils.py
+++ b/mergify_cli/tests/test_utils.py
@@ -14,7 +14,9 @@
 # under the License.
 from __future__ import annotations
 
+import asyncio
 import json
+import typing
 from typing import TYPE_CHECKING
 from unittest import mock
 
@@ -36,6 +38,40 @@ def test_command_error_str_handles_non_utf8_stdout() -> None:
     # str(CommandError) must not raise — error paths depend on it.
     error = utils.CommandError(("git", "show", "abc"), 1, b"\xff\xfe broken")
     assert "failed to run `git show abc`" in str(error)
+
+
+async def test_run_command_forces_c_locale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Several call sites (fetch_notes_ref, read_reasons) match git error
+    # messages by English substring. Subprocesses must therefore run with
+    # LC_ALL=C/LANG=C regardless of the user's locale.
+    monkeypatch.setenv("LC_ALL", "fr_FR.UTF-8")
+    monkeypatch.setenv("LANG", "fr_FR.UTF-8")
+    monkeypatch.setenv("LANGUAGE", "fr")
+
+    captured_env: dict[str, str] = {}
+
+    async def fake_exec(
+        *args: str,  # noqa: ARG001
+        **kwargs: typing.Any,
+    ) -> typing.Any:
+        captured_env.update(kwargs["env"])
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self) -> tuple[bytes, bytes]:
+                return b"ok", b""
+
+        return _Proc()
+
+    with mock.patch.object(asyncio, "create_subprocess_exec", fake_exec):
+        await utils.run_command("git", "status")
+
+    assert captured_env["LC_ALL"] == "C"
+    assert captured_env["LANG"] == "C"
+    assert captured_env["LANGUAGE"] == "C"
 
 
 @pytest.mark.usefixtures("_git_repo")

--- a/mergify_cli/utils.py
+++ b/mergify_cli/utils.py
@@ -126,6 +126,12 @@ class MergifyError(click.ClickException):
         click.secho(f"error: {self.message}", file=file, err=True, fg="red")
 
 
+def subprocess_env() -> dict[str, str]:
+    # Force C locale: fetch_notes_ref and read_reasons match git error
+    # messages by English substring, which breaks under translated locales.
+    return {**os.environ, "LC_ALL": "C", "LANG": "C", "LANGUAGE": "C"}
+
+
 async def run_command(*args: str) -> str:
     if is_debug():
         console.print(f"[purple]DEBUG: running: git {' '.join(args)} [/]")
@@ -134,6 +140,7 @@ async def run_command(*args: str) -> str:
             *args,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
+            env=subprocess_env(),
         )
     except FileNotFoundError as e:
         raise CommandError(args, -1, str(e).encode()) from e


### PR DESCRIPTION
`mergify stack push` crashed on first push when the user's locale is not
English. `fetch_notes_ref` and `read_reasons` match git error output by
substring (e.g. `b"couldn't find remote ref"`, `b"no note found"`), but
git emits translated messages — under fr_FR git says
`fatal : impossible de trouver la référence distante`, the substring
check fails, and the exception is re-raised.

Force `LC_ALL=C LANG=C LANGUAGE=C` on git subprocesses spawned by
`run_command` and `_git_patch_id` so the output we parse is stable
regardless of the user's locale. The other git call sites (ci/queue,
ci/scopes, stack/reorder) parse by exit code or null-delimited output
and are deliberately left alone — `git rebase -i` in particular shows
its messages to the user, and forcing English would degrade UX.

Add a regression test that mocks `create_subprocess_exec` and asserts
`run_command` propagates the C-locale env even when the surrounding
shell is fr_FR.