### PR TITLE
fix(http): bump read/write timeout to 10s and reword timeout error

### DIFF
--- a/mergify_cli/cli.py
+++ b/mergify_cli/cli.py
@@ -87,17 +87,21 @@ def main() -> None:
             raise SystemExit(ExitCode.MERGIFY_API_ERROR) from None
         raise SystemExit(ExitCode.GITHUB_API_ERROR) from None
     except httpx.RequestError as e:
-        url = str(e.request.url)
+        if str(e.request.url).startswith(utils.get_mergify_api_url()):
+            service = "Mergify"
+            exit_code = ExitCode.MERGIFY_API_ERROR
+        else:
+            service = "GitHub"
+            exit_code = ExitCode.GITHUB_API_ERROR
+
         if isinstance(e, httpx.TimeoutException):
             console_error(
-                f"timed out contacting {url}. "
-                "Check your network connection or try again later.",
+                f"{service} did not respond in time. "
+                "The request was aborted — please retry.",
             )
         else:
-            console_error(f"network error contacting {url}: {e}")
-        if url.startswith(utils.get_mergify_api_url()):
-            raise SystemExit(ExitCode.MERGIFY_API_ERROR) from None
-        raise SystemExit(ExitCode.GITHUB_API_ERROR) from None
+            console_error(f"could not reach {service}: {e}")
+        raise SystemExit(exit_code) from None
     except utils.CommandError as e:
         console.print(f"error: {e}", style="red")
         raise SystemExit(ExitCode.GENERIC_ERROR) from None

--- a/mergify_cli/tests/test_cli.py
+++ b/mergify_cli/tests/test_cli.py
@@ -84,8 +84,8 @@ def test_cli_connect_timeout_shows_clean_message(
 
     assert exc_info.value.code == ExitCode.GITHUB_API_ERROR
     out = capsys.readouterr().out
-    assert "timed out" in out
-    assert "https://api.github.com/user" in out
+    assert "GitHub did not respond in time" in out
+    assert "please retry" in out
     assert "Traceback" not in out
     assert "ConnectTimeout" not in out
 
@@ -103,7 +103,7 @@ def test_cli_connect_timeout_to_mergify_api(
         cli_mod.main()
 
     assert exc_info.value.code == ExitCode.MERGIFY_API_ERROR
-    assert "timed out" in capsys.readouterr().out
+    assert "Mergify did not respond in time" in capsys.readouterr().out
 
 
 def test_cli_connect_error_shows_clean_message(
@@ -120,7 +120,7 @@ def test_cli_connect_error_shows_clean_message(
 
     assert exc_info.value.code == ExitCode.GITHUB_API_ERROR
     out = capsys.readouterr().out
-    assert "network error" in out
+    assert "could not reach GitHub" in out
     assert "connection refused" in out
 
 

--- a/mergify_cli/tests/test_utils.py
+++ b/mergify_cli/tests/test_utils.py
@@ -257,6 +257,18 @@ def test_get_mergify_http_client() -> None:
     assert client.base_url == "https://api.mergify.com"
 
 
+def test_get_http_client_read_write_timeout_has_headroom() -> None:
+    # A flat 5s timeout previously aborted `stack push` whenever GitHub took
+    # longer than 5s to send PR create/update response headers; lock in the
+    # structured timeout so connect/pool stay short while read/write get
+    # enough headroom to absorb transient slowdowns.
+    client = utils.get_http_client("https://example.com")
+    assert client.timeout.connect == pytest.approx(5.0)
+    assert client.timeout.pool == pytest.approx(5.0)
+    assert client.timeout.read == pytest.approx(10.0)
+    assert client.timeout.write == pytest.approx(10.0)
+
+
 class TestCheckForStatus:
     async def test_success_does_nothing(self) -> None:
         request = httpx.Request("GET", "https://api.mergify.com/v1/repos/owner/repo")

--- a/mergify_cli/utils.py
+++ b/mergify_cli/utils.py
@@ -336,7 +336,10 @@ def get_http_client(
         headers=default_headers,
         event_hooks=default_event_hooks,
         follow_redirects=follow_redirects,
-        timeout=5.0,
+        # GitHub's PR create/update can briefly exceed 5s under load, but
+        # a slow CLI is worse than a fast retry — 10s absorbs transient
+        # hiccups while keeping the tool responsive when GitHub is down.
+        timeout=httpx.Timeout(5.0, read=10.0, write=10.0),
     )
 
 


### PR DESCRIPTION
The shared httpx.AsyncClient was constructed with a flat `timeout=5.0`,
which httpx applies to every phase. GitHub's PR create/update regularly
takes longer than 5s under load, so transient slowdowns abort
`mergify stack push` mid-stack with `httpx.ReadTimeout` even though the
request was already sent and likely accepted server side.

Switch to `httpx.Timeout(5.0, read=10.0, write=10.0)`: 10s absorbs
common hiccups while staying snappy enough for an interactive CLI to
fail fast on real outages — and `discover_changes`' `head:` search
makes re-running the push safe (already-created PRs are detected).

Also reword the friendly `httpx.RequestError` handler in `main()`: name
the upstream ("GitHub did not respond in time. The request was aborted
— please retry.") instead of pasting the raw URL and suggesting a
network check, which conflates a slow upstream with a broken network.