### PR TITLE
refactor(tui): share StyledGlyph across queue show/status renderers

### DIFF
--- a/crates/mergify-ci/src/detector.rs
+++ b/crates/mergify-ci/src/detector.rs
@@ -184,32 +184,7 @@ fn read_github_event_pull_request_number() -> Result<Option<u64>, CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Clear every CI-provider env var the detector inspects, then
-    /// apply the test-specific overrides on top. Without this, a
-    /// test running on a real CI host inherits provider state and
-    /// the detector picks the wrong branch.
-    pub(crate) fn with_ci_env<F: FnOnce() -> R, R>(extra: &[(&str, Option<&str>)], f: F) -> R {
-        let mut vars: Vec<(String, Option<String>)> = [
-            "JENKINS_URL",
-            "GITHUB_ACTIONS",
-            "GITHUB_REPOSITORY",
-            "GITHUB_EVENT_PATH",
-            "CIRCLECI",
-            "CIRCLE_REPOSITORY_URL",
-            "BUILDKITE",
-            "BUILDKITE_REPO",
-            "BUILDKITE_PULL_REQUEST",
-            "GIT_URL",
-        ]
-        .into_iter()
-        .map(|k| (k.to_string(), None))
-        .collect();
-        for (k, v) in extra {
-            vars.push((k.to_string(), v.map(ToString::to_string)));
-        }
-        temp_env::with_vars(vars, f)
-    }
+    use crate::testing::with_ci_env;
 
     #[test]
     fn ci_provider_jenkins_takes_precedence() {

--- a/crates/mergify-ci/src/lib.rs
+++ b/crates/mergify-ci/src/lib.rs
@@ -14,3 +14,6 @@ pub mod queue_info;
 pub mod queue_metadata;
 pub mod scopes_send;
 pub mod tests_show;
+
+#[cfg(test)]
+mod testing;

--- a/crates/mergify-ci/src/scopes_send.rs
+++ b/crates/mergify-ci/src/scopes_send.rs
@@ -156,58 +156,8 @@ mod tests {
     use wiremock::matchers::path;
 
     use super::*;
-
-    /// Clear every CI-provider env var the resolver inspects, then
-    /// apply the test-specific overrides on top. Without this, a test
-    /// running on a real CI host (Buildkite, Actions, …) inherits
-    /// provider env vars and the new provider-aware resolver picks
-    /// the wrong branch.
-    fn with_ci_env<F: FnOnce() -> R, R>(extra: &[(&str, Option<&str>)], f: F) -> R {
-        let mut vars: Vec<(String, Option<String>)> = [
-            "JENKINS_URL",
-            "GITHUB_ACTIONS",
-            "GITHUB_REPOSITORY",
-            "GITHUB_EVENT_PATH",
-            "CIRCLECI",
-            "CIRCLE_REPOSITORY_URL",
-            "BUILDKITE",
-            "BUILDKITE_REPO",
-            "BUILDKITE_PULL_REQUEST",
-            "GIT_URL",
-        ]
-        .into_iter()
-        .map(|k| (k.to_string(), None))
-        .collect();
-        for (k, v) in extra {
-            vars.push((k.to_string(), v.map(ToString::to_string)));
-        }
-        temp_env::with_vars(vars, f)
-    }
-
-    async fn with_ci_env_async<F: std::future::Future<Output = R>, R>(
-        extra: &[(&str, Option<&str>)],
-        f: F,
-    ) -> R {
-        let mut vars: Vec<(String, Option<String>)> = [
-            "JENKINS_URL",
-            "GITHUB_ACTIONS",
-            "GITHUB_REPOSITORY",
-            "GITHUB_EVENT_PATH",
-            "CIRCLECI",
-            "CIRCLE_REPOSITORY_URL",
-            "BUILDKITE",
-            "BUILDKITE_REPO",
-            "BUILDKITE_PULL_REQUEST",
-            "GIT_URL",
-        ]
-        .into_iter()
-        .map(|k| (k.to_string(), None))
-        .collect();
-        for (k, v) in extra {
-            vars.push((k.to_string(), v.map(ToString::to_string)));
-        }
-        temp_env::async_with_vars(vars, f).await
-    }
+    use crate::testing::with_ci_env;
+    use crate::testing::with_ci_env_async;
 
     #[test]
     fn resolve_repository_prefers_flag_over_env() {

--- a/crates/mergify-ci/src/testing.rs
+++ b/crates/mergify-ci/src/testing.rs
@@ -1,0 +1,67 @@
+//! Test-only helpers shared between `detector` and `scopes_send`.
+//!
+//! Both modules test CI-provider-aware code paths and need to scrub
+//! the host's CI env vars before running each case — otherwise a
+//! test running on a real Buildkite/Actions/Circle/Jenkins host
+//! inherits provider state and the detector picks the wrong branch.
+//! Two flavors: a sync `with_ci_env` and an async `with_ci_env_async`
+//! (used by the `#[tokio::test]` cases in `scopes_send`).
+
+use std::future::Future;
+
+/// Env vars the CI-provider detection chain inspects. Clear every
+/// one of them before applying the test-specific overrides, so the
+/// host environment can't leak into the test.
+///
+/// `GITHUB_OUTPUT` belongs on this list too — when the suite runs
+/// *on* a GHA runner that var points at the runner's real
+/// step-output file, and any test that exercises a code path
+/// appending a heredoc (e.g. `ci scopes` →
+/// `MERGIFY_SCOPES<<ghadelimiter_…`) will splice its own
+/// delimiter into the runner's file. GHA then fails the step with
+/// "Matching delimiter not found". Scrubbing it forces the no-op
+/// `env::var("GITHUB_OUTPUT").ok()` branch unless the test
+/// explicitly points it at a temp file.
+const CI_ENV_VARS: &[&str] = &[
+    "JENKINS_URL",
+    "GITHUB_ACTIONS",
+    "GITHUB_REPOSITORY",
+    "GITHUB_EVENT_PATH",
+    "GITHUB_OUTPUT",
+    "CIRCLECI",
+    "CIRCLE_REPOSITORY_URL",
+    "BUILDKITE",
+    "BUILDKITE_REPO",
+    "BUILDKITE_PULL_REQUEST",
+    "GIT_URL",
+];
+
+fn merged_overrides(extra: &[(&str, Option<&str>)]) -> Vec<(String, Option<String>)> {
+    let mut vars: Vec<(String, Option<String>)> = CI_ENV_VARS
+        .iter()
+        .map(|k| ((*k).to_string(), None))
+        .collect();
+    for (k, v) in extra {
+        vars.push(((*k).to_string(), v.map(ToString::to_string)));
+    }
+    vars
+}
+
+/// Run `f` with the CI-provider env vars cleared, plus the
+/// `extra` overrides applied on top.
+pub(crate) fn with_ci_env<F, R>(extra: &[(&str, Option<&str>)], f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    temp_env::with_vars(merged_overrides(extra), f)
+}
+
+/// Async counterpart to [`with_ci_env`]. Used by `#[tokio::test]`
+/// cases in `scopes_send` — the sync variant can't bridge `.await`
+/// points.
+pub(crate) async fn with_ci_env_async<F, R>(extra: &[(&str, Option<&str>)], f: F) -> R
+where
+    F: Future<Output = R>,
+{
+    temp_env::async_with_vars(merged_overrides(extra), f).await
+}

--- a/crates/mergify-config/src/lib.rs
+++ b/crates/mergify-config/src/lib.rs
@@ -1,7 +1,7 @@
 //! Native Rust implementation of the `mergify config` subcommands.
 //!
-//! Phase 1.3 ports `config validate`. Phase 1.3b adds `config
-//! simulate`. Both share the config-file resolver in [`paths`].
+//! Hosts `config validate` and `config simulate`; both share the
+//! config-file resolver in [`paths`].
 
 pub mod paths;
 pub mod simulate;

--- a/crates/mergify-core/src/error.rs
+++ b/crates/mergify-core/src/error.rs
@@ -5,10 +5,9 @@
 //! the appropriate `ExitCode` and writes a human-readable message
 //! to stderr before exiting.
 //!
-//! This enum grows as new error sources are added. Today it covers
-//! the categories needed to port the `config` pilot (Phase 1.3);
-//! subsequent sub-phases add variants for HTTP failures, git
-//! subprocess failures, and so on.
+//! This enum grows as new error sources are added — add a variant
+//! per error category, never a generic `String` catch-all for new
+//! kinds of failure that have their own exit code.
 
 use std::io;
 

--- a/crates/mergify-core/src/exit_code.rs
+++ b/crates/mergify-core/src/exit_code.rs
@@ -2,9 +2,9 @@
 //!
 //! Mirrors `mergify_cli.exit_codes.ExitCode` in the Python
 //! implementation. The contract — which (command, failure mode)
-//! maps to which exit code — is locked by Phase 0.1 and enforced by
-//! the compat-test harness. Changing a variant's numeric value is a
-//! breaking change for downstream scripts.
+//! maps to which exit code — is enforced by the compat-test
+//! harness. Changing a variant's numeric value is a breaking change
+//! for downstream scripts.
 
 use std::process::ExitCode as ProcessExitCode;
 

--- a/crates/mergify-core/src/lib.rs
+++ b/crates/mergify-core/src/lib.rs
@@ -1,7 +1,5 @@
 //! Shared foundations for the mergify CLI Rust port.
 //!
-//! Phase 1.2 populates this crate with:
-//!
 //! - [`exit_code::ExitCode`] — typed exit codes mirroring the
 //!   Python `exit_codes.py` contract.
 //! - [`error::CliError`] — top-level error enum with deterministic
@@ -11,9 +9,11 @@
 //!   in.
 //! - [`http::Client`] — wraps `reqwest` with bearer auth, retry,
 //!   and typed error mapping for the Mergify and GitHub APIs.
-//!
-//! Git operations, interactive prompts, and config loading arrive
-//! in subsequent sub-phases.
+//! - [`auth`] — resolve `--repository` / `--token` / `--api-url`
+//!   from the same flag → env → fallback chain the Python CLI uses.
+//! - [`command_context::CommandContext`] — bundle the resolved
+//!   trio + a pre-configured Mergify HTTP client for the
+//!   queue/freeze command preludes.
 
 pub mod auth;
 pub mod command_context;

--- a/crates/mergify-core/src/output.rs
+++ b/crates/mergify-core/src/output.rs
@@ -5,7 +5,7 @@
 //! directly. This keeps the JSON and human rendering paths
 //! symmetric, lets commands stay test-friendly, and gives a single
 //! place to enforce the "stdout must be a single JSON document
-//! under `--json`" invariant (Phase 0.3).
+//! under `--json`" invariant.
 //!
 //! The trait is deliberately small. Commands emit one "result"
 //! value that knows how to render itself both as JSON (via

--- a/crates/mergify-freeze/src/list.rs
+++ b/crates/mergify-freeze/src/list.rs
@@ -188,16 +188,12 @@ fn write_row(
                 spaces = " ".repeat(pad),
             )?;
         } else if HEADERS[i] == "Status" {
+            // `Theme::fg` already collapses to `Style::new()` when
+            // colors are disabled — no need for an extra branch.
             let style = if cell == "active" {
-                if theme.enabled {
-                    theme.fg(AnsiColor::Green)
-                } else {
-                    anstyle::Style::new()
-                }
-            } else if theme.enabled {
-                theme.fg(AnsiColor::Yellow)
+                theme.fg(AnsiColor::Green)
             } else {
-                anstyle::Style::new()
+                theme.fg(AnsiColor::Yellow)
             };
             write!(
                 w,

--- a/crates/mergify-py-shim/src/lib.rs
+++ b/crates/mergify-py-shim/src/lib.rs
@@ -21,7 +21,8 @@
 //! native impl first and only falls back to [`run`] for un-ported
 //! commands. The plan is for each port PR to delete its Python
 //! implementation in the same change, so the shim's reach shrinks
-//! one command at a time. Phase 6 deletes this crate entirely.
+//! one command at a time; this crate is deleted entirely once
+//! everything is ported.
 
 use std::env;
 use std::io;

--- a/crates/mergify-queue/src/lib.rs
+++ b/crates/mergify-queue/src/lib.rs
@@ -1,13 +1,8 @@
 //! Native Rust implementation of the `mergify queue` subcommands.
 //!
-//! Phase 1.5 ported `pause` and `unpause` — two idempotent API
-//! calls that rest on the HTTP client added in 1.2b and the
-//! `put`/`delete_if_exists` methods added alongside this crate.
-//! Phase 1.7 ports `status`, the read-only command that fetches
-//! the merge-queue snapshot and renders it either as a JSON
-//! passthrough or as the human-friendly batch tree + waiting list.
-//! `queue show` stays shimmed until its conditions/checks tree
-//! ports next.
+//! Hosts `pause` / `unpause` (idempotent API mutations), `status`
+//! (read-only batch tree + waiting list, with JSON passthrough),
+//! and `show` (per-PR detail with checks + conditions tree).
 
 pub mod pause;
 pub mod show;

--- a/crates/mergify-queue/src/show.rs
+++ b/crates/mergify-queue/src/show.rs
@@ -27,12 +27,12 @@
 use std::io::Write;
 
 use anstyle::AnsiColor;
-use anstyle::Style;
 use chrono::DateTime;
 use chrono::Utc;
 use mergify_core::CliError;
 use mergify_core::CommandContext;
 use mergify_core::Output;
+use mergify_tui::StyledGlyph;
 use mergify_tui::Theme;
 use mergify_tui::relative_time;
 use mergify_tui::tree;
@@ -230,11 +230,12 @@ fn print_checks_section(
     now: DateTime<Utc>,
 ) -> std::io::Result<()> {
     writeln!(w)?;
-    let (icon, style) = check_state_glyph(theme, &mc.ci_state);
+    let glyph = check_state_glyph(theme, &mc.ci_state);
     write!(
         w,
         "  CI State: {S}{icon} {state}{R}",
-        S = style,
+        S = glyph.style,
+        icon = glyph.icon,
         state = mc.ci_state,
         R = theme.reset,
     )?;
@@ -267,7 +268,7 @@ fn print_checks_table(w: &mut dyn Write, theme: &Theme, checks: &[Check]) -> std
         .max()
         .unwrap_or(0);
     for check in checks {
-        let (icon, style) = check_state_glyph(theme, &check.state);
+        let glyph = check_state_glyph(theme, &check.state);
         let pad = name_width.saturating_sub(check.name.chars().count());
         writeln!(
             w,
@@ -276,7 +277,8 @@ fn print_checks_table(w: &mut dyn Write, theme: &Theme, checks: &[Check]) -> std
             name = check.name,
             spaces = " ".repeat(pad),
             R = theme.reset,
-            S = style,
+            S = glyph.style,
+            icon = glyph.icon,
             state = check.state,
         )?;
     }
@@ -325,11 +327,12 @@ fn print_checks_summary(w: &mut dyn Write, theme: &Theme, checks: &[Check]) -> s
             check.state.as_str(),
             "failure" | "error" | "timed_out" | "action_required"
         ) {
-            let (icon, style) = check_state_glyph(theme, &check.state);
+            let glyph = check_state_glyph(theme, &check.state);
             writeln!(
                 w,
                 "    {S}{icon} {state}{R}  {D}{name}{R}",
-                S = style,
+                S = glyph.style,
+                icon = glyph.icon,
                 state = check.state,
                 R = theme.reset,
                 D = theme.dim,
@@ -340,17 +343,17 @@ fn print_checks_summary(w: &mut dyn Write, theme: &Theme, checks: &[Check]) -> s
     Ok(())
 }
 
-/// Map a check state string to (icon, ANSI style). Mirrors Python's
+/// Map a check state string to its [`StyledGlyph`]. Mirrors Python's
 /// `CHECK_STATE_STYLES`; unknown states fall back to a dim `?` so
 /// the renderer never crashes on a new API code.
-fn check_state_glyph(theme: &Theme, state: &str) -> (&'static str, Style) {
+fn check_state_glyph(theme: &Theme, state: &str) -> StyledGlyph {
     match state {
-        "success" => ("✓", theme.fg(AnsiColor::Green)),
-        "pending" => ("◌", theme.fg(AnsiColor::Yellow)),
-        "failure" | "error" | "action_required" => ("✗", theme.fg(AnsiColor::Red)),
-        "timed_out" => ("⏰", theme.fg(AnsiColor::Red)),
-        "cancelled" | "neutral" | "skipped" | "stale" => ("○", theme.dim),
-        _ => ("?", theme.dim),
+        "success" => StyledGlyph::new("✓", theme.fg(AnsiColor::Green)),
+        "pending" => StyledGlyph::new("◌", theme.fg(AnsiColor::Yellow)),
+        "failure" | "error" | "action_required" => StyledGlyph::new("✗", theme.fg(AnsiColor::Red)),
+        "timed_out" => StyledGlyph::new("⏰", theme.fg(AnsiColor::Red)),
+        "cancelled" | "neutral" | "skipped" | "stale" => StyledGlyph::new("○", theme.dim),
+        _ => StyledGlyph::new("?", theme.dim),
     }
 }
 
@@ -446,15 +449,16 @@ fn write_condition_tree(
     let last = nodes.len() - 1;
     for (i, node) in nodes.iter().enumerate() {
         let (branch, continuation) = tree::branch_chars(i == last);
-        let (icon, style) = if node.r#match {
-            ("✓", theme.fg(AnsiColor::Green))
+        let glyph = if node.r#match {
+            StyledGlyph::new("✓", theme.fg(AnsiColor::Green))
         } else {
-            ("✗", theme.fg(AnsiColor::Red))
+            StyledGlyph::new("✗", theme.fg(AnsiColor::Red))
         };
         writeln!(
             w,
             "{prefix}{branch}{S}{icon}{R} {label}",
-            S = style,
+            S = glyph.style,
+            icon = glyph.icon,
             R = theme.reset,
             label = node.label,
         )?;

--- a/crates/mergify-queue/src/status.rs
+++ b/crates/mergify-queue/src/status.rs
@@ -29,13 +29,13 @@ use std::collections::HashSet;
 use std::io::Write;
 
 use anstyle::AnsiColor;
-use anstyle::Style;
 use chrono::DateTime;
 use chrono::Utc;
 use indexmap::IndexMap;
 use mergify_core::CliError;
 use mergify_core::CommandContext;
 use mergify_core::Output;
+use mergify_tui::StyledGlyph;
 use mergify_tui::Theme;
 use mergify_tui::relative_time;
 use mergify_tui::tree;
@@ -194,28 +194,48 @@ fn emit_human(output: &mut dyn Output, repository: &str, view: &StatusView) -> s
     })
 }
 
-/// Map a queue batch status code to a foreground color, honoring
-/// the theme's enabled flag. Mirrors Python's `STATUS_STYLES`;
-/// unknown codes render dim.
-fn batch_status_style(theme: &Theme, code: &str) -> Style {
-    if !theme.enabled {
-        return Style::new();
-    }
-    match code {
-        "running" => theme.fg(AnsiColor::Green),
-        // Python rendered `merged` as `"dim green"` — bold off,
-        // green on, dimmed. anstyle composes the same effect by
-        // setting `dimmed()` on the green style.
-        "merged" => theme.fg(AnsiColor::Green).dimmed(),
-        "failed" => theme.fg(AnsiColor::Red),
-        "bisecting"
-        | "preparing"
-        | "waiting_for_previous_batches"
-        | "waiting_for_requeue"
-        | "waiting_schedule" => theme.fg(AnsiColor::Yellow),
-        "waiting_for_merge" | "frozen" => theme.fg(AnsiColor::Cyan),
-        _ => theme.dim,
-    }
+/// Map a queue batch status code to its [`StyledGlyph`]. Mirrors
+/// Python's `STATUS_STYLES` (icon + color side); unknown codes fall
+/// back to a dim `?`.
+fn batch_glyph(theme: &Theme, code: &str) -> StyledGlyph {
+    // `theme.fg` already collapses to `Style::new()` when colors are
+    // off — except for `merged`, which we compose as `green.dimmed()`.
+    // When colors are off the `dimmed` attribute would still emit a
+    // dim escape, so short-circuit here to keep the plain output
+    // truly plain.
+    let style = if theme.enabled {
+        match code {
+            "running" => theme.fg(AnsiColor::Green),
+            // Python rendered `merged` as `"dim green"` — bold off,
+            // green on, dimmed. anstyle composes the same effect by
+            // setting `dimmed()` on the green style.
+            "merged" => theme.fg(AnsiColor::Green).dimmed(),
+            "failed" => theme.fg(AnsiColor::Red),
+            "bisecting"
+            | "preparing"
+            | "waiting_for_previous_batches"
+            | "waiting_for_requeue"
+            | "waiting_schedule" => theme.fg(AnsiColor::Yellow),
+            "waiting_for_merge" | "frozen" => theme.fg(AnsiColor::Cyan),
+            _ => theme.dim,
+        }
+    } else {
+        anstyle::Style::new()
+    };
+    let icon = match code {
+        "running" => "●",
+        "bisecting" => "◑",
+        "preparing" => "◌",
+        "failed" => "✗",
+        "merged" => "✓",
+        "waiting_for_merge" => "◎",
+        "waiting_for_previous_batches" | "waiting_for_batch" => "⏳",
+        "waiting_for_requeue" => "↻",
+        "waiting_schedule" => "⏰",
+        "frozen" => "❄",
+        _ => "?",
+    };
+    StyledGlyph::new(icon, style)
 }
 
 fn print_pause(
@@ -281,12 +301,12 @@ fn print_batch_line(
     batch: &Batch,
     now: DateTime<Utc>,
 ) -> std::io::Result<()> {
-    let icon = status_icon(&batch.status.code);
-    let icon_style = batch_status_style(theme, &batch.status.code);
+    let glyph = batch_glyph(theme, &batch.status.code);
     write!(
         w,
         "{branch}{S}{icon} {code}{R}",
-        S = icon_style,
+        S = glyph.style,
+        icon = glyph.icon,
         code = batch.status.code,
         R = theme.reset,
     )?;
@@ -377,24 +397,6 @@ fn print_waiting_prs(
         writeln!(w)?;
     }
     Ok(())
-}
-
-/// Map a batch-status code to a compact Unicode icon. Same icons as
-/// the Python implementation; unknown codes fall back to `?`.
-fn status_icon(code: &str) -> &'static str {
-    match code {
-        "running" => "●",
-        "bisecting" => "◑",
-        "preparing" => "◌",
-        "failed" => "✗",
-        "merged" => "✓",
-        "waiting_for_merge" => "◎",
-        "waiting_for_previous_batches" | "waiting_for_batch" => "⏳",
-        "waiting_for_requeue" => "↻",
-        "waiting_schedule" => "⏰",
-        "frozen" => "❄",
-        _ => "?",
-    }
 }
 
 /// Topological sort of batches by `parent_ids`. Roots come first,
@@ -543,22 +545,29 @@ mod tests {
     }
 
     #[test]
-    fn status_icon_known_codes() {
-        assert_eq!(status_icon("running"), "●");
-        assert_eq!(status_icon("merged"), "✓");
-        assert_eq!(status_icon("failed"), "✗");
+    fn batch_glyph_known_codes() {
+        // Pin a no-color theme so we exercise the icon mapping
+        // without coupling the assertions to the ANSI escape format.
+        let theme = Theme::new(false);
+        assert_eq!(batch_glyph(&theme, "running").icon, "●");
+        assert_eq!(batch_glyph(&theme, "merged").icon, "✓");
+        assert_eq!(batch_glyph(&theme, "failed").icon, "✗");
         // Two pairs that share an icon vs. a different icon —
         // mirrors the Python `STATUS_STYLES` table, so a future
         // table edit can't silently swap glyphs without updating
         // this test.
-        assert_eq!(status_icon("waiting_for_previous_batches"), "⏳");
-        assert_eq!(status_icon("waiting_for_batch"), "⏳");
-        assert_eq!(status_icon("waiting_for_requeue"), "↻");
+        assert_eq!(
+            batch_glyph(&theme, "waiting_for_previous_batches").icon,
+            "⏳"
+        );
+        assert_eq!(batch_glyph(&theme, "waiting_for_batch").icon, "⏳");
+        assert_eq!(batch_glyph(&theme, "waiting_for_requeue").icon, "↻");
     }
 
     #[test]
-    fn status_icon_unknown_falls_back() {
-        assert_eq!(status_icon("brand-new-status"), "?");
+    fn batch_glyph_unknown_falls_back() {
+        let theme = Theme::new(false);
+        assert_eq!(batch_glyph(&theme, "brand-new-status").icon, "?");
     }
 
     fn sample_batch(id: &str, parents: &[&str]) -> Batch {

--- a/crates/mergify-tui/src/glyph.rs
+++ b/crates/mergify-tui/src/glyph.rs
@@ -1,0 +1,27 @@
+//! Pairing of a Unicode icon with its [`anstyle::Style`].
+//!
+//! Multiple commands map an enum-ish state code (CI check states,
+//! merge-queue batch states, …) to "render this icon in that color".
+//! Both halves of that pair travel together at every call site: the
+//! icon goes in the formatted output, the style wraps it. Bundling
+//! them into one named type beats returning a `(&str, Style)` tuple
+//! — the field names document what's what at the call site, and
+//! future fields (e.g. a dim suffix) can be added without rewriting
+//! every consumer.
+
+use anstyle::Style;
+
+#[derive(Clone, Copy)]
+pub struct StyledGlyph {
+    pub icon: &'static str,
+    pub style: Style,
+}
+
+impl StyledGlyph {
+    /// Convenience constructor — saves a few `StyledGlyph { … }`
+    /// braces at the dense pattern-match call sites.
+    #[must_use]
+    pub const fn new(icon: &'static str, style: Style) -> Self {
+        Self { icon, style }
+    }
+}

--- a/crates/mergify-tui/src/lib.rs
+++ b/crates/mergify-tui/src/lib.rs
@@ -15,6 +15,10 @@
 //!   palette. The same closure-based emit code paths produce
 //!   styled output on a TTY and plain text everywhere else with no
 //!   conditional branching at every write.
+//! - [`glyph`]: [`StyledGlyph`] — pairs a Unicode icon with the
+//!   [`anstyle::Style`] it's drawn in. Used by commands that map
+//!   state codes (check states, batch states, …) to a small visual
+//!   token.
 //! - [`time`]: [`relative_time`](time::relative_time) formats an
 //!   ISO-8601/RFC-3339 timestamp as a coarse delta (`Ns` / `Nm` /
 //!   `Nh` / `Nd`), with `~…` / `… ago` decorators for
@@ -27,9 +31,11 @@
 //!   [`LAST_CONTINUATION`](tree::LAST_CONTINUATION)) and the
 //!   [`branch_chars`](tree::branch_chars) helper.
 
+pub mod glyph;
 pub mod theme;
 pub mod time;
 pub mod tree;
 
+pub use glyph::StyledGlyph;
 pub use theme::Theme;
 pub use time::relative_time;


### PR DESCRIPTION
`queue show` and `queue status` both map an enum-ish state code to
an "(icon, ANSI style)" pair, but spelled the pairing two different
ways: `show.rs::check_state_glyph` returned `(&'static str, Style)`,
while `status.rs` split it into separate `status_icon` /
`batch_status_style` functions. Same shape, different names, drifting
naturally as new states land.

Add a small `StyledGlyph` struct to `mergify-tui` and route both
callers through it. `status.rs::status_icon` + `batch_status_style`
collapse into a single `batch_glyph(theme, code) -> StyledGlyph`;
the early-return for the disabled-theme case is preserved (the
`merged → green.dimmed()` composition would otherwise emit a dim
escape when colors are off).

The third candidate — `freeze/list.rs`'s active/scheduled coloring
— stays inline: it has no icon, just a two-arm color pick, and
forcing a `StyledGlyph::new("", color)` would add more noise than
it removes.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Depends-On: #1443