### PR TITLE
feat(stack): add mergify stack reword command

### DIFF
--- a/mergify_cli/stack/cli.py
+++ b/mergify_cli/stack/cli.py
@@ -20,6 +20,7 @@ from mergify_cli.stack import note as stack_note_mod
 from mergify_cli.stack import open as stack_open_mod
 from mergify_cli.stack import push as stack_push_mod
 from mergify_cli.stack import reorder as stack_reorder_mod
+from mergify_cli.stack import reword as stack_reword_mod
 from mergify_cli.stack import setup as stack_setup_mod
 from mergify_cli.stack import squash as stack_squash_mod
 from mergify_cli.stack import sync as stack_sync_mod
@@ -644,6 +645,31 @@ async def open_cmd(
 @utils.run_with_asyncio
 async def fixup(*, commits: tuple[str, ...], dry_run: bool) -> None:
     await stack_squash_mod.stack_fixup(list(commits), dry_run=dry_run)
+
+
+@stack.command(help="Change a commit's message")
+@click.argument("commit")
+@click.option(
+    "-m",
+    "--message",
+    "message",
+    default=None,
+    help="New commit message. If omitted, opens $GIT_EDITOR.",
+)
+@click.option(
+    "--dry-run",
+    "-n",
+    is_flag=True,
+    default=False,
+    help="Show the plan without rebasing",
+)
+@utils.run_with_asyncio
+async def reword(*, commit: str, message: str | None, dry_run: bool) -> None:
+    await stack_reword_mod.stack_reword(
+        commit_prefix=commit,
+        message=message,
+        dry_run=dry_run,
+    )
 
 
 @stack.command(help="Squash commits into a target commit")

--- a/mergify_cli/stack/reword.py
+++ b/mergify_cli/stack/reword.py
@@ -1,0 +1,87 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import os
+import pathlib
+import shlex
+import tempfile
+
+from mergify_cli import console
+from mergify_cli import utils
+from mergify_cli.stack.reorder import display_action_plan
+from mergify_cli.stack.reorder import get_stack_commits
+from mergify_cli.stack.reorder import match_commit
+from mergify_cli.stack.reorder import run_action_rebase
+
+
+async def stack_reword(
+    commit_prefix: str,
+    *,
+    message: str | None,
+    dry_run: bool,
+) -> None:
+    os.chdir(await utils.git("rev-parse", "--show-toplevel"))
+    trunk = await utils.get_trunk()
+    base = await utils.git("merge-base", trunk, "HEAD")
+    commits = get_stack_commits(base)
+
+    if not commits:
+        console.print("No commits in the stack", style="green")
+        return
+
+    target_sha, _, _ = match_commit(commit_prefix, commits)
+    current_shas = [c[0] for c in commits]
+
+    # The rebase action used differs depending on whether -m was provided
+    # (see below); reflect that in the displayed plan.
+    plan_action = "reword" if message is None else "amend"
+    display_action_plan("Reword plan:", commits, {target_sha: plan_action})
+
+    if dry_run:
+        console.print("Dry run — no changes made", style="green")
+        return
+
+    if message is None:
+        # Mark target as `reword`: git stops at that commit and runs
+        # `git commit --amend`, which opens $GIT_EDITOR. Works in a TTY;
+        # hangs in agent contexts. Pass -m to stay non-interactive.
+        run_action_rebase(base, current_shas, {target_sha: "reword"})
+    else:
+        # Keep the target as `pick` and inject `exec git commit --amend
+        # -F <file>` immediately after. The amend runs while HEAD is
+        # the target commit, so prepare-commit-msg re-attaches the
+        # Change-Id. The message is passed via a temp file (not
+        # `-m "..."`) so multi-line messages survive embedding into a
+        # single rebase-todo line.
+        msg_fd, msg_path = tempfile.mkstemp(suffix=".txt", prefix="mergify_reword_msg_")
+        with os.fdopen(msg_fd, "w") as f:
+            f.write(message)
+        # Intentionally NOT in a `finally`: if `run_action_rebase` raises
+        # SystemExit (conflicts), the rebase-todo still references this
+        # file, so `git rebase --continue` will need it to complete the
+        # exec amend. Leak the file rather than break --continue; the
+        # system temp directory is cleaned up by the OS.
+        run_action_rebase(
+            base,
+            current_shas,
+            {},
+            exec_after_sha=target_sha,
+            exec_command=f"git commit --amend -F {shlex.quote(msg_path)}",
+        )
+        pathlib.Path(msg_path).unlink(missing_ok=True)
+
+    console.print("Commit reworded successfully.", style="green")

--- a/mergify_cli/tests/stack/test_reword.py
+++ b/mergify_cli/tests/stack/test_reword.py
@@ -1,0 +1,224 @@
+#
+#  Copyright © 2021-2026 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mergify_cli.exit_codes import ExitCode
+from mergify_cli.stack.reword import stack_reword
+
+
+if TYPE_CHECKING:
+    import pathlib
+
+
+def _run_git(*args: str, cwd: pathlib.Path | None = None) -> str:
+    return subprocess.check_output(
+        ["git", *args],
+        text=True,
+        cwd=cwd,
+    ).strip()
+
+
+def _create_commit(
+    repo: pathlib.Path,
+    filename: str,
+    content: str,
+    message: str,
+) -> tuple[str, str | None]:
+    (repo / filename).write_text(content)
+    _run_git("add", filename, cwd=repo)
+    _run_git("commit", "-m", message, cwd=repo)
+    sha = _run_git("rev-parse", "HEAD", cwd=repo)
+    body = _run_git("log", "-1", "--format=%b", "HEAD", cwd=repo)
+    change_id_match = re.search(r"Change-Id: (I[0-9a-z]{40})", body)
+    return sha, change_id_match.group(1) if change_id_match else None
+
+
+def _get_commit_subjects(repo: pathlib.Path, n: int = 10) -> list[str]:
+    raw = _run_git(
+        "log",
+        "--reverse",
+        f"-{n}",
+        "--format=%s",
+        cwd=repo,
+    )
+    return [line for line in raw.splitlines() if line.strip()]
+
+
+def _setup_tracking(repo: pathlib.Path) -> None:
+    origin_path = repo.parent / f"{repo.name}_origin.git"
+    _run_git("init", "--bare", str(origin_path))
+    _run_git("remote", "add", "origin", str(origin_path), cwd=repo)
+    _run_git("push", "origin", "main", cwd=repo)
+    _run_git("branch", "--set-upstream-to=origin/main", cwd=repo)
+
+
+@pytest.fixture
+def stack_repo(
+    git_repo_with_hooks: pathlib.Path,
+) -> tuple[pathlib.Path, list[tuple[str, str | None]]]:
+    """Create a repo with 3 feature commits (A, B, C) on top of main."""
+    repo = git_repo_with_hooks
+
+    (repo / "init.txt").write_text("init")
+    _run_git("add", "init.txt", cwd=repo)
+    _run_git("commit", "-m", "Initial commit", cwd=repo)
+
+    _setup_tracking(repo)
+
+    _run_git("checkout", "-b", "feature", "main", cwd=repo)
+    _run_git("branch", "--set-upstream-to=origin/main", cwd=repo)
+
+    commits = []
+    for label, filename in [("A", "a.txt"), ("B", "b.txt"), ("C", "c.txt")]:
+        sha, cid = _create_commit(repo, filename, f"content {label}", f"Commit {label}")
+        commits.append((sha, cid))
+
+    return repo, commits
+
+
+class TestStackReword:
+    async def test_reword_middle_commit(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """reword B with -m: B's message changes; A and C untouched."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_b = commits[1][0][:12]
+
+        await stack_reword(sha_b, message="Renamed B", dry_run=False)
+
+        feature = [s for s in _get_commit_subjects(repo) if not s.startswith("Initial")]
+        assert feature == ["Commit A", "Renamed B", "Commit C"]
+
+    async def test_reword_first_commit(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_a = commits[0][0][:12]
+
+        await stack_reword(sha_a, message="Renamed A", dry_run=False)
+
+        feature = [s for s in _get_commit_subjects(repo) if not s.startswith("Initial")]
+        assert feature == ["Renamed A", "Commit B", "Commit C"]
+
+    async def test_reword_last_commit(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_c = commits[2][0][:12]
+
+        await stack_reword(sha_c, message="Renamed C", dry_run=False)
+
+        feature = [s for s in _get_commit_subjects(repo) if not s.startswith("Initial")]
+        assert feature == ["Commit A", "Commit B", "Renamed C"]
+
+    async def test_reword_by_change_id(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        cid_b = commits[1][1]
+        assert cid_b is not None
+
+        await stack_reword(cid_b[:8], message="Via Change-Id", dry_run=False)
+
+        feature = [s for s in _get_commit_subjects(repo) if not s.startswith("Initial")]
+        assert feature == ["Commit A", "Via Change-Id", "Commit C"]
+
+    async def test_reword_multiline_message(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        """Multi-line message is preserved (passed via temp file, not -m)."""
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        sha_b = commits[1][0][:12]
+        new_msg = "Renamed B\n\nThis paragraph explains what B does.\n\nFixes #42"
+
+        await stack_reword(sha_b, message=new_msg, dry_run=False)
+
+        log = _run_git("log", "--format=%H %s", "main..HEAD", cwd=repo)
+        new_sha = next(
+            line.split(" ", 1)[0] for line in log.splitlines() if "Renamed B" in line
+        )
+        body = _run_git("log", "-1", "--format=%B", new_sha, cwd=repo).strip()
+        assert "Renamed B" in body
+        assert "This paragraph explains what B does." in body
+        assert "Fixes #42" in body
+
+    async def test_reword_unknown_prefix_errors(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        repo, _commits = stack_repo
+        os.chdir(repo)
+
+        with pytest.raises(SystemExit) as exc_info:
+            await stack_reword("deadbeef", message="X", dry_run=False)
+        assert exc_info.value.code == ExitCode.STACK_NOT_FOUND
+
+    async def test_reword_dry_run(
+        self,
+        stack_repo: tuple[pathlib.Path, list[tuple[str, str | None]]],
+    ) -> None:
+        repo, commits = stack_repo
+        os.chdir(repo)
+
+        head_before = _run_git("rev-parse", "HEAD", cwd=repo)
+
+        sha_b = commits[1][0][:12]
+        await stack_reword(sha_b, message="X", dry_run=True)
+
+        head_after = _run_git("rev-parse", "HEAD", cwd=repo)
+        assert head_before == head_after
+
+    async def test_reword_empty_stack(
+        self,
+        git_repo_with_hooks: pathlib.Path,
+    ) -> None:
+        repo = git_repo_with_hooks
+
+        (repo / "init.txt").write_text("init")
+        _run_git("add", "init.txt", cwd=repo)
+        _run_git("commit", "-m", "Initial commit", cwd=repo)
+
+        _setup_tracking(repo)
+
+        _run_git("checkout", "-b", "feature", "main", cwd=repo)
+        _run_git("branch", "--set-upstream-to=origin/main", cwd=repo)
+
+        os.chdir(repo)
+
+        # Should return without error — no commits to reword
+        await stack_reword("abc", message="X", dry_run=False)

--- a/skills/mergify-stack/SKILL.md
+++ b/skills/mergify-stack/SKILL.md
@@ -25,6 +25,7 @@ A branch is a stack. Keep stacks short and focused:
 - **Reordering**: Stash any local changes first (`git stash -u`), then use `mergify stack reorder` (list all commits in desired order) or `mergify stack move` (move a single commit) instead of manual `git rebase -i` — non-interactive and avoids `GIT_SEQUENCE_EDITOR` quoting issues
 - **Fixup**: Stash any local changes first (`git stash -u`), then use `mergify stack fixup <SHA>...` to fold a commit into its parent (drops the listed commit's message). Non-interactive — never use `git rebase -i` for this.
 - **Squash**: Stash any local changes first (`git stash -u`), then use `mergify stack squash SRC... into TARGET [-m "msg"]` to combine multiple commits into one, with an optional custom message. Non-interactive — never use `git rebase -i` for this.
+- **Reword**: Stash any local changes first (`git stash -u`), then use `mergify stack reword <SHA> -m "new message"` to change a commit's message in place. Non-interactive when `-m` is given — never use `git rebase -i` for this.
 - **Commit titles**: Follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `docs:`)
 - **PR title & body**: `mergify stack` copies the commit message title to the PR title and the commit message body to the PR body — so write commit messages as if they were PR descriptions. **Everything that should appear in the PR (ticket references, context, test plans) MUST go in the commit message.**
 - **Ticket references**: Include ticket/issue references (e.g., `MRGFY-1234`, `Fixes #123`) in the commit message body, not added separately to the PR.
@@ -43,6 +44,7 @@ A branch is a stack. Keep stacks short and focused:
 | `git commit` on `main` | `mergify stack new <name>` first | `mergify stack push` will fail on the default branch |
 | `git rebase -i` to fixup a commit | `mergify stack fixup <SHA>` | Non-interactive — works inside LLM/agent sessions; no editor spawned |
 | `git rebase -i` to squash commits | `mergify stack squash A B into X [-m "..."]` | Non-interactive — works inside LLM/agent sessions; no editor spawned |
+| `git rebase -i` to change a commit message | `mergify stack reword <SHA> -m "..."` | Non-interactive — works inside LLM/agent sessions; no editor spawned |
 | Deferring lint fixes to a later commit | Include the fix in the commit that caused it | Each commit runs CI independently; later commits won't save earlier ones |
 | Rebase/reorder/checkout/sync with dirty worktree | `git stash -u` first, then `git stash pop` after | Uncommitted changes are lost or cause conflicts during these operations |
 | Amending a pushed commit with no explanation | `mergify stack note -m "why"` before `mergify stack push` | The reason is recorded in the PR's Revision history table and JSON marker, so reviewers don't need to diff to understand the change |
@@ -65,6 +67,8 @@ mergify stack fixup X              # Fold commit X into its parent (drops X's me
 mergify stack fixup X Y Z          # Fold each into its parent (multi-fixup)
 mergify stack squash X into Y      # Reorder X adjacent to Y, fold X into Y (keeps Y's message)
 mergify stack squash X Y into Z -m "msg"  # Fold X Y into Z with a custom message
+mergify stack reword X -m "msg"    # Change commit X's message non-interactively
+mergify stack reword X             # Change commit X's message via $GIT_EDITOR (TTY only)
 mergify stack note -m "why"        # Attach an amend reason to HEAD (shown in PR revision history)
 mergify stack note <SHA-or-Change-Id-prefix> -m "why"  # Attach to a specific commit in the stack
 mergify stack note --append -m "more"                  # Append to an existing note
@@ -129,6 +133,7 @@ git stash -u                # Stash tracked + untracked changes if any
 - `mergify stack reorder` / `mergify stack move`
 - `mergify stack fixup`
 - `mergify stack squash`
+- `mergify stack reword`
 - `mergify stack checkout`
 - `mergify stack sync`
 - `mergify stack new` (switches to new branch)


### PR DESCRIPTION
Add "mergify stack reword COMMIT [-m MESSAGE]" which changes a single
commit's message non-interactively, replacing the manual
"GIT_SEQUENCE_EDITOR='sed -i ... pick → reword' git rebase -i" recipe.

With -m, the rebase keeps COMMIT as `pick` and inserts an `exec git
commit --amend -F <tmpfile>` line right after it — the amend runs while
HEAD still points at the target, so prepare-commit-msg re-attaches the
Change-Id via the existing hook. Multi-line messages are passed via the
temp file rather than `-m "..."`, so they survive embedding into a
single rebase-todo line. Without -m, COMMIT is marked as `reword` so
git stops and opens $GIT_EDITOR for that commit only — convenient in a
TTY, but it will hang in agent contexts (pass -m to stay non-interactive).

Errors when COMMIT prefix is unknown. Supports --dry-run.

Also documents the reword command in skills/mergify-stack/SKILL.md.