### PR TITLE
refactor(config): standardize the workspace on serde_yaml_ng for YAML parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,7 +1102,7 @@ dependencies = [
  "mergify-test-support",
  "serde",
  "serde_json",
- "serde_norway",
+ "serde_yaml_ng",
  "temp-env",
  "tempfile",
  "tokio",
@@ -1826,19 +1826,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_norway"
-version = "0.9.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml-norway",
-]
-
-[[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2154,12 +2141,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "unsafe-libyaml-norway"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,6 +1063,7 @@ name = "mergify-ci"
 version = "0.0.0"
 dependencies = [
  "chrono",
+ "getrandom 0.3.4",
  "mergify-core",
  "mergify-test-support",
  "serde",
@@ -1072,7 +1073,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "url",
- "uuid",
  "wiremock",
 ]
 
@@ -2190,17 +2190,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "1.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
-dependencies = [
- "getrandom 0.4.2",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "uuid-simd"

--- a/crates/mergify-ci/Cargo.toml
+++ b/crates/mergify-ci/Cargo.toml
@@ -12,12 +12,12 @@ publish = false
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
 mergify-core = { path = "../mergify-core" }
+getrandom = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml_ng = "0.10"
 tokio = { version = "1", default-features = false, features = ["rt"] }
 url = "2"
-uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 mergify-test-support = { path = "../mergify-test-support" }

--- a/crates/mergify-ci/src/queue_info.rs
+++ b/crates/mergify-ci/src/queue_info.rs
@@ -48,7 +48,7 @@ fn write_github_output(metadata: &MergeQueueMetadata) -> Result<(), CliError> {
     let Some(path) = env::var("GITHUB_OUTPUT").ok().filter(|s| !s.is_empty()) else {
         return Ok(());
     };
-    let delimiter = format!("ghadelimiter_{}", uuid::Uuid::new_v4());
+    let delimiter = format!("ghadelimiter_{}", random_delimiter_suffix()?);
     let compact = serde_json::to_string(metadata)
         .map_err(|e| CliError::Generic(format!("failed to serialize queue metadata: {e}")))?;
     let mut file = OpenOptions::new()
@@ -59,6 +59,24 @@ fn write_github_output(metadata: &MergeQueueMetadata) -> Result<(), CliError> {
     writeln!(file, "{compact}")?;
     writeln!(file, "{delimiter}")?;
     Ok(())
+}
+
+/// 16 random bytes rendered as 32 lowercase hex chars — enough
+/// entropy to be unguessable inside one GitHub Actions step, which
+/// is all the heredoc delimiter needs (it just has to be absent
+/// from the metadata payload). `getrandom` reads from the OS RNG
+/// directly; we don't need the UUID parsing/formatting plumbing
+/// that `uuid` adds on top.
+fn random_delimiter_suffix() -> Result<String, CliError> {
+    let mut buf = [0u8; 16];
+    getrandom::fill(&mut buf)
+        .map_err(|e| CliError::Generic(format!("OS random source unavailable: {e}")))?;
+    let mut hex = String::with_capacity(buf.len() * 2);
+    for b in buf {
+        use std::fmt::Write as _;
+        write!(hex, "{b:02x}").expect("writing to String is infallible");
+    }
+    Ok(hex)
 }
 
 #[cfg(test)]

--- a/crates/mergify-config/Cargo.toml
+++ b/crates/mergify-config/Cargo.toml
@@ -14,7 +14,7 @@ mergify-core = { path = "../mergify-core" }
 jsonschema = { version = "0.46", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_norway = "0.9"
+serde_yaml_ng = "0.10"
 url = "2"
 
 [dev-dependencies]

--- a/crates/mergify-config/src/validate.rs
+++ b/crates/mergify-config/src/validate.rs
@@ -57,10 +57,10 @@ pub async fn run(explicit_path: Option<&Path>, output: &mut dyn Output) -> Resul
 fn load_yaml(path: &Path) -> Result<serde_json::Value, CliError> {
     let text = std::fs::read_to_string(path)
         .map_err(|e| CliError::Configuration(format!("cannot read {}: {e}", path.display())))?;
-    // Parse as YAML into serde_norway::Value, then convert to JSON
+    // Parse as YAML into serde_yaml_ng::Value, then convert to JSON
     // so jsonschema can validate. The conversion is always lossless
     // for valid Mergify configs (mappings, sequences, scalars).
-    let yaml_value: serde_norway::Value = serde_norway::from_str(&text)
+    let yaml_value: serde_yaml_ng::Value = serde_yaml_ng::from_str(&text)
         .map_err(|e| CliError::Configuration(format!("Invalid YAML in {}: {e}", path.display())))?;
     // Mergify configs are YAML mappings at the top level; an empty
     // file deserializes to Null, which we treat as an empty mapping.


### PR DESCRIPTION
The workspace had two YAML parsers — both forks of the archived
`dtolnay/serde-yaml`. `mergify-config` used `serde_norway` for
`.mergify.yml`; `mergify-ci` used `serde_yaml_ng` for merge-queue
metadata in PR bodies and git notes. Same job, two crates, two
transitive `unsafe-libyaml*` trees in Cargo.lock.

Standardize on `serde_yaml_ng` for both. The decision is grounded
in concrete signal, not vibe:

  Metric                     serde_norway   serde_yaml_ng
  ─────────────────────────  ─────────────  ─────────────
  Reverse-deps on lib.rs     229 (78 dir.)  618 (349 dir.)
  GitHub stars               53             109
  Last commit                2025-08-04     2025-09-14
  Bus factor (recent prs)    1 (solo)       merges externals
  Maintainer statement       v0.9.40 title  README: explicit
                             "I'm gonna       upstream-compat
                              maintain this"  intent
  unsafe-libyaml backend     forked ("…-    canonical
                             norway")
  Open since                 2024-06-10     2024-05-03
  License                    Apache-2.0     MIT (= upstream)

`serde_yaml_ng` wins on every axis that matters for the "will this
still be alive in two years" question: three-times the ecosystem
adoption, more recent activity, accepts third-party PRs, declares
the maintenance commitment in writing, and uses the canonical
`unsafe-libyaml` rather than a parallel-fork backend.

Functional surface is identical for both of our use shapes —
`from_str` to a typed struct for ci, `from_str` to `Value`
then convert to `serde_json::Value` for config validation.
Migration is purely a rename at the one call site.

Cargo.lock drops `serde_norway` and `unsafe-libyaml-norway`.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Depends-On: #1446