### PR TITLE
feat(stack): add mergify stack drop command

### DIFF
--- a/mergify_cli/stack/cli.py
+++ b/mergify_cli/stack/cli.py
@@ -12,6 +12,7 @@ from mergify_cli import console_error
 from mergify_cli import utils
 from mergify_cli.dym import DYMGroup
 from mergify_cli.stack import checkout as stack_checkout_mod
+from mergify_cli.stack import drop as stack_drop_mod
 from mergify_cli.stack import edit as stack_edit_mod
 from mergify_cli.stack import list as stack_list_mod
 from mergify_cli.stack import move as stack_move_mod
@@ -670,6 +671,20 @@ async def reword(*, commit: str, message: str | None, dry_run: bool) -> None:
         message=message,
         dry_run=dry_run,
     )
+
+
+@stack.command(help="Drop commits from the stack")
+@click.argument("commits", nargs=-1, required=True)
+@click.option(
+    "--dry-run",
+    "-n",
+    is_flag=True,
+    default=False,
+    help="Show the plan without dropping",
+)
+@utils.run_with_asyncio
+async def drop(*, commits: tuple[str, ...], dry_run: bool) -> None:
+    await stack_drop_mod.stack_drop(list(commits), dry_run=dry_run)
 
 
 @stack.command(help="Squash commits into a target commit")

--- a/mergify_cli/stack/drop.py
+++ b/mergify_cli/stack/drop.py
@@ -1,0 +1,68 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import os
+import sys
+
+from mergify_cli import console
+from mergify_cli import console_error
+from mergify_cli import utils
+from mergify_cli.exit_codes import ExitCode
+from mergify_cli.stack.reorder import display_action_plan
+from mergify_cli.stack.reorder import get_stack_commits
+from mergify_cli.stack.reorder import match_commit
+from mergify_cli.stack.reorder import run_action_rebase
+
+
+async def stack_drop(
+    commit_prefixes: list[str],
+    *,
+    dry_run: bool,
+) -> None:
+    os.chdir(await utils.git("rev-parse", "--show-toplevel"))
+    trunk = await utils.get_trunk()
+    base = await utils.git("merge-base", trunk, "HEAD")
+    commits = get_stack_commits(base)
+
+    if not commits:
+        console.print("No commits in the stack", style="green")
+        return
+
+    matched = [match_commit(p, commits) for p in commit_prefixes]
+
+    matched_shas = [c[0] for c in matched]
+    if len(set(matched_shas)) != len(matched_shas):
+        seen: set[str] = set()
+        for prefix, sha in zip(commit_prefixes, matched_shas, strict=True):
+            if sha in seen:
+                console_error(
+                    f"duplicate — prefix '{prefix}' resolves to the same commit as another prefix",
+                )
+                sys.exit(ExitCode.INVALID_STATE)
+            seen.add(sha)
+
+    actions = dict.fromkeys(matched_shas, "drop")
+    current_shas = [c[0] for c in commits]
+
+    display_action_plan("Drop plan:", commits, actions)
+
+    if dry_run:
+        console.print("Dry run — no changes made", style="green")
+        return
+
+    run_action_rebase(base, current_shas, actions)
+    console.print("Commits dropped successfully.", style="green")

--- a/mergify_cli/tests/stack/test_drop.py
+++ b/mergify_cli/tests/stack/test_drop.py
@@ -1,0 +1,259 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergify_cli.exit_codes import ExitCode
+from mergify_cli.stack.drop import stack_drop
+
+
+if TYPE_CHECKING:
+    import pathlib
+
+
+def _run_git(*args: str, cwd: pathlib.Path | None = None) -> str:
+    return subprocess.check_output(
+        ["git", *args],
+        text=True,
+        cwd=cwd,
+    ).strip()
+
+
+def _create_commit(
+    repo: pathlib.Path,
+    filename: str,
+    content: str,
+    message: str,
+) -> tuple[str, str | None]:
+    (repo / filename).write_text(content)
+    _run_git("add", filename, cwd=repo)
+    _run_git("commit", "-m", message, cwd=repo)
+    sha = _run_git("rev-parse", "HEAD", cwd=repo)
+    body = _run_git("log", "-1", "--format=%b", "HEAD", cwd=repo)
+    change_id_match = re.search(r"Change-Id: (I[0-9a-z]{40})", body)
+    return sha, change_id_match.group(1) if change_id_match else None
+
+
+def _get_commit_subjects(repo: pathlib.Path, n: int = 10) -> list[str]:
+    raw = _run_git(
+        "log",
+        "--reverse",
+        f"-{n}",
+        "--format=%s",
+        cwd=repo,
+    )
+    return [line for line in raw.splitlines() if line.strip()]
+
+
+def _setup_tracking(repo: pathlib.Path) -> None:
+    origin_path = repo.parent / f"{repo.name}_origin.git"
+    _run_git("init", "--bare", str(origin_path))
+    _run_git("remote", "add", "origin", str(origin_path), cwd=repo)
+    _run_git("push", "origin", "main", cwd=repo)
+    _run_git("branch", "--set-upstream-to=origin/main", cwd=repo)
+
+
+@pytest.fixture
+def stack_repo(
+    git_repo_with_hooks: pathlib.Path,
+) -> tuple[pathlib.Path, list[tuple[str, str | None]]]:
+    """Create a repo with 3 feature commits (A, B, C) on top of main."""
+    repo = git_repo_with_hooks
+
+    (repo / "init.txt").write_text("init")
+    _run_git("add", "init.txt", cwd=repo)
+    _run_git("commit", "-m", "Initial commit", cwd=repo)
+
+    _setup_tracking(repo)
+
+    _run_git("checkout", "-b", "feature", "main", cwd=repo)
+    _run_git("branch", "--set-upstream-to=origin/main", cwd=repo)
+
+    commits = []
+    for label, filename in [("A", "a.txt"), ("B", "b.txt"), ("C", "c.txt")]:
+        sha, cid = _create_commit(repo, filename, f"content {label}", f"Commit {label}")
+        commits.append((sha, cid))
+
+    return repo, commits
+
+
+class TestStackDrop:
+    async def test_drop_middle_commit(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """drop B: stack becomes [A, C]; B's file disappears."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_b = commits[1][0][:12]
+
+        await stack_drop([sha_b], dry_run=False)
+
+        feature = [s for s in _get_commit_subjects(repo) if s.startswith("Commit")]
+        assert feature == ["Commit A", "Commit C"]
+
+        assert (repo / "a.txt").exists()
+        assert not (repo / "b.txt").exists()
+        assert (repo / "c.txt").exists()
+
+    async def test_drop_first_commit(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """Dropping the first commit of the stack works."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_a = commits[0][0][:12]
+
+        await stack_drop([sha_a], dry_run=False)
+
+        feature = [s for s in _get_commit_subjects(repo) if s.startswith("Commit")]
+        assert feature == ["Commit B", "Commit C"]
+
+        assert not (repo / "a.txt").exists()
+        assert (repo / "b.txt").exists()
+        assert (repo / "c.txt").exists()
+
+    async def test_drop_last_commit(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """Dropping HEAD works."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_c = commits[2][0][:12]
+
+        await stack_drop([sha_c], dry_run=False)
+
+        feature = [s for s in _get_commit_subjects(repo) if s.startswith("Commit")]
+        assert feature == ["Commit A", "Commit B"]
+
+        assert not (repo / "c.txt").exists()
+
+    async def test_drop_multiple(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """drop A C: only B remains."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_a = commits[0][0][:12]
+        sha_c = commits[2][0][:12]
+
+        await stack_drop([sha_a, sha_c], dry_run=False)
+
+        feature = [s for s in _get_commit_subjects(repo) if s.startswith("Commit")]
+        assert feature == ["Commit B"]
+
+    async def test_drop_all(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """Dropping every stack commit empties the stack."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        prefixes = [c[0][:12] for c in commits]
+
+        await stack_drop(prefixes, dry_run=False)
+
+        feature = [s for s in _get_commit_subjects(repo) if s.startswith("Commit")]
+        assert feature == []
+
+    async def test_drop_by_change_id(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """Drop by Change-Id prefix works."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        cid_b = commits[1][1]
+        assert cid_b is not None
+
+        await stack_drop([cid_b[:8]], dry_run=False)
+
+        feature = [s for s in _get_commit_subjects(repo) if s.startswith("Commit")]
+        assert feature == ["Commit A", "Commit C"]
+
+    async def test_drop_unknown_prefix_errors(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        repo, _commits = stack_repo
+        os.chdir(repo)
+
+        with pytest.raises(SystemExit) as exc_info:
+            await stack_drop(["deadbeef"], dry_run=False)
+        assert exc_info.value.code == ExitCode.STACK_NOT_FOUND
+
+    async def test_drop_duplicate_prefix_errors(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_b = commits[1][0][:12]
+
+        with pytest.raises(SystemExit) as exc_info:
+            await stack_drop([sha_b, sha_b], dry_run=False)
+        assert exc_info.value.code == ExitCode.INVALID_STATE
+
+    async def test_drop_dry_run(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        head_before = _run_git("rev-parse", "HEAD", cwd=repo)
+
+        sha_b = commits[1][0][:12]
+        await stack_drop([sha_b], dry_run=True)
+
+        head_after = _run_git("rev-parse", "HEAD", cwd=repo)
+        assert head_before == head_after
+
+    async def test_drop_empty_stack(
+        self,
+        git_repo_with_hooks: pathlib.Path,
+    ) -> None:
+        repo = git_repo_with_hooks
+
+        (repo / "init.txt").write_text("init")
+        _run_git("add", "init.txt", cwd=repo)
+        _run_git("commit", "-m", "Initial commit", cwd=repo)
+
+        _setup_tracking(repo)
+
+        _run_git("checkout", "-b", "feature", "main", cwd=repo)
+        _run_git("branch", "--set-upstream-to=origin/main", cwd=repo)
+
+        os.chdir(repo)
+
+        # Should return without error — no commits to drop
+        await stack_drop(["abc"], dry_run=False)

--- a/skills/mergify-stack/SKILL.md
+++ b/skills/mergify-stack/SKILL.md
@@ -26,6 +26,7 @@ A branch is a stack. Keep stacks short and focused:
 - **Fixup**: Stash any local changes first (`git stash -u`), then use `mergify stack fixup <SHA>...` to fold a commit into its parent (drops the listed commit's message). Non-interactive — never use `git rebase -i` for this.
 - **Squash**: Stash any local changes first (`git stash -u`), then use `mergify stack squash SRC... into TARGET [-m "msg"]` to combine multiple commits into one, with an optional custom message. Non-interactive — never use `git rebase -i` for this.
 - **Reword**: Stash any local changes first (`git stash -u`), then use `mergify stack reword <SHA> -m "new message"` to change a commit's message in place. Non-interactive when `-m` is given — never use `git rebase -i` for this.
+- **Drop**: Stash any local changes first (`git stash -u`), then use `mergify stack drop <SHA>...` to remove commits from the stack. Non-interactive — never use `git rebase -i` for this.
 - **Commit titles**: Follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `docs:`)
 - **PR title & body**: `mergify stack` copies the commit message title to the PR title and the commit message body to the PR body — so write commit messages as if they were PR descriptions. **Everything that should appear in the PR (ticket references, context, test plans) MUST go in the commit message.**
 - **Ticket references**: Include ticket/issue references (e.g., `MRGFY-1234`, `Fixes #123`) in the commit message body, not added separately to the PR.
@@ -46,6 +47,7 @@ A branch is a stack. Keep stacks short and focused:
 | `git rebase -i` to squash commits | `mergify stack squash A B into X [-m "..."]` | Non-interactive — works inside LLM/agent sessions; no editor spawned |
 | `git rebase -i` to change a commit message | `mergify stack reword <SHA> -m "..."` | Non-interactive — works inside LLM/agent sessions; no editor spawned |
 | `git rebase -i` to amend a mid-stack commit | `mergify stack edit <SHA-or-Change-Id-prefix>` then `git commit --amend` then `git rebase --continue` | Non-interactive — pauses the rebase at the target commit without spawning an editor |
+| `git rebase -i` to drop a commit | `mergify stack drop <SHA>...` | Non-interactive — works inside LLM/agent sessions; no editor spawned |
 | `GIT_SEQUENCE_EDITOR='sed -i ...' git rebase -i` (any variant) | One of `mergify stack {edit,fixup,squash,reorder,move}` | Hand-rolled sequence-editor scripts are brittle; there is already a non-interactive command for every common rewrite |
 | Deferring lint fixes to a later commit | Include the fix in the commit that caused it | Each commit runs CI independently; later commits won't save earlier ones |
 | Rebase/reorder/checkout/sync with dirty worktree | `git stash -u` first, then `git stash pop` after | Uncommitted changes are lost or cause conflicts during these operations |
@@ -72,6 +74,8 @@ mergify stack squash X Y into Z -m "msg"  # Fold X Y into Z with a custom messag
 mergify stack reword X -m "msg"    # Change commit X's message non-interactively
 mergify stack reword X             # Change commit X's message via $GIT_EDITOR (TTY only)
 mergify stack edit X               # Pause the rebase at X so you can `git commit --amend` it (X is required; no-arg form is interactive)
+mergify stack drop X               # Drop commit X from the stack
+mergify stack drop X Y Z           # Drop multiple commits in one rebase
 mergify stack note -m "why"        # Attach an amend reason to HEAD (shown in PR revision history)
 mergify stack note <SHA-or-Change-Id-prefix> -m "why"  # Attach to a specific commit in the stack
 mergify stack note --append -m "more"                  # Append to an existing note
@@ -137,6 +141,7 @@ git stash -u                # Stash tracked + untracked changes if any
 - `mergify stack fixup`
 - `mergify stack squash`
 - `mergify stack reword`
+- `mergify stack drop`
 - `mergify stack checkout`
 - `mergify stack sync`
 - `mergify stack new` (switches to new branch)


### PR DESCRIPTION
Add "mergify stack drop COMMIT..." which removes one or more commits
from the stack in a single non-interactive rebase, replacing the
brittle "GIT_SEQUENCE_EDITOR='sed -i ... pick → drop' git rebase -i"
recipe agents tend to reach for.

Multiple commits can be listed (matched by SHA or Change-Id prefix);
unlike fixup, dropping the first commit in the stack is fine. Errors
on unknown or duplicated prefixes. Supports --dry-run.

Also documents the drop command in skills/mergify-stack/SKILL.md.