### PR TITLE
fix(stack): make revision-history compare URL show the actual amendment

### DIFF
--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -679,20 +679,20 @@ async def stack_push(
         console.log("[green]Comments updated.[/]")
 
         if revision_history:
-            # Compute replay SHAs after push_branches has made the new commits
+            # Compute amend SHAs after push_branches has made the new commits
             # (and their parents) reachable on the GitHub server. Doing this
             # before the push would cause the Git Data API uploads to fail for
             # any PR whose parent is another PR in the same stack — those
             # parents only exist server-side once we've pushed.
-            replay_sem = asyncio.Semaphore(MAX_CONCURRENT_API_CALLS)
+            amend_sem = asyncio.Semaphore(MAX_CONCURRENT_API_CALLS)
 
-            async def _maybe_replay(
+            async def _maybe_amend(
                 change: changes.LocalChange,
             ) -> tuple[str, str | None]:
                 if change_types.get(change.id) != "content":
                     return change.id, None
                 try:
-                    async with replay_sem:
+                    async with amend_sem:
                         sha = await replay.replay_for_revision(
                             client=client,
                             user=user,
@@ -717,20 +717,20 @@ async def stack_push(
                     )
                 return change.id, sha
 
-            replay_results = await asyncio.gather(
+            amend_results = await asyncio.gather(
                 *(
-                    _maybe_replay(task.change)
+                    _maybe_amend(task.change)
                     for task in tasks
                     if task.change.action == "update" and task.change.pull is not None
                 ),
             )
-            replay_shas: dict[str, str | None] = dict(replay_results)
+            amend_shas: dict[str, str | None] = dict(amend_results)
 
             updated_changes = [
                 (
                     task.change,
                     change_types.get(task.change.id, "unknown"),
-                    replay_shas.get(task.change.id),
+                    amend_shas.get(task.change.id),
                 )
                 for task in tasks
                 if task.change.action == "update" and task.change.pull is not None
@@ -850,7 +850,13 @@ class _RevisionEntry:
     new_sha: str
     timestamp: datetime.datetime | None
     reason: str = ""
-    replay_sha: str | None = None
+    # Synthetic commit whose parent is old_sha and whose tree is new_sha's
+    # content re-applied onto parent(old_sha). Paired with old_sha in a
+    # `compare/old_sha...amend_sha` URL it renders the rebase-aware
+    # amendment — i.e. what the user actually changed, with rebase noise
+    # filtered out. None when the synth commit could not be produced
+    # (conflict, API error, or no-op).
+    amend_sha: str | None = None
 
     @property
     def timestamp_human(self) -> str:
@@ -863,24 +869,6 @@ class _RevisionEntry:
         if self.timestamp is None:
             return None
         return self.timestamp.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    @property
-    def effective_old_sha(self) -> str:
-        """SHA to use as the 'from' anchor in compare URLs.
-
-        Prefers replay_sha when present (rebase-aware diff anchored at
-        the synthetic replay commit); falls back to old_sha otherwise.
-
-        Initial entries have old_sha=None and never get a compare URL,
-        so callers must guard with an old_sha-not-None check; this
-        property asserts the invariant rather than returning None and
-        forcing every caller to cast.
-        """
-        sha = self.replay_sha or self.old_sha
-        if sha is None:
-            msg = "effective_old_sha called on initial entry (old_sha=None)"
-            raise AssertionError(msg)
-        return sha
 
 
 @dataclasses.dataclass
@@ -919,7 +907,7 @@ class RevisionHistoryComment:
         change_type: ChangeType,
         timestamp: datetime.datetime,
         reason: str = "",
-        replay_sha: str | None = None,
+        amend_sha: str | None = None,
     ) -> RevisionHistoryComment:
         entries = [
             _RevisionEntry(1, "initial", None, old_sha, timestamp),
@@ -930,7 +918,7 @@ class RevisionHistoryComment:
                 new_sha,
                 timestamp,
                 reason=reason,
-                replay_sha=replay_sha,
+                amend_sha=amend_sha,
             ),
         ]
         return cls(
@@ -948,7 +936,7 @@ class RevisionHistoryComment:
         change_type: ChangeType,
         timestamp: datetime.datetime,
         reason: str = "",
-        replay_sha: str | None = None,
+        amend_sha: str | None = None,
     ) -> None:
         next_number = len(self.entries) + 1
         self.entries.append(
@@ -959,9 +947,24 @@ class RevisionHistoryComment:
                 new_sha,
                 timestamp,
                 reason=reason,
-                replay_sha=replay_sha,
+                amend_sha=amend_sha,
             ),
         )
+
+    def _entry_compare_url(self, entry: _RevisionEntry) -> str:
+        """Compare URL anchored at old_sha \u2192 amend_sha (rebase-aware) when
+        the synth commit is available, else old_sha \u2192 new_sha (raw).
+
+        GitHub's compare URL semantics use merge-base(A, B) \u2192 B for both
+        `..` and `...` (they're normalised the same). The amend_sha is a
+        descendant of old_sha, so merge-base = old_sha and the page
+        renders exactly old_sha \u2192 amend_sha = the user's amendment.
+        """
+        if entry.old_sha is None:
+            msg = "_entry_compare_url called on initial entry (old_sha=None)"
+            raise AssertionError(msg)
+        head_sha = entry.amend_sha if entry.amend_sha is not None else entry.new_sha
+        return self._compare_url(entry.old_sha, head_sha)
 
     def _render_entry(self, entry: _RevisionEntry) -> str:
         if entry.old_sha is None:
@@ -972,11 +975,13 @@ class RevisionHistoryComment:
                 f"`{entry.old_sha[:7]} \u2192 {entry.new_sha[:7]}` _(rebase only)_"
             )
         else:
-            url = self._compare_url(entry.effective_old_sha, entry.new_sha)
+            url = self._entry_compare_url(entry)
             changes_cell = f"[`{entry.old_sha[:7]} \u2192 {entry.new_sha[:7]}`]({url})"
-            if entry.replay_sha is not None:
-                # Synthetic replay commits get GC'd by GitHub eventually; keep
-                # a durable raw-diff link for the long tail.
+            if entry.amend_sha is not None:
+                # Synthetic amend commits get GC'd by GitHub eventually; keep
+                # a durable raw-diff link (always-resolvable PR-head SHAs) for
+                # the long tail. Its diff includes any rebase noise, which is
+                # the price of durability.
                 raw_url = self._compare_url(entry.old_sha, entry.new_sha)
                 changes_cell = f"{changes_cell} ([raw]({raw_url}))"
         reason_cell = _escape_reason(entry.reason)
@@ -987,7 +992,7 @@ class RevisionHistoryComment:
 
     def _json_marker(self, pull_number: int) -> str:
         payload = {
-            "schema_version": 1,
+            "schema_version": 2,
             "pull_number": pull_number,
             "entries": [
                 {
@@ -997,14 +1002,9 @@ class RevisionHistoryComment:
                     "new_sha": e.new_sha,
                     "timestamp_iso": e.timestamp_iso,
                     "reason": e.reason,
-                    "replay_sha": e.replay_sha,
+                    "amend_sha": e.amend_sha,
                     "compare_url": (
-                        None
-                        if e.old_sha is None
-                        else self._compare_url(
-                            e.effective_old_sha,
-                            e.new_sha,
-                        )
+                        None if e.old_sha is None else self._entry_compare_url(e)
                     ),
                 }
                 for e in self.entries
@@ -1101,7 +1101,7 @@ class RevisionHistoryComment:
                     continue
                 if (
                     isinstance(payload, dict)
-                    and payload.get("schema_version") == 1
+                    and payload.get("schema_version") in {1, 2}
                     and isinstance(payload.get("entries"), list)
                 ):
                     marker_entries = payload["entries"]
@@ -1135,9 +1135,13 @@ class RevisionHistoryComment:
                 reason = data.get("reason")
                 if isinstance(reason, str):
                     entry.reason = reason
-                replay_sha = data.get("replay_sha")
-                if isinstance(replay_sha, str) or replay_sha is None:
-                    entry.replay_sha = replay_sha
+                # schema v2 uses amend_sha; v1 used replay_sha with different
+                # semantics (sibling on new base) so we don't migrate the
+                # value — the rendered row is preserved verbatim via
+                # _raw_rows, so old comments keep their original URL.
+                amend_sha = data.get("amend_sha")
+                if isinstance(amend_sha, str) or amend_sha is None:
+                    entry.amend_sha = amend_sha
 
         return cls(
             github_server=github_server,
@@ -1219,7 +1223,7 @@ async def _update_revision_for_pull(
     change: changes.LocalChange,
     change_type: ChangeType,
     *,
-    replay_sha: str | None,
+    amend_sha: str | None,
     timestamp: datetime.datetime,
     sem: asyncio.Semaphore,
 ) -> None:
@@ -1247,7 +1251,7 @@ async def _update_revision_for_pull(
             change_type=change_type,
             timestamp=timestamp,
             reason=change.reason,
-            replay_sha=replay_sha,
+            amend_sha=amend_sha,
         )
 
         for comment in comments:
@@ -1265,7 +1269,7 @@ async def _update_revision_for_pull(
                         change_type=change_type,
                         timestamp=timestamp,
                         reason=change.reason,
-                        replay_sha=replay_sha,
+                        amend_sha=amend_sha,
                     )
                     new_body = parsed.body(pull_number)
                     if comment["body"] != new_body:
@@ -1310,11 +1314,11 @@ async def create_or_update_revision_comments(
                 github_server,
                 change,
                 change_type,
-                replay_sha=replay_sha,
+                amend_sha=amend_sha,
                 timestamp=now,
                 sem=sem,
             )
-            for change, change_type, replay_sha in updated_changes
+            for change, change_type, amend_sha in updated_changes
         ),
     )
 

--- a/mergify_cli/stack/replay.py
+++ b/mergify_cli/stack/replay.py
@@ -27,7 +27,7 @@ from mergify_cli import utils
 @dataclasses.dataclass(frozen=True)
 class MergedTree:
     tree_sha: str
-    parent_new_sha: str
+    parent_old_sha: str
 
 
 async def compute_merged_tree(
@@ -35,7 +35,13 @@ async def compute_merged_tree(
     old_sha: str,
     new_sha: str,
 ) -> MergedTree | None:
-    """Compute the tree of `old_sha` replayed onto `parent(new_sha)`.
+    """Compute the tree of `new_sha` replayed onto `parent(old_sha)`.
+
+    The result is the user's amendment isolated from any rebase noise:
+    parent_old_sha + (parent_new_sha → new_sha diff). Pairing this tree
+    with `old_sha` as the commit's parent produces a commit whose diff
+    against `old_sha` is exactly the amendment — which is what we want
+    in the revision-history compare URL.
 
     Returns None on conflict, missing parents, or any git error.
     Requires git >= 2.38 for `git merge-tree --write-tree`.
@@ -52,9 +58,9 @@ async def compute_merged_tree(
         output = await utils.git(
             "merge-tree",
             "--write-tree",
-            f"--merge-base={parent_old_sha}",
-            parent_new_sha,
-            old_sha,
+            f"--merge-base={parent_new_sha}",
+            parent_old_sha,
+            new_sha,
         )
     except utils.CommandError:
         # Non-zero exit = conflict (or older git that doesn't support flags).
@@ -65,7 +71,7 @@ async def compute_merged_tree(
     if not lines:
         return None
 
-    return MergedTree(tree_sha=lines[0], parent_new_sha=parent_new_sha)
+    return MergedTree(tree_sha=lines[0], parent_old_sha=parent_old_sha)
 
 
 def _mode_to_type(mode: str) -> str:
@@ -141,16 +147,21 @@ async def upload_replay_commit(
     user: str,
     repo: str,
     base_tree_sha: str,
-    parent_new_sha: str,
     old_sha: str,
+    new_sha: str,
     entries: list[dict[str, str | None]],
 ) -> str | None:
     """Materialise a synthetic commit on the GitHub server, no ref attached.
 
-    Posts the tree delta with `base_tree=parent_new_tree_sha`, then a commit
-    with `parents=[parent_new_sha]`. Returns the commit SHA on success or
-    None on any API error. The unreferenced object will be GC'd by GitHub
-    eventually; the compare URL works in the meantime.
+    Posts the tree delta with `base_tree=parent_old_tree_sha`, then a commit
+    with `parents=[old_sha]`. The synthetic commit's parent is the previous
+    PR head, so GitHub's `compare/old_sha...amend_sha` URL uses old_sha as
+    merge-base and renders exactly the amendment — without the rebase noise
+    that a sibling-on-new-base would have surfaced.
+
+    Returns the commit SHA on success or None on any API error. The
+    unreferenced object will be GC'd by GitHub eventually; the compare URL
+    works in the meantime.
     """
     tree_payload: dict[str, typing.Any] = {
         "base_tree": base_tree_sha,
@@ -170,10 +181,10 @@ async def upload_replay_commit(
             f"/repos/{user}/{repo}/git/commits",
             json={
                 "message": (
-                    f"mergify-cli: replay {old_sha[:7]} on {parent_new_sha[:7]}"
+                    f"mergify-cli: replay {new_sha[:7]} on {old_sha[:7]}"
                 ),
                 "tree": new_tree_sha,
-                "parents": [parent_new_sha],
+                "parents": [old_sha],
             },
         )
         commit_resp.raise_for_status()
@@ -206,15 +217,15 @@ async def replay_for_revision(
 
     try:
         # ^{tree} dereferences a commit SHA to its root tree SHA (git plumbing syntax).
-        parent_new_tree_sha = await utils.git(
+        parent_old_tree_sha = await utils.git(
             "rev-parse",
-            f"{merged.parent_new_sha}^{{tree}}",
+            f"{merged.parent_old_sha}^{{tree}}",
         )
     except utils.CommandError:
         return None
 
     entries = await compute_tree_delta(
-        base_tree_sha=parent_new_tree_sha,
+        base_tree_sha=parent_old_tree_sha,
         merged_tree_sha=merged.tree_sha,
     )
     if not entries:
@@ -226,8 +237,8 @@ async def replay_for_revision(
         client=client,
         user=user,
         repo=repo,
-        base_tree_sha=parent_new_tree_sha,
-        parent_new_sha=merged.parent_new_sha,
+        base_tree_sha=parent_old_tree_sha,
         old_sha=old_sha,
+        new_sha=new_sha,
         entries=entries,
     )

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -1205,7 +1205,7 @@ def test_revision_history_body_contains_json_marker() -> None:
     payload = json.loads(payload_str)
 
     assert payload == {
-        "schema_version": 1,
+        "schema_version": 2,
         "pull_number": 42,
         "entries": [
             {
@@ -1215,7 +1215,7 @@ def test_revision_history_body_contains_json_marker() -> None:
                 "new_sha": "abc1234567890abcdef1234567890abcdef123456",
                 "timestamp_iso": "2026-04-14T14:30:00Z",
                 "reason": "",
-                "replay_sha": None,
+                "amend_sha": None,
                 "compare_url": None,
             },
             {
@@ -1225,7 +1225,7 @@ def test_revision_history_body_contains_json_marker() -> None:
                 "new_sha": "def5678901234567890abcdef1234567890abcdef",
                 "timestamp_iso": "2026-04-14T14:30:00Z",
                 "reason": "",
-                "replay_sha": None,
+                "amend_sha": None,
                 "compare_url": (
                     "https://github.com/owner/repo/compare/"
                     "abc1234567890abcdef1234567890abcdef123456..."
@@ -1256,8 +1256,8 @@ def test_revision_history_body_json_marker_is_single_line_compact() -> None:
     assert '": ' not in marker_line
 
 
-def test_revision_history_comment_replay_sha_round_trip() -> None:
-    """replay_sha is preserved across body() and parse()."""
+def test_revision_history_comment_amend_sha_round_trip() -> None:
+    """amend_sha is preserved across body() and parse()."""
     original = push.RevisionHistoryComment.create_initial(
         github_server="https://api.github.com",
         user="owner",
@@ -1266,7 +1266,7 @@ def test_revision_history_comment_replay_sha_round_trip() -> None:
         new_sha="def5678901234567890abcdef1234567890abcdef",
         change_type="content",
         timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
-        replay_sha="111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1",
+        amend_sha="111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1",
     )
     body = original.body(pull_number=1)
     parsed = push.RevisionHistoryComment.parse(
@@ -1276,9 +1276,9 @@ def test_revision_history_comment_replay_sha_round_trip() -> None:
         repo="repo",
     )
     assert parsed is not None
-    # entry 1 is "initial" (no replay), entry 2 has replay_sha
-    assert parsed.entries[1].replay_sha == "111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1"
-    assert parsed.entries[0].replay_sha is None
+    # entry 1 is "initial" (no amend), entry 2 has amend_sha
+    assert parsed.entries[1].amend_sha == "111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1"
+    assert parsed.entries[0].amend_sha is None
 
 
 @pytest.mark.respx(base_url="https://api.github.com/")
@@ -1388,12 +1388,13 @@ async def test_create_revision_comment_on_update(
 
 
 @pytest.mark.respx(base_url="https://api.github.com/")
-async def test_create_revision_comment_with_replay_sha_renders_dual_link(
+async def test_create_revision_comment_with_amend_sha_renders_dual_link(
     git_mock: test_utils.GitMock,
     respx_mock: respx.MockRouter,
 ) -> None:
-    """When replay_for_revision returns a SHA, the rendered comment uses it as
-    the primary URL anchor and appends a (raw) fallback link to old_sha."""
+    """When replay_for_revision returns a SHA, the rendered comment points
+    `old_sha...amend_sha` (rebase-aware) for the primary link and falls back
+    to `old_sha...new_sha` for the durable (raw) link."""
     git_mock.commit(
         test_utils.Commit(
             sha="new_commit_sha",
@@ -1461,7 +1462,7 @@ async def test_create_revision_comment_with_replay_sha_renders_dual_link(
         mock.patch.object(
             replay,
             "replay_for_revision",
-            return_value="replayshaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+            return_value="amendshaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
         ),
     ):
         await push.stack_push(
@@ -1483,14 +1484,15 @@ async def test_create_revision_comment_with_replay_sha_renders_dual_link(
     ]
     assert len(revision_calls) == 1
     posted_body = json.loads(revision_calls[0].request.content)["body"]
-    # Primary link is anchored at the replay SHA
+    # Primary link anchors at old_sha and heads at the amend SHA.
     assert (
-        "/compare/replayshaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX...new_commit_sha"
+        "/compare/old_commit_sha...amendshaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
         in posted_body
     )
-    # Raw fallback link is anchored at the original old SHA
+    # Raw fallback link uses the durable old_sha → new_sha pair.
     assert (
-        "([raw](https://github.com/user/repo/compare/old_commit_sha..." in posted_body
+        "([raw](https://github.com/user/repo/compare/old_commit_sha...new_commit_sha)"
+        in posted_body
     )
 
 
@@ -1583,7 +1585,7 @@ async def test_stack_push_survives_replay_for_revision_raising(
         )
 
     # The revision comment was still posted, falling back to the standard URL
-    # anchored at old_commit_sha (no replay_sha present).
+    # anchored at old_commit_sha (no amend_sha present).
     revision_calls = [
         call
         for call in post_revision_mock.calls
@@ -1594,7 +1596,7 @@ async def test_stack_push_survives_replay_for_revision_raising(
     assert len(revision_calls) == 1
     posted_body = json.loads(revision_calls[0].request.content)["body"]
     assert "/compare/old_commit_sha...new_commit_sha" in posted_body
-    # No raw fallback link since no replay_sha was produced.
+    # No raw fallback link since no amend_sha was produced.
     assert "[raw]" not in posted_body
 
 
@@ -2974,8 +2976,9 @@ def test_revision_history_renders_badge_for_pure_rebase() -> None:
     assert "`abc1234 → def5678`" in rebase_line
 
 
-def test_revision_history_uses_replay_sha_for_url_when_present() -> None:
-    """When replay_sha is set, primary URL anchors at it; raw link uses old_sha."""
+def test_revision_history_uses_amend_sha_for_url_when_present() -> None:
+    """When amend_sha is set, primary URL is old_sha→amend_sha; raw link
+    falls back to old_sha→new_sha for durability after GitHub GC."""
     comment = push.RevisionHistoryComment.create_initial(
         github_server="https://api.github.com",
         user="owner",
@@ -2984,29 +2987,31 @@ def test_revision_history_uses_replay_sha_for_url_when_present() -> None:
         new_sha="bbb5678901234567890abcdef1234567890abcdef",
         change_type="content",
         timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
-        replay_sha="ccc9999999999999999999999999999999999999",
+        amend_sha="ccc9999999999999999999999999999999999999",
     )
     body = comment.body(pull_number=1)
     row = next(line for line in body.splitlines() if "| 2 | content |" in line)
     rebase_aware_url = (
         "https://github.com/owner/repo/compare/"
-        "ccc9999999999999999999999999999999999999"
-        "...bbb5678901234567890abcdef1234567890abcdef"
+        "aaa1234567890abcdef1234567890abcdef123456"
+        "...ccc9999999999999999999999999999999999999"
     )
     raw_url = (
         "https://github.com/owner/repo/compare/"
         "aaa1234567890abcdef1234567890abcdef123456"
         "...bbb5678901234567890abcdef1234567890abcdef"
     )
-    # Primary clickable label uses the human-readable SHAs and points at the
-    # rebase-aware URL (the synthetic replay commit).
+    # Primary clickable label keeps the human-readable old→new SHAs; the
+    # link targets the rebase-aware compare (old_sha to the synth amend
+    # commit), which renders just the user's amendment.
     assert f"[`aaa1234 → bbb5678`]({rebase_aware_url})" in row
-    # Raw link is appended for durability after GitHub GCs the synthetic commit.
+    # Raw link uses the durable old_sha → new_sha pair so the long tail
+    # still has a working URL after GitHub GCs the synthetic commit.
     assert f"([raw]({raw_url}))" in row
 
 
-def test_revision_history_uses_old_sha_for_url_when_replay_sha_absent() -> None:
-    """When replay_sha is absent, single link anchors at old_sha; no raw link."""
+def test_revision_history_uses_old_sha_for_url_when_amend_sha_absent() -> None:
+    """When amend_sha is absent, single link anchors at old_sha; no raw link."""
     comment = push.RevisionHistoryComment.create_initial(
         github_server="https://api.github.com",
         user="owner",
@@ -3015,7 +3020,7 @@ def test_revision_history_uses_old_sha_for_url_when_replay_sha_absent() -> None:
         new_sha="bbb5678901234567890abcdef1234567890abcdef",
         change_type="content",
         timestamp=datetime.datetime(2026, 4, 14, 14, 30, tzinfo=datetime.UTC),
-        # replay_sha omitted
+        # amend_sha omitted
     )
     body = comment.body(pull_number=1)
     row = next(line for line in body.splitlines() if "| 2 | content |" in line)
@@ -3023,15 +3028,15 @@ def test_revision_history_uses_old_sha_for_url_when_replay_sha_absent() -> None:
         "/compare/aaa1234567890abcdef1234567890abcdef123456"
         "...bbb5678901234567890abcdef1234567890abcdef" in row
     )
-    # No replay → no raw fallback link
+    # No amend → no raw fallback link
     assert "[raw]" not in row
 
 
 @pytest.mark.respx(base_url="https://api.github.com")
-async def test_create_or_update_revision_comments_passes_replay_sha(
+async def test_create_or_update_revision_comments_passes_amend_sha(
     respx_mock: respx.MockRouter,
 ) -> None:
-    """The replay_sha from change_types tuple lands in the rendered comment."""
+    """The amend_sha from change_types tuple lands in the rendered comment."""
     import httpx
 
     pull = {"number": 42, "merged_at": None, "head": {"sha": "newsha"}, "url": "u"}
@@ -3055,9 +3060,11 @@ async def test_create_or_update_revision_comments_passes_replay_sha(
             "owner",
             "repo",
             "https://api.github.com",
-            [(change, "content", "replayshaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")],
+            [(change, "content", "amendshaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")],
         )
 
     assert create_route.called
     body = create_route.calls.last.request.read()
-    assert b"replayshaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX...newshaaaaaaaa" in body
+    # Primary link: old_sha → amend_sha (rebase-aware).
+    assert b"oldshaaaaaaaa" in body
+    assert b"...amendshaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" in body

--- a/mergify_cli/tests/stack/test_replay.py
+++ b/mergify_cli/tests/stack/test_replay.py
@@ -29,15 +29,15 @@ if typing.TYPE_CHECKING:
 
 
 async def test_compute_merged_tree_clean(git_mock: test_utils.GitMock) -> None:
-    """Clean merge returns the merged tree SHA."""
+    """Clean merge returns the merged tree SHA: new_sha replayed onto parent_old_sha."""
     git_mock.mock("rev-parse", "old_sha^", output="parent_old_sha")
     git_mock.mock("rev-parse", "new_sha^", output="parent_new_sha")
     git_mock.mock(
         "merge-tree",
         "--write-tree",
-        "--merge-base=parent_old_sha",
-        "parent_new_sha",
-        "old_sha",
+        "--merge-base=parent_new_sha",
+        "parent_old_sha",
+        "new_sha",
         output="merged_tree_sha",
     )
 
@@ -45,7 +45,7 @@ async def test_compute_merged_tree_clean(git_mock: test_utils.GitMock) -> None:
 
     assert result == replay.MergedTree(
         tree_sha="merged_tree_sha",
-        parent_new_sha="parent_new_sha",
+        parent_old_sha="parent_old_sha",
     )
 
 
@@ -58,9 +58,9 @@ async def test_compute_merged_tree_conflict_returns_none(
     git_mock.mock_error(
         "merge-tree",
         "--write-tree",
-        "--merge-base=parent_old_sha",
-        "parent_new_sha",
-        "old_sha",
+        "--merge-base=parent_new_sha",
+        "parent_old_sha",
+        "new_sha",
     )
 
     result = await replay.compute_merged_tree(old_sha="old_sha", new_sha="new_sha")
@@ -150,23 +150,25 @@ async def test_upload_replay_commit_posts_tree_then_commit() -> None:
             client=client,
             user="owner",
             repo="repo",
-            base_tree_sha="parent_new_tree_sha",
-            parent_new_sha="parent_new_sha",
+            base_tree_sha="parent_old_tree_sha",
             old_sha="abc1234",
+            new_sha="def5678",
             entries=entries,
         )
 
     assert sha == "new_commit_server_sha"
     assert tree_route.called
     tree_body = json.loads(tree_route.calls.last.request.read())
-    assert tree_body["base_tree"] == "parent_new_tree_sha"
+    assert tree_body["base_tree"] == "parent_old_tree_sha"
     assert tree_body["tree"] == [
         {"path": "src/a.py", "mode": "100644", "type": "blob", "sha": "bbb2222"},
     ]
     assert commit_route.called
     commit_body = json.loads(commit_route.calls.last.request.read())
     assert commit_body["tree"] == "new_tree_server_sha"
-    assert commit_body["parents"] == ["parent_new_sha"]
+    # Synth commit must be a CHILD of old_sha so that compare/old_sha...amend_sha
+    # uses old_sha as merge-base and renders the actual amendment.
+    assert commit_body["parents"] == ["abc1234"]
 
 
 @respx.mock
@@ -182,9 +184,9 @@ async def test_upload_replay_commit_returns_none_on_api_error() -> None:
             client=client,
             user="owner",
             repo="repo",
-            base_tree_sha="parent_new_tree_sha",
-            parent_new_sha="parent_new_sha",
+            base_tree_sha="parent_old_tree_sha",
             old_sha="abc1234",
+            new_sha="def5678",
             entries=[],
         )
 
@@ -207,9 +209,9 @@ async def test_upload_replay_commit_returns_none_on_commit_post_failure() -> Non
             client=client,
             user="owner",
             repo="repo",
-            base_tree_sha="parent_new_tree_sha",
-            parent_new_sha="parent_new_sha",
+            base_tree_sha="parent_old_tree_sha",
             old_sha="abc1234",
+            new_sha="def5678",
             entries=[],
         )
 
@@ -231,18 +233,18 @@ async def test_replay_for_revision_happy_path(git_mock: test_utils.GitMock) -> N
     git_mock.mock(
         "merge-tree",
         "--write-tree",
-        "--merge-base=parent_old_sha",
-        "parent_new_sha",
-        "old_sha",
+        "--merge-base=parent_new_sha",
+        "parent_old_sha",
+        "new_sha",
         output="merged_tree_sha",
     )
-    git_mock.mock("rev-parse", "parent_new_sha^{tree}", output="parent_new_tree_sha")
+    git_mock.mock("rev-parse", "parent_old_sha^{tree}", output="parent_old_tree_sha")
     git_mock.mock(
         "diff-tree",
         "-r",
         "--raw",
         "--no-renames",
-        "parent_new_tree_sha",
+        "parent_old_tree_sha",
         "merged_tree_sha",
         output=":100644 100644 aaa bbb M\tsrc/x.py\n",
     )
@@ -269,9 +271,9 @@ async def test_replay_for_revision_conflict_returns_none(
     git_mock.mock_error(
         "merge-tree",
         "--write-tree",
-        "--merge-base=parent_old_sha",
-        "parent_new_sha",
-        "old_sha",
+        "--merge-base=parent_new_sha",
+        "parent_old_sha",
+        "new_sha",
     )
 
     async with httpx.AsyncClient(base_url="https://api.github.com") as client:
@@ -290,24 +292,24 @@ async def test_replay_for_revision_conflict_returns_none(
 async def test_replay_for_revision_no_diff_returns_none(
     git_mock: test_utils.GitMock,
 ) -> None:
-    """If merged tree equals parent_new's tree, there's nothing to upload."""
+    """If merged tree equals parent_old's tree, there's nothing to upload."""
     git_mock.mock("rev-parse", "old_sha^", output="parent_old_sha")
     git_mock.mock("rev-parse", "new_sha^", output="parent_new_sha")
     git_mock.mock(
         "merge-tree",
         "--write-tree",
-        "--merge-base=parent_old_sha",
-        "parent_new_sha",
-        "old_sha",
+        "--merge-base=parent_new_sha",
+        "parent_old_sha",
+        "new_sha",
         output="merged_tree_sha",
     )
-    git_mock.mock("rev-parse", "parent_new_sha^{tree}", output="parent_new_tree_sha")
+    git_mock.mock("rev-parse", "parent_old_sha^{tree}", output="parent_old_tree_sha")
     git_mock.mock(
         "diff-tree",
         "-r",
         "--raw",
         "--no-renames",
-        "parent_new_tree_sha",
+        "parent_old_tree_sha",
         "merged_tree_sha",
         output="",
     )
@@ -334,12 +336,12 @@ async def test_replay_for_revision_rev_parse_tree_error_returns_none(
     git_mock.mock(
         "merge-tree",
         "--write-tree",
-        "--merge-base=parent_old_sha",
-        "parent_new_sha",
-        "old_sha",
+        "--merge-base=parent_new_sha",
+        "parent_old_sha",
+        "new_sha",
         output="merged_tree_sha",
     )
-    git_mock.mock_error("rev-parse", "parent_new_sha^{tree}")
+    git_mock.mock_error("rev-parse", "parent_old_sha^{tree}")
 
     async with httpx.AsyncClient(base_url="https://api.github.com") as client:
         sha = await replay.replay_for_revision(


### PR DESCRIPTION
The "rebase-aware compare" link used `compare/replay_sha...new_sha` where
`replay_sha` was a sibling of `new_sha` on the same parent. GitHub's
compare URL semantics — `..` and `...` are normalised to the same
merge-base(A,B)→B view — meant the page always rendered the full PR
diff against their shared parent, not the user's amendment.

Build the synth commit as a child of `old_sha` instead, with `new_sha`'s
content re-applied onto `parent(old_sha)`. Then merge-base = old_sha and
`compare/old_sha...amend_sha` renders exactly the amendment.

Renames `replay_sha` → `amend_sha` across push/replay and bumps the
revision-data JSON marker to schema_version=2. The parser still accepts
v1 markers (rendered rows are preserved verbatim via _raw_rows, so old
comments keep their original URL).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>