### PR TITLE
chore(deps): bump jsonschema to 0.46

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.16.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -935,13 +941,13 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.35.0"
+version = "0.46.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0303b14f91cbac17c64aaf2ef60ab71fe5f34c3867cedcbca72c9dd15f5040fe"
+checksum = "fc59d2432e047d6090ba1d83c782d0128bd6203857978218f5614dbd3287281f"
 dependencies = [
  "ahash",
- "base64",
  "bytecount",
+ "data-encoding",
  "email_address",
  "fancy-regex",
  "fraction",
@@ -1080,6 +1086,12 @@ dependencies = [
  "tempfile",
  "thiserror",
 ]
+
+[[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "mio"
@@ -1414,14 +1426,16 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.35.0"
+version = "0.46.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22d0d0665043906aacf1d83bea9d61e5134f8f437815b84320e7facf8ff4e9c2"
+checksum = "cb674900ca31acd75c4aaf63f48e43e719631c0539ea5a9e64163d1296bcb730"
 dependencies = [
  "ahash",
  "fluent-uri",
  "getrandom 0.3.4",
  "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
  "parking_lot",
  "percent-encoding",
  "serde_json",

--- a/crates/mergify-config/Cargo.toml
+++ b/crates/mergify-config/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 mergify-core = { path = "../mergify-core" }
-jsonschema = { version = "0.35", default-features = false }
+jsonschema = { version = "0.46", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_norway = "0.9"

--- a/crates/mergify-config/src/validate.rs
+++ b/crates/mergify-config/src/validate.rs
@@ -108,7 +108,7 @@ fn validate_against_schema(
     let mut errors: Vec<ValidationError> = validator
         .iter_errors(config)
         .map(|err| {
-            let path = err.instance_path.to_string();
+            let path = err.instance_path().to_string();
             let pretty_path = if path.is_empty() || path == "/" {
                 "(root)".to_string()
             } else {


### PR DESCRIPTION
jsonschema 0.37 made the fields of `ValidationError` private; the
struct must now be inspected through getter methods. Update
`validate_against_schema` to call `instance_path()` instead of
reading the field directly so the workspace builds against 0.46.

The other 0.35 → 0.46 changes (registry construction overhaul,
`evaluate()` API, output reports, etc.) are not used here — we
build a single `Validator` with `jsonschema::options().build()` and
iterate errors via `iter_errors`, which both keep their public
shape across the bump.

Renovate originally bundled this with a reqwest bump in #1330;
splitting it so each breaking-change update lands as its own
reviewable commit.