### PR TITLE
ci: factor wheel build into reusable workflow + smoke-build on every PR

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,131 @@
+name: build wheels
+
+# Reusable workflow that builds the per-target maturin wheel matrix
+# plus the sdist. Called from:
+#
+#   - `ci.yaml` on every PR — smoke build, no publish, version stays
+#     at the placeholder so PRs can iterate without colliding with
+#     PyPI versioning.
+#   - `release.yml` on `release: published` — same matrix, but the
+#     wheel version is stamped from `$GITHUB_REF` and the artifacts
+#     are uploaded for the publish job to push to PyPI.
+#
+# Targets: Linux x64 + arm64 (manylinux), macOS x64 + arm64,
+# Windows x64. Add new targets here when a new platform is on the
+# support matrix — both CI and release pick it up automatically.
+#
+# Linux arm64 uses a native `ubuntu-24.04-arm` runner instead of
+# cross-compiling: `ring`'s ARM-asm build script needs the C
+# compiler to define `__ARM_ARCH`, which the cross-gcc inside the
+# manylinux Docker image doesn't, and a native runner sidesteps the
+# problem entirely.
+
+on:
+  workflow_call:
+    inputs:
+      stamp-version:
+        description: |
+          When true, replace `version = "..."` in pyproject.toml
+          with the git tag value (`${GITHUB_REF#refs/tags/}`)
+          before maturin runs. Keep false for PR smoke builds so
+          CI exercises the full path with the placeholder version.
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build-wheels:
+    name: build wheel (${{ matrix.target }})
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - os: macos-15
+            target: x86_64-apple-darwin
+          - os: macos-15
+            target: aarch64-apple-darwin
+          - os: windows-2025
+            target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: actions/setup-python@v6.2.0
+        with:
+          python-version: 3.14
+
+      - name: Stamp wheel version from git tag
+        if: inputs.stamp-version
+        shell: bash
+        run: |
+          set -eu
+          VERSION="${GITHUB_REF#refs/tags/}"
+          # `sed -i.bak`/rm form works on both BSD (macOS) and GNU
+          # (Linux) sed without divergent flag handling. On Windows
+          # the runner ships GNU sed via Git Bash, which honours the
+          # same syntax.
+          sed -i.bak -E "s/^version = \".*\"$/version = \"${VERSION}\"/" pyproject.toml
+          rm -f pyproject.toml.bak
+          echo "Stamped pyproject.toml:"
+          grep '^version = ' pyproject.toml
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          # `manylinux: auto` picks the most-compatible glibc the
+          # target supports; `--strip` shaves debug symbols off the
+          # bundled binary.
+          args: --release --strip --out target/wheels
+          manylinux: auto
+          sccache: true
+
+      # Only upload artifacts when the caller actually needs them
+      # (release.yml downloads them in its publish job). PR smoke
+      # builds just need the build to succeed — keeping the
+      # artifact upload off saves cache space and a few seconds per
+      # platform.
+      - uses: actions/upload-artifact@v4
+        if: inputs.stamp-version
+        with:
+          name: wheel-${{ matrix.target }}
+          path: target/wheels/*.whl
+
+  build-sdist:
+    name: build sdist
+    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+    # The sdist is only useful for the release publish step. PR
+    # smoke runs would just throw it away — skip the whole job.
+    if: inputs.stamp-version
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Stamp wheel version from git tag
+        shell: bash
+        run: |
+          set -eu
+          VERSION="${GITHUB_REF#refs/tags/}"
+          sed -i.bak -E "s/^version = \".*\"$/version = \"${VERSION}\"/" pyproject.toml
+          rm -f pyproject.toml.bak
+
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out target/wheels
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-sdist
+          path: target/wheels/*.tar.gz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,12 @@ jobs:
         run: cargo build --release
 
   test:
-    timeout-minutes: 15
+    # Cold-cache cargo builds on Windows can push past 15 minutes
+    # (uv sync invokes the maturin build-backend, which compiles the
+    # whole Rust workspace). Warm runs land in ~10 min; 25 gives the
+    # cold path enough headroom to avoid spurious cancellations
+    # without masking a genuinely runaway build.
+    timeout-minutes: 25
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2025, macos-15]
@@ -134,6 +139,17 @@ jobs:
           # to ensure the utf8 mode is enabled.
           python -c "import test_binary_build; test_binary_build.test_reexec_enables_utf8_and_prints_emoji();"
 
+  # Smoke build the full release wheel matrix on every PR so a
+  # cross-compile or platform-specific maturin failure is caught
+  # here, not on the next `release: published` event. Calls the
+  # same reusable workflow the release uses, with version stamping
+  # disabled (the placeholder "0.0.0" stays in pyproject.toml so
+  # the wheel name doesn't pretend to be a release version).
+  wheels:
+    uses: ./.github/workflows/build-wheels.yml
+    with:
+      stamp-version: false
+
   ci-gate:
     if: ${{ !cancelled() }}
     needs:
@@ -141,6 +157,7 @@ jobs:
       - linters
       - compat-tests
       - rust
+      - wheels
     runs-on: ubuntu-latest
     steps:
       - name: Verify all jobs succeeded

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,14 @@
 name: upload release to PyPI
 
-# Builds platform-tagged wheels (one per supported target) plus an
-# sdist, then publishes everything to PyPI in a single
-# Trusted-Publisher upload. The wheel version is stamped from the
-# git tag (`$GITHUB_REF`) so the existing tag-driven release UX
-# stays the same as the pre-port hatch-vcs flow.
+# Builds the platform-tagged wheel matrix (delegated to
+# `build-wheels.yml`) plus an sdist with the wheel version stamped
+# from the git tag, then publishes everything to PyPI in a single
+# Trusted-Publisher upload.
 #
-# Targets: Linux x64/arm64 (manylinux), macOS x64/arm64,
-# Windows x64. Add new targets here when a new platform is on the
-# support matrix.
+# `build-wheels.yml` is shared with `ci.yaml`; the only release-
+# specific behaviour lives here (version stamping, the publish
+# step itself). Adding a new platform target in `build-wheels.yml`
+# automatically extends the release matrix.
 
 on:
   release:
@@ -16,96 +16,16 @@ on:
       - published
 
 jobs:
-  build-wheels:
-    name: build wheel (${{ matrix.target }})
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-24.04
-            target: x86_64-unknown-linux-gnu
-          - os: ubuntu-24.04
-            target: aarch64-unknown-linux-gnu
-          - os: macos-15
-            target: x86_64-apple-darwin
-          - os: macos-15
-            target: aarch64-apple-darwin
-          - os: windows-2025
-            target: x86_64-pc-windows-msvc
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v6.0.2
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: 3.14
-
-      - name: Stamp wheel version from git tag
-        shell: bash
-        run: |
-          set -eu
-          VERSION="${GITHUB_REF#refs/tags/}"
-          # `sed -i.bak`/rm form works on both BSD (macOS) and GNU
-          # (Linux) sed without divergent flag handling. On Windows
-          # the runner ships GNU sed via Git Bash, which honours the
-          # same syntax.
-          sed -i.bak -E "s/^version = \".*\"$/version = \"${VERSION}\"/" pyproject.toml
-          rm -f pyproject.toml.bak
-          echo "Stamped pyproject.toml:"
-          grep '^version = ' pyproject.toml
-
-      - name: Build wheel
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.target }}
-          # `manylinux: auto` picks the most-compatible glibc the
-          # target supports; `--strip` shaves debug symbols off the
-          # bundled binary.
-          args: --release --strip --out target/wheels
-          manylinux: auto
-          sccache: true
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: wheel-${{ matrix.target }}
-          path: target/wheels/*.whl
-
-  build-sdist:
-    name: build sdist
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6.0.2
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Stamp wheel version from git tag
-        shell: bash
-        run: |
-          set -eu
-          VERSION="${GITHUB_REF#refs/tags/}"
-          sed -i.bak -E "s/^version = \".*\"$/version = \"${VERSION}\"/" pyproject.toml
-          rm -f pyproject.toml.bak
-
-      - uses: PyO3/maturin-action@v1
-        with:
-          command: sdist
-          args: --out target/wheels
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: wheel-sdist
-          path: target/wheels/*.tar.gz
+  build:
+    uses: ./.github/workflows/build-wheels.yml
+    with:
+      stamp-version: true
 
   publish:
     name: publish to PyPI
     runs-on: ubuntu-24.04
     needs:
-      - build-wheels
-      - build-sdist
+      - build
     environment: release
     permissions:
       id-token: write


### PR DESCRIPTION
The first real release after the maturin switch (#1321) failed on
the `aarch64-unknown-linux-gnu` job: `ring`'s ARM-asm build script
fired in the manylinux Docker container's cross-toolchain, where
gcc doesn't define `__ARM_ARCH`, so the C compile aborted before
the wheel was produced. The `aarch64-apple-darwin` and Windows x64
wheels built fine and would have shipped, but PyPI rejected the
half-published release because one platform was missing. Nothing
in `ci.yaml` exercised the cross-compile path, so the failure only
surfaced when a real tag was pushed — exactly the worst time.

Two changes:

1. `build-wheels.yml` (new, reusable via `workflow_call`): factors
   out the per-target wheel matrix + sdist build. `stamp-version`
   input controls whether the git tag is sed'd into pyproject.toml
   before maturin runs. `release.yml` calls it with `true`,
   `ci.yaml` calls it with `false`. Adding a new platform target
   touches one file instead of two.

2. `aarch64-unknown-linux-gnu` switches from cross-compile (Docker
   manylinux container) to a native `ubuntu-24.04-arm` runner. The
   C cross-gcc / `ring` ARM-asm interaction goes away; maturin's
   `manylinux: auto` still produces the right manylinux2014_aarch64
   wheel because it's running natively now.

3. `ci.yaml` adds a `wheels` job that runs the same reusable
   workflow on every PR. The build doesn't publish — artifacts
   stay attached to the run. Future cross-compile, platform, or
   maturin-action regressions fail PR CI instead of a release.
   `ci-gate` learns about the new job so a failure blocks the gate.

`release.yml` shrinks to just the publish glue: download all
artifacts collected by the reusable workflow into `dist/`, push to
PyPI via Trusted Publishing.