### PR TITLE
fix(packaging): bundle LICENSE in wheel and sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,13 @@ manifest-path = "crates/mergify-cli/Cargo.toml"
 python-source = "."
 module-name = "mergify_cli"
 strip = true
+# Bundle LICENSE in both the wheel and sdist. PEP 639 metadata
+# (auto-derived by maturin from `license = "Apache-2.0"`) emits a
+# `License-File: LICENSE` field, and PyPI's upload validator rejects
+# the artifact with `400 License-File LICENSE does not exist in
+# distribution file` if the file isn't actually bundled. Listing it
+# here keeps wheel + sdist in sync with the metadata.
+include = ["LICENSE"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
The 2026.5.5.1 release upload to PyPI failed with
``400 License-File LICENSE does not exist in distribution file
mergify_cli-2026.5.5.1.tar.gz at mergify_cli-2026.5.5.1/LICENSE``.

Maturin auto-derives a ``License-File: LICENSE`` PEP 639 metadata
field from ``license = "Apache-2.0"`` plus the project root
``LICENSE`` file, but the sdist tarball (``maturin sdist``) packs
the cargo workspace and the Python source dir without picking up
the project root ``LICENSE`` itself. PyPI's upload validator
cross-checks the metadata against the tarball contents and 400s
when they disagree.

Listing ``LICENSE`` in ``[tool.maturin].include`` puts it back in
both the wheel and the sdist, so the metadata claim is honored and
PyPI accepts the upload.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>