### PR TITLE
test(ci): add live smoke test for ci git-refs

### DIFF
--- a/func-tests/test_live_smoke.py
+++ b/func-tests/test_live_smoke.py
@@ -99,6 +99,31 @@ def test_queue_pause_unpause_roundtrip(
     )
 
 
+def test_ci_git_refs_fallback(
+    cli: typing.Callable[..., typing.Any],
+) -> None:
+    """`mergify ci git-refs` falls back to ``HEAD^..HEAD`` when no
+    CI provider env is set.
+
+    Doesn't need ``live_token`` — the command is locally evaluated
+    (no API call). The conftest fixture scrubs every CI/event env
+    var and runs in a tmp dir, so the detector lands on its
+    literal-string fallback path. This is the same smoke test we
+    want to keep working when the command moves from Python to
+    Rust — same contract, both ends of the port.
+    """
+    result = cli("ci", "git-refs")
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    # Pin the exact two-line output. Substring matches would let
+    # added lines or rearrangements slip through silently, which
+    # defeats the "pin the contract" intent. The Python and Rust
+    # implementations both emit precisely this text on the
+    # fallback path.
+    assert result.stdout == "Base: HEAD^\nHead: HEAD\n", (
+        f"output drifted from the pinned format\nstdout:\n{result.stdout!r}"
+    )
+
+
 def test_scopes_send(
     live_token: str,
     cli: typing.Callable[..., typing.Any],


### PR DESCRIPTION
Pins the contract for ``mergify ci git-refs`` so a future Rust
port can be validated against the same test that exercised the
Python implementation. The next commit ports the command; this
one lands first so it runs against Python at its own CI, then
against Rust on rebase — same test, both ends of the port.

The test runs in the existing live-tests harness but doesn't
need the live token: ``ci git-refs`` is locally evaluated (no
API call). The conftest fixture scrubs every CI provider env
var and runs in a tmp dir, so the detector lands on its literal
``HEAD^..HEAD`` fallback path. The assertion checks for ``Base:
HEAD^`` and ``Head: HEAD`` in stdout — output format that the
Python and Rust implementations share verbatim.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>