### PR TITLE
fix(stack): make revision-history compare URL show the actual amendment

### DIFF
--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -850,6 +850,12 @@ class _RevisionEntry:
     new_sha: str
     timestamp: datetime.datetime | None
     reason: str = ""
+    # Synthetic commit produced by replay_for_revision. Its parent is
+    # old_sha and its tree is new_sha's content re-applied onto
+    # parent(old_sha) — so `compare/old_sha...replay_sha` uses old_sha
+    # as merge-base and renders just the user's amendment (rebase noise
+    # excluded). None when the synth commit could not be produced
+    # (conflict, API error, or no-op).
     replay_sha: str | None = None
 
     @property
@@ -863,24 +869,6 @@ class _RevisionEntry:
         if self.timestamp is None:
             return None
         return self.timestamp.astimezone(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    @property
-    def effective_old_sha(self) -> str:
-        """SHA to use as the 'from' anchor in compare URLs.
-
-        Prefers replay_sha when present (rebase-aware diff anchored at
-        the synthetic replay commit); falls back to old_sha otherwise.
-
-        Initial entries have old_sha=None and never get a compare URL,
-        so callers must guard with an old_sha-not-None check; this
-        property asserts the invariant rather than returning None and
-        forcing every caller to cast.
-        """
-        sha = self.replay_sha or self.old_sha
-        if sha is None:
-            msg = "effective_old_sha called on initial entry (old_sha=None)"
-            raise AssertionError(msg)
-        return sha
 
 
 @dataclasses.dataclass
@@ -963,6 +951,19 @@ class RevisionHistoryComment:
             ),
         )
 
+    def _entry_head_sha(self, entry: _RevisionEntry) -> str:
+        """SHA to use as the 'to' anchor in compare URLs.
+
+        Prefers replay_sha when present: it's a synth child of old_sha
+        holding new_sha's tree re-applied onto parent(old_sha), so
+        compare/old_sha...replay_sha renders just the amendment (the
+        merge-base GitHub picks for the compare page is old_sha itself).
+
+        Falls back to new_sha otherwise — the resulting URL still uses
+        old_sha as base; the diff just includes any rebase noise.
+        """
+        return entry.replay_sha if entry.replay_sha is not None else entry.new_sha
+
     def _render_entry(self, entry: _RevisionEntry) -> str:
         if entry.old_sha is None:
             changes_cell = f"`{entry.new_sha[:7]}`"
@@ -972,11 +973,13 @@ class RevisionHistoryComment:
                 f"`{entry.old_sha[:7]} \u2192 {entry.new_sha[:7]}` _(rebase only)_"
             )
         else:
-            url = self._compare_url(entry.effective_old_sha, entry.new_sha)
+            url = self._compare_url(entry.old_sha, self._entry_head_sha(entry))
             changes_cell = f"[`{entry.old_sha[:7]} \u2192 {entry.new_sha[:7]}`]({url})"
             if entry.replay_sha is not None:
                 # Synthetic replay commits get GC'd by GitHub eventually; keep
-                # a durable raw-diff link for the long tail.
+                # a durable raw-diff link (always-resolvable PR-head SHAs) for
+                # the long tail. Its diff includes any rebase noise, which is
+                # the price of durability.
                 raw_url = self._compare_url(entry.old_sha, entry.new_sha)
                 changes_cell = f"{changes_cell} ([raw]({raw_url}))"
         reason_cell = _escape_reason(entry.reason)
@@ -1002,8 +1005,8 @@ class RevisionHistoryComment:
                         None
                         if e.old_sha is None
                         else self._compare_url(
-                            e.effective_old_sha,
-                            e.new_sha,
+                            e.old_sha,
+                            self._entry_head_sha(e),
                         )
                     ),
                 }

--- a/mergify_cli/stack/replay.py
+++ b/mergify_cli/stack/replay.py
@@ -27,7 +27,7 @@ from mergify_cli import utils
 @dataclasses.dataclass(frozen=True)
 class MergedTree:
     tree_sha: str
-    parent_new_sha: str
+    parent_old_sha: str
 
 
 async def compute_merged_tree(
@@ -35,7 +35,13 @@ async def compute_merged_tree(
     old_sha: str,
     new_sha: str,
 ) -> MergedTree | None:
-    """Compute the tree of `old_sha` replayed onto `parent(new_sha)`.
+    """Compute the tree of `new_sha` replayed onto `parent(old_sha)`.
+
+    The result is the user's amendment isolated from any rebase noise:
+    parent_old_sha + (parent_new_sha → new_sha diff). Pairing this tree
+    with `old_sha` as the commit's parent produces a commit whose diff
+    against `old_sha` is exactly the amendment — which is what we want
+    in the revision-history compare URL.
 
     Returns None on conflict, missing parents, or any git error.
     Requires git >= 2.38 for `git merge-tree --write-tree`.
@@ -52,9 +58,9 @@ async def compute_merged_tree(
         output = await utils.git(
             "merge-tree",
             "--write-tree",
-            f"--merge-base={parent_old_sha}",
-            parent_new_sha,
-            old_sha,
+            f"--merge-base={parent_new_sha}",
+            parent_old_sha,
+            new_sha,
         )
     except utils.CommandError:
         # Non-zero exit = conflict (or older git that doesn't support flags).
@@ -65,7 +71,7 @@ async def compute_merged_tree(
     if not lines:
         return None
 
-    return MergedTree(tree_sha=lines[0], parent_new_sha=parent_new_sha)
+    return MergedTree(tree_sha=lines[0], parent_old_sha=parent_old_sha)
 
 
 def _mode_to_type(mode: str) -> str:
@@ -141,16 +147,21 @@ async def upload_replay_commit(
     user: str,
     repo: str,
     base_tree_sha: str,
-    parent_new_sha: str,
     old_sha: str,
+    new_sha: str,
     entries: list[dict[str, str | None]],
 ) -> str | None:
     """Materialise a synthetic commit on the GitHub server, no ref attached.
 
-    Posts the tree delta with `base_tree=parent_new_tree_sha`, then a commit
-    with `parents=[parent_new_sha]`. Returns the commit SHA on success or
-    None on any API error. The unreferenced object will be GC'd by GitHub
-    eventually; the compare URL works in the meantime.
+    Posts the tree delta with `base_tree=parent_old_tree_sha`, then a commit
+    with `parents=[old_sha]`. The synthetic commit's parent is the previous
+    PR head, so GitHub's `compare/old_sha...amend_sha` URL uses old_sha as
+    merge-base and renders exactly the amendment — without the rebase noise
+    that a sibling-on-new-base would have surfaced.
+
+    Returns the commit SHA on success or None on any API error. The
+    unreferenced object will be GC'd by GitHub eventually; the compare URL
+    works in the meantime.
     """
     tree_payload: dict[str, typing.Any] = {
         "base_tree": base_tree_sha,
@@ -169,11 +180,9 @@ async def upload_replay_commit(
         commit_resp = await client.post(
             f"/repos/{user}/{repo}/git/commits",
             json={
-                "message": (
-                    f"mergify-cli: replay {old_sha[:7]} on {parent_new_sha[:7]}"
-                ),
+                "message": (f"mergify-cli: replay {new_sha[:7]} on {old_sha[:7]}"),
                 "tree": new_tree_sha,
-                "parents": [parent_new_sha],
+                "parents": [old_sha],
             },
         )
         commit_resp.raise_for_status()
@@ -206,15 +215,15 @@ async def replay_for_revision(
 
     try:
         # ^{tree} dereferences a commit SHA to its root tree SHA (git plumbing syntax).
-        parent_new_tree_sha = await utils.git(
+        parent_old_tree_sha = await utils.git(
             "rev-parse",
-            f"{merged.parent_new_sha}^{{tree}}",
+            f"{merged.parent_old_sha}^{{tree}}",
         )
     except utils.CommandError:
         return None
 
     entries = await compute_tree_delta(
-        base_tree_sha=parent_new_tree_sha,
+        base_tree_sha=parent_old_tree_sha,
         merged_tree_sha=merged.tree_sha,
     )
     if not entries:
@@ -226,8 +235,8 @@ async def replay_for_revision(
         client=client,
         user=user,
         repo=repo,
-        base_tree_sha=parent_new_tree_sha,
-        parent_new_sha=merged.parent_new_sha,
+        base_tree_sha=parent_old_tree_sha,
         old_sha=old_sha,
+        new_sha=new_sha,
         entries=entries,
     )

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -1392,8 +1392,9 @@ async def test_create_revision_comment_with_replay_sha_renders_dual_link(
     git_mock: test_utils.GitMock,
     respx_mock: respx.MockRouter,
 ) -> None:
-    """When replay_for_revision returns a SHA, the rendered comment uses it as
-    the primary URL anchor and appends a (raw) fallback link to old_sha."""
+    """When replay_for_revision returns a SHA, the rendered comment points
+    `old_sha...replay_sha` (rebase-aware) for the primary link and falls
+    back to `old_sha...new_sha` for the durable (raw) link."""
     git_mock.commit(
         test_utils.Commit(
             sha="new_commit_sha",
@@ -1483,14 +1484,17 @@ async def test_create_revision_comment_with_replay_sha_renders_dual_link(
     ]
     assert len(revision_calls) == 1
     posted_body = json.loads(revision_calls[0].request.content)["body"]
-    # Primary link is anchored at the replay SHA
+    # Primary link: old_sha → replay_sha (rebase-aware). The replay commit
+    # is a child of old_sha, so GitHub uses old_sha as merge-base and the
+    # page renders just the amendment.
     assert (
-        "/compare/replayshaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX...new_commit_sha"
+        "/compare/old_commit_sha...replayshaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
         in posted_body
     )
-    # Raw fallback link is anchored at the original old SHA
+    # Raw fallback link uses the durable old_sha → new_sha pair.
     assert (
-        "([raw](https://github.com/user/repo/compare/old_commit_sha..." in posted_body
+        "([raw](https://github.com/user/repo/compare/old_commit_sha...new_commit_sha)"
+        in posted_body
     )
 
 
@@ -2975,7 +2979,8 @@ def test_revision_history_renders_badge_for_pure_rebase() -> None:
 
 
 def test_revision_history_uses_replay_sha_for_url_when_present() -> None:
-    """When replay_sha is set, primary URL anchors at it; raw link uses old_sha."""
+    """When replay_sha is set, primary URL is old_sha→replay_sha; raw link
+    falls back to old_sha→new_sha for durability after GitHub GC."""
     comment = push.RevisionHistoryComment.create_initial(
         github_server="https://api.github.com",
         user="owner",
@@ -2990,18 +2995,20 @@ def test_revision_history_uses_replay_sha_for_url_when_present() -> None:
     row = next(line for line in body.splitlines() if "| 2 | content |" in line)
     rebase_aware_url = (
         "https://github.com/owner/repo/compare/"
-        "ccc9999999999999999999999999999999999999"
-        "...bbb5678901234567890abcdef1234567890abcdef"
+        "aaa1234567890abcdef1234567890abcdef123456"
+        "...ccc9999999999999999999999999999999999999"
     )
     raw_url = (
         "https://github.com/owner/repo/compare/"
         "aaa1234567890abcdef1234567890abcdef123456"
         "...bbb5678901234567890abcdef1234567890abcdef"
     )
-    # Primary clickable label uses the human-readable SHAs and points at the
-    # rebase-aware URL (the synthetic replay commit).
+    # Primary clickable label keeps the human-readable old→new SHAs; the
+    # link targets the rebase-aware compare (old_sha → synth replay
+    # commit), which renders just the user's amendment.
     assert f"[`aaa1234 → bbb5678`]({rebase_aware_url})" in row
-    # Raw link is appended for durability after GitHub GCs the synthetic commit.
+    # Raw link uses the durable old_sha → new_sha pair so the long tail
+    # still has a working URL after GitHub GCs the synthetic commit.
     assert f"([raw]({raw_url}))" in row
 
 
@@ -3060,4 +3067,8 @@ async def test_create_or_update_revision_comments_passes_replay_sha(
 
     assert create_route.called
     body = create_route.calls.last.request.read()
-    assert b"replayshaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX...newshaaaaaaaa" in body
+    # Primary link: old_sha → replay_sha (rebase-aware).
+    assert (
+        b"oldshaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        b"...replayshaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    ) in body

--- a/mergify_cli/tests/stack/test_replay.py
+++ b/mergify_cli/tests/stack/test_replay.py
@@ -16,28 +16,32 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import typing
 
 import httpx
 import respx
 
+from mergify_cli import utils
 from mergify_cli.stack import replay
 
 
 if typing.TYPE_CHECKING:
+    import pathlib
+
     from mergify_cli.tests import utils as test_utils
 
 
 async def test_compute_merged_tree_clean(git_mock: test_utils.GitMock) -> None:
-    """Clean merge returns the merged tree SHA."""
+    """Clean merge returns the merged tree SHA: new_sha replayed onto parent_old_sha."""
     git_mock.mock("rev-parse", "old_sha^", output="parent_old_sha")
     git_mock.mock("rev-parse", "new_sha^", output="parent_new_sha")
     git_mock.mock(
         "merge-tree",
         "--write-tree",
-        "--merge-base=parent_old_sha",
-        "parent_new_sha",
-        "old_sha",
+        "--merge-base=parent_new_sha",
+        "parent_old_sha",
+        "new_sha",
         output="merged_tree_sha",
     )
 
@@ -45,7 +49,7 @@ async def test_compute_merged_tree_clean(git_mock: test_utils.GitMock) -> None:
 
     assert result == replay.MergedTree(
         tree_sha="merged_tree_sha",
-        parent_new_sha="parent_new_sha",
+        parent_old_sha="parent_old_sha",
     )
 
 
@@ -58,9 +62,9 @@ async def test_compute_merged_tree_conflict_returns_none(
     git_mock.mock_error(
         "merge-tree",
         "--write-tree",
-        "--merge-base=parent_old_sha",
-        "parent_new_sha",
-        "old_sha",
+        "--merge-base=parent_new_sha",
+        "parent_old_sha",
+        "new_sha",
     )
 
     result = await replay.compute_merged_tree(old_sha="old_sha", new_sha="new_sha")
@@ -150,23 +154,25 @@ async def test_upload_replay_commit_posts_tree_then_commit() -> None:
             client=client,
             user="owner",
             repo="repo",
-            base_tree_sha="parent_new_tree_sha",
-            parent_new_sha="parent_new_sha",
+            base_tree_sha="parent_old_tree_sha",
             old_sha="abc1234",
+            new_sha="def5678",
             entries=entries,
         )
 
     assert sha == "new_commit_server_sha"
     assert tree_route.called
     tree_body = json.loads(tree_route.calls.last.request.read())
-    assert tree_body["base_tree"] == "parent_new_tree_sha"
+    assert tree_body["base_tree"] == "parent_old_tree_sha"
     assert tree_body["tree"] == [
         {"path": "src/a.py", "mode": "100644", "type": "blob", "sha": "bbb2222"},
     ]
     assert commit_route.called
     commit_body = json.loads(commit_route.calls.last.request.read())
     assert commit_body["tree"] == "new_tree_server_sha"
-    assert commit_body["parents"] == ["parent_new_sha"]
+    # Synth commit must be a CHILD of old_sha so that compare/old_sha...amend_sha
+    # uses old_sha as merge-base and renders the actual amendment.
+    assert commit_body["parents"] == ["abc1234"]
 
 
 @respx.mock
@@ -182,9 +188,9 @@ async def test_upload_replay_commit_returns_none_on_api_error() -> None:
             client=client,
             user="owner",
             repo="repo",
-            base_tree_sha="parent_new_tree_sha",
-            parent_new_sha="parent_new_sha",
+            base_tree_sha="parent_old_tree_sha",
             old_sha="abc1234",
+            new_sha="def5678",
             entries=[],
         )
 
@@ -207,9 +213,9 @@ async def test_upload_replay_commit_returns_none_on_commit_post_failure() -> Non
             client=client,
             user="owner",
             repo="repo",
-            base_tree_sha="parent_new_tree_sha",
-            parent_new_sha="parent_new_sha",
+            base_tree_sha="parent_old_tree_sha",
             old_sha="abc1234",
+            new_sha="def5678",
             entries=[],
         )
 
@@ -231,18 +237,18 @@ async def test_replay_for_revision_happy_path(git_mock: test_utils.GitMock) -> N
     git_mock.mock(
         "merge-tree",
         "--write-tree",
-        "--merge-base=parent_old_sha",
-        "parent_new_sha",
-        "old_sha",
+        "--merge-base=parent_new_sha",
+        "parent_old_sha",
+        "new_sha",
         output="merged_tree_sha",
     )
-    git_mock.mock("rev-parse", "parent_new_sha^{tree}", output="parent_new_tree_sha")
+    git_mock.mock("rev-parse", "parent_old_sha^{tree}", output="parent_old_tree_sha")
     git_mock.mock(
         "diff-tree",
         "-r",
         "--raw",
         "--no-renames",
-        "parent_new_tree_sha",
+        "parent_old_tree_sha",
         "merged_tree_sha",
         output=":100644 100644 aaa bbb M\tsrc/x.py\n",
     )
@@ -269,9 +275,9 @@ async def test_replay_for_revision_conflict_returns_none(
     git_mock.mock_error(
         "merge-tree",
         "--write-tree",
-        "--merge-base=parent_old_sha",
-        "parent_new_sha",
-        "old_sha",
+        "--merge-base=parent_new_sha",
+        "parent_old_sha",
+        "new_sha",
     )
 
     async with httpx.AsyncClient(base_url="https://api.github.com") as client:
@@ -290,24 +296,24 @@ async def test_replay_for_revision_conflict_returns_none(
 async def test_replay_for_revision_no_diff_returns_none(
     git_mock: test_utils.GitMock,
 ) -> None:
-    """If merged tree equals parent_new's tree, there's nothing to upload."""
+    """If merged tree equals parent_old's tree, there's nothing to upload."""
     git_mock.mock("rev-parse", "old_sha^", output="parent_old_sha")
     git_mock.mock("rev-parse", "new_sha^", output="parent_new_sha")
     git_mock.mock(
         "merge-tree",
         "--write-tree",
-        "--merge-base=parent_old_sha",
-        "parent_new_sha",
-        "old_sha",
+        "--merge-base=parent_new_sha",
+        "parent_old_sha",
+        "new_sha",
         output="merged_tree_sha",
     )
-    git_mock.mock("rev-parse", "parent_new_sha^{tree}", output="parent_new_tree_sha")
+    git_mock.mock("rev-parse", "parent_old_sha^{tree}", output="parent_old_tree_sha")
     git_mock.mock(
         "diff-tree",
         "-r",
         "--raw",
         "--no-renames",
-        "parent_new_tree_sha",
+        "parent_old_tree_sha",
         "merged_tree_sha",
         output="",
     )
@@ -334,12 +340,12 @@ async def test_replay_for_revision_rev_parse_tree_error_returns_none(
     git_mock.mock(
         "merge-tree",
         "--write-tree",
-        "--merge-base=parent_old_sha",
-        "parent_new_sha",
-        "old_sha",
+        "--merge-base=parent_new_sha",
+        "parent_old_sha",
+        "new_sha",
         output="merged_tree_sha",
     )
-    git_mock.mock_error("rev-parse", "parent_new_sha^{tree}")
+    git_mock.mock_error("rev-parse", "parent_old_sha^{tree}")
 
     async with httpx.AsyncClient(base_url="https://api.github.com") as client:
         sha = await replay.replay_for_revision(
@@ -351,3 +357,63 @@ async def test_replay_for_revision_rev_parse_tree_error_returns_none(
         )
 
     assert sha is None
+
+
+async def test_compute_merged_tree_against_real_git(
+    _git_repo: None,
+    tmp_path: pathlib.Path,
+) -> None:
+    """Drive compute_merged_tree against a real git repo with a real
+    merge-tree call (no mocking) to lock in the orientation.
+
+    Models the bug we fixed: a PR amended on a stable base. If the
+    merge-tree arguments regress (e.g. someone swaps `parent_old_sha`
+    and `parent_new_sha` back), the merged tree would equal old_sha's
+    tree and the assertion below would fail.
+    """
+
+    def run(*args: str) -> str:
+        return subprocess.check_output(["git", *args], cwd=tmp_path, text=True).strip()
+
+    # base commit on main (the PR base), then the old PR head and the new
+    # PR head, both anchored on the same base — mirrors a force-pushed PR
+    # whose base did not move (the scenario where the original sibling-on-
+    # new-base replay produced a useless full-PR diff).
+    (tmp_path / "base.txt").write_text("base\n")
+    run("add", "base.txt")
+    run("commit", "-m", "base")
+    base_sha = run("rev-parse", "HEAD")
+
+    # old PR head: adds routes.py
+    (tmp_path / "routes.py").write_text("# routes\n")
+    run("add", "routes.py")
+    run("commit", "-m", "add routes")
+    old_sha = run("rev-parse", "HEAD")
+
+    # new PR head: starts again from base, adds routes.py (same blob) plus
+    # the amendment (a follow-up migration + a tweak to an existing file).
+    run("reset", "--hard", base_sha)
+    (tmp_path / "routes.py").write_text("# routes\n")
+    (tmp_path / "migration.py").write_text("# migration\n")
+    (tmp_path / "base.txt").write_text("base\nindex\n")
+    run("add", "routes.py", "migration.py", "base.txt")
+    run("commit", "-m", "add routes + follow-up migration")
+    new_sha = run("rev-parse", "HEAD")
+
+    merged = await replay.compute_merged_tree(old_sha=old_sha, new_sha=new_sha)
+    assert merged is not None
+    assert merged.parent_old_sha == base_sha
+
+    # diff-tree between old_sha's tree and the merged tree must contain
+    # ONLY the amendment (migration.py added, base.txt modified). If the
+    # orientation regresses, this will pick up routes.py too.
+    diff = await utils.git(
+        "diff-tree",
+        "-r",
+        "--no-renames",
+        "--name-status",
+        old_sha,
+        merged.tree_sha,
+    )
+    changed = sorted(line.split("\t", 1)[1] for line in diff.splitlines() if line)
+    assert changed == ["base.txt", "migration.py"]


### PR DESCRIPTION
The "rebase-aware compare" link used `compare/replay_sha...new_sha`
where `replay_sha` was a sibling of `new_sha` on the same parent.
GitHub's compare URL semantics — `..` and `...` normalise to the same
merge-base(A,B)→B view — meant the page always rendered the full PR
diff against their shared parent, not the user's amendment.

Build the synth commit as a child of `old_sha` instead, with `new_sha`'s
content re-applied onto `parent(old_sha)`. Then merge-base = old_sha
and `compare/old_sha...replay_sha` renders exactly the amendment.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>