### PR TITLE
refactor(ci): consolidate the CI-env scrubber into a shared testing module

### DIFF
--- a/crates/mergify-ci/src/detector.rs
+++ b/crates/mergify-ci/src/detector.rs
@@ -184,32 +184,7 @@ fn read_github_event_pull_request_number() -> Result<Option<u64>, CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Clear every CI-provider env var the detector inspects, then
-    /// apply the test-specific overrides on top. Without this, a
-    /// test running on a real CI host inherits provider state and
-    /// the detector picks the wrong branch.
-    pub(crate) fn with_ci_env<F: FnOnce() -> R, R>(extra: &[(&str, Option<&str>)], f: F) -> R {
-        let mut vars: Vec<(String, Option<String>)> = [
-            "JENKINS_URL",
-            "GITHUB_ACTIONS",
-            "GITHUB_REPOSITORY",
-            "GITHUB_EVENT_PATH",
-            "CIRCLECI",
-            "CIRCLE_REPOSITORY_URL",
-            "BUILDKITE",
-            "BUILDKITE_REPO",
-            "BUILDKITE_PULL_REQUEST",
-            "GIT_URL",
-        ]
-        .into_iter()
-        .map(|k| (k.to_string(), None))
-        .collect();
-        for (k, v) in extra {
-            vars.push((k.to_string(), v.map(ToString::to_string)));
-        }
-        temp_env::with_vars(vars, f)
-    }
+    use crate::testing::with_ci_env;
 
     #[test]
     fn ci_provider_jenkins_takes_precedence() {

--- a/crates/mergify-ci/src/lib.rs
+++ b/crates/mergify-ci/src/lib.rs
@@ -14,3 +14,6 @@ pub mod queue_info;
 pub mod queue_metadata;
 pub mod scopes_send;
 pub mod tests_show;
+
+#[cfg(test)]
+mod testing;

--- a/crates/mergify-ci/src/scopes_send.rs
+++ b/crates/mergify-ci/src/scopes_send.rs
@@ -156,58 +156,8 @@ mod tests {
     use wiremock::matchers::path;
 
     use super::*;
-
-    /// Clear every CI-provider env var the resolver inspects, then
-    /// apply the test-specific overrides on top. Without this, a test
-    /// running on a real CI host (Buildkite, Actions, …) inherits
-    /// provider env vars and the new provider-aware resolver picks
-    /// the wrong branch.
-    fn with_ci_env<F: FnOnce() -> R, R>(extra: &[(&str, Option<&str>)], f: F) -> R {
-        let mut vars: Vec<(String, Option<String>)> = [
-            "JENKINS_URL",
-            "GITHUB_ACTIONS",
-            "GITHUB_REPOSITORY",
-            "GITHUB_EVENT_PATH",
-            "CIRCLECI",
-            "CIRCLE_REPOSITORY_URL",
-            "BUILDKITE",
-            "BUILDKITE_REPO",
-            "BUILDKITE_PULL_REQUEST",
-            "GIT_URL",
-        ]
-        .into_iter()
-        .map(|k| (k.to_string(), None))
-        .collect();
-        for (k, v) in extra {
-            vars.push((k.to_string(), v.map(ToString::to_string)));
-        }
-        temp_env::with_vars(vars, f)
-    }
-
-    async fn with_ci_env_async<F: std::future::Future<Output = R>, R>(
-        extra: &[(&str, Option<&str>)],
-        f: F,
-    ) -> R {
-        let mut vars: Vec<(String, Option<String>)> = [
-            "JENKINS_URL",
-            "GITHUB_ACTIONS",
-            "GITHUB_REPOSITORY",
-            "GITHUB_EVENT_PATH",
-            "CIRCLECI",
-            "CIRCLE_REPOSITORY_URL",
-            "BUILDKITE",
-            "BUILDKITE_REPO",
-            "BUILDKITE_PULL_REQUEST",
-            "GIT_URL",
-        ]
-        .into_iter()
-        .map(|k| (k.to_string(), None))
-        .collect();
-        for (k, v) in extra {
-            vars.push((k.to_string(), v.map(ToString::to_string)));
-        }
-        temp_env::async_with_vars(vars, f).await
-    }
+    use crate::testing::with_ci_env;
+    use crate::testing::with_ci_env_async;
 
     #[test]
     fn resolve_repository_prefers_flag_over_env() {

--- a/crates/mergify-ci/src/testing.rs
+++ b/crates/mergify-ci/src/testing.rs
@@ -1,0 +1,67 @@
+//! Test-only helpers shared between `detector` and `scopes_send`.
+//!
+//! Both modules test CI-provider-aware code paths and need to scrub
+//! the host's CI env vars before running each case — otherwise a
+//! test running on a real Buildkite/Actions/Circle/Jenkins host
+//! inherits provider state and the detector picks the wrong branch.
+//! Two flavors: a sync `with_ci_env` and an async `with_ci_env_async`
+//! (used by the `#[tokio::test]` cases in `scopes_send`).
+
+use std::future::Future;
+
+/// Env vars the CI-provider detection chain inspects. Clear every
+/// one of them before applying the test-specific overrides, so the
+/// host environment can't leak into the test.
+///
+/// `GITHUB_OUTPUT` belongs on this list too — when the suite runs
+/// *on* a GHA runner that var points at the runner's real
+/// step-output file, and any test that exercises a code path
+/// appending a heredoc (e.g. `ci scopes` →
+/// `MERGIFY_SCOPES<<ghadelimiter_…`) will splice its own
+/// delimiter into the runner's file. GHA then fails the step with
+/// "Matching delimiter not found". Scrubbing it forces the no-op
+/// `env::var("GITHUB_OUTPUT").ok()` branch unless the test
+/// explicitly points it at a temp file.
+const CI_ENV_VARS: &[&str] = &[
+    "JENKINS_URL",
+    "GITHUB_ACTIONS",
+    "GITHUB_REPOSITORY",
+    "GITHUB_EVENT_PATH",
+    "GITHUB_OUTPUT",
+    "CIRCLECI",
+    "CIRCLE_REPOSITORY_URL",
+    "BUILDKITE",
+    "BUILDKITE_REPO",
+    "BUILDKITE_PULL_REQUEST",
+    "GIT_URL",
+];
+
+fn merged_overrides(extra: &[(&str, Option<&str>)]) -> Vec<(String, Option<String>)> {
+    let mut vars: Vec<(String, Option<String>)> = CI_ENV_VARS
+        .iter()
+        .map(|k| ((*k).to_string(), None))
+        .collect();
+    for (k, v) in extra {
+        vars.push(((*k).to_string(), v.map(ToString::to_string)));
+    }
+    vars
+}
+
+/// Run `f` with the CI-provider env vars cleared, plus the
+/// `extra` overrides applied on top.
+pub(crate) fn with_ci_env<F, R>(extra: &[(&str, Option<&str>)], f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    temp_env::with_vars(merged_overrides(extra), f)
+}
+
+/// Async counterpart to [`with_ci_env`]. Used by `#[tokio::test]`
+/// cases in `scopes_send` — the sync variant can't bridge `.await`
+/// points.
+pub(crate) async fn with_ci_env_async<F, R>(extra: &[(&str, Option<&str>)], f: F) -> R
+where
+    F: Future<Output = R>,
+{
+    temp_env::async_with_vars(merged_overrides(extra), f).await
+}


### PR DESCRIPTION
`with_ci_env` (clear every CI-provider env var before applying
test overrides) lived in two copies — one inside the `tests`
sub-module of `detector.rs`, one inside `scopes_send.rs` (which
also had a `with_ci_env_async` counterpart). Both spelled the same
10-var list inline; both were drifting candidates.

Extract to a new `crate::testing` (`#[cfg(test)] mod testing`) with
the env-var list named as a const, sync + async variants behind one
helper that builds the override list. Each test module now does a
plain `use crate::testing::with_ci_env;`.

Net `-71 / +51`. No behavior change; the existing 49 `mergify-ci`
tests still pass.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>