### PR TITLE
feat(rust): port `ci scopes` to native Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +587,19 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1064,6 +1087,8 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "getrandom 0.3.4",
+ "globset",
+ "mergify-config",
  "mergify-core",
  "mergify-test-support",
  "serde",

--- a/crates/mergify-ci/Cargo.toml
+++ b/crates/mergify-ci/Cargo.toml
@@ -11,8 +11,10 @@ publish = false
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
-mergify-core = { path = "../mergify-core" }
 getrandom = "0.3"
+globset = "0.4"
+mergify-config = { path = "../mergify-config" }
+mergify-core = { path = "../mergify-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml_ng = "0.10"

--- a/crates/mergify-ci/src/git_refs.rs
+++ b/crates/mergify-ci/src/git_refs.rs
@@ -59,7 +59,12 @@ pub enum ReferencesSource {
 }
 
 impl ReferencesSource {
-    fn as_str(self) -> &'static str {
+    /// Wire-format string for the source provenance. Used in
+    /// emitted JSON / shell / markdown across `git-refs` and
+    /// `scopes`, so the names are part of the CLI's public
+    /// contract.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::Manual => "manual",
             Self::MergeQueue => "merge_queue",

--- a/crates/mergify-ci/src/lib.rs
+++ b/crates/mergify-ci/src/lib.rs
@@ -12,6 +12,7 @@ pub mod git_refs;
 pub mod github_event;
 pub mod queue_info;
 pub mod queue_metadata;
+pub mod scopes_detect;
 pub mod scopes_send;
 pub mod tests_show;
 

--- a/crates/mergify-ci/src/scopes_detect/changed_files.rs
+++ b/crates/mergify-ci/src/scopes_detect/changed_files.rs
@@ -1,0 +1,203 @@
+//! `git diff` between two refs, with progressive deepening of a
+//! shallow clone if no merge base exists yet.
+//!
+//! Mirrors `mergify_cli/ci/scopes/changed_files.py`. The history
+//! deepening is necessary in CI: GitHub Actions checkouts default
+//! to depth=1, and the merge base between `base` and `head`
+//! probably lives further back. We fetch in batches of 100
+//! commits until either a merge base appears or the commit count
+//! stops growing (meaning we've reached the root and there's
+//! genuinely no common ancestor).
+
+use std::process::Command;
+
+use mergify_core::CliError;
+
+/// Scoped namespace for refs we fetch ourselves, to avoid
+/// clashing with `refs/remotes/origin/*` (which may not exist or
+/// may point elsewhere).
+const FETCHED_REF_PREFIX: &str = "refs/mergify-cli/fetched/";
+
+const COMMITS_BATCH_SIZE: u64 = 100;
+
+fn is_sha(ref_: &str) -> bool {
+    // Only full 40-char SHAs — abbreviated SHAs would false-match
+    // branch names like "deadbeef" and cause `git fetch` to treat
+    // them as branches.
+    ref_.len() == 40
+        && ref_
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+}
+
+fn is_local_ref(ref_: &str) -> bool {
+    ref_ == "HEAD" || ref_.starts_with("HEAD~") || ref_.starts_with("HEAD^")
+}
+
+fn local_ref(ref_: &str) -> String {
+    if is_sha(ref_) || is_local_ref(ref_) {
+        ref_.to_string()
+    } else {
+        format!("{FETCHED_REF_PREFIX}{ref_}")
+    }
+}
+
+fn fetch_arg(ref_: &str) -> Option<String> {
+    if is_local_ref(ref_) {
+        None
+    } else if is_sha(ref_) {
+        Some(ref_.to_string())
+    } else {
+        // `git fetch origin <branch>` only updates `FETCH_HEAD`;
+        // use an explicit refspec so the branch becomes a real
+        // local ref we can name later.
+        Some(format!("+{ref_}:{}", local_ref(ref_)))
+    }
+}
+
+fn run_git(args: &[&str]) -> Result<String, CliError> {
+    let out = Command::new("git")
+        .args(args)
+        .output()
+        .map_err(|e| CliError::Generic(format!("failed to spawn `git {args:?}`: {e}")))?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Err(CliError::Generic(format!(
+            "`git {}` failed ({}): {}",
+            args.join(" "),
+            out.status,
+            stderr.trim(),
+        )));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn has_merge_base(base: &str, head: &str) -> bool {
+    Command::new("git")
+        .args(["merge-base", "--", base, head])
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+fn commits_count() -> Result<u64, CliError> {
+    let out = run_git(&["rev-list", "--count", "--all"])?;
+    out.parse::<u64>()
+        .map_err(|e| CliError::Generic(format!("could not parse commit count {out:?}: {e}")))
+}
+
+fn fetch(depth_flag: &str, fetch_args: &[String]) -> Result<(), CliError> {
+    let mut args: Vec<&str> = vec!["fetch", "--no-tags", depth_flag, "origin"];
+    if !fetch_args.is_empty() {
+        args.push("--");
+        for fa in fetch_args {
+            args.push(fa);
+        }
+    }
+    run_git(&args).map(drop)
+}
+
+/// Deepen the local clone until `base` and `head` share an
+/// ancestor (or until we've exhausted history). Returns the
+/// pair of local ref names (`refs/mergify-cli/fetched/<ref>` for
+/// remote names; `HEAD~N` / `HEAD^N` / SHA passed through
+/// untouched) that the subsequent `git diff` should target.
+pub fn ensure_history(base: &str, head: &str) -> Result<(String, String), CliError> {
+    if has_merge_base(base, head) {
+        return Ok((base.to_string(), head.to_string()));
+    }
+
+    let fetch_args: Vec<String> = [fetch_arg(base), fetch_arg(head)]
+        .into_iter()
+        .flatten()
+        .collect();
+    let local_base = local_ref(base);
+    let local_head = local_ref(head);
+    let mut depth = COMMITS_BATCH_SIZE;
+
+    fetch(&format!("--depth={depth}"), &fetch_args)?;
+
+    let mut last_count = commits_count()?;
+    while !has_merge_base(&local_base, &local_head) {
+        depth = depth.saturating_mul(2);
+        fetch(&format!("--deepen={depth}"), &fetch_args)?;
+        let count = commits_count()?;
+        if count == last_count {
+            // No new commits this round — we've reached the root
+            // and the refs genuinely have no common ancestor.
+            if !has_merge_base(&local_base, &local_head) {
+                return Err(CliError::Generic(format!(
+                    "cannot find a common ancestor between {base} and {head}",
+                )));
+            }
+            break;
+        }
+        last_count = count;
+    }
+
+    Ok((local_base, local_head))
+}
+
+/// Names of files changed between `base` and `head`. Uses the
+/// `base...head` (three-dot) diff to compare `head` against
+/// `merge-base(base, head)`, which is what CI scope detection
+/// wants: "files this branch touched on top of trunk."
+pub fn git_changed_files(base: &str, head: &str) -> Result<Vec<String>, CliError> {
+    let (local_base, local_head) = ensure_history(base, head)?;
+    let range = format!("{local_base}...{local_head}");
+    // `--diff-filter=ACMRTD` matches Python: Added, Copied,
+    // Modified, Renamed, Type-changed, Deleted. Excludes
+    // Unmerged (U), Unknown (X), Broken (B).
+    let out = run_git(&["diff", "--name-only", "--diff-filter=ACMRTD", &range, "--"])?;
+    Ok(out
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(ToString::to_string)
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_sha_matches_only_full_40char_lowercase_hex() {
+        assert!(is_sha("0123456789abcdef0123456789abcdef01234567"));
+        // Uppercase rejected (consistent with Python's regex
+        // `^[0-9a-f]{40}$`).
+        assert!(!is_sha("0123456789ABCDEF0123456789ABCDEF01234567"));
+        // Shorter rejected — abbreviated SHAs would false-match
+        // branch names like "deadbeef".
+        assert!(!is_sha("deadbeef"));
+        // Branch name (non-hex char).
+        assert!(!is_sha("main"));
+    }
+
+    #[test]
+    fn local_ref_namespacing() {
+        // HEAD-relative refs pass through untouched.
+        assert_eq!(local_ref("HEAD"), "HEAD");
+        assert_eq!(local_ref("HEAD~1"), "HEAD~1");
+        assert_eq!(local_ref("HEAD^2"), "HEAD^2");
+        // Full SHAs pass through untouched.
+        let sha = "a".repeat(40);
+        assert_eq!(local_ref(&sha), sha);
+        // Branch names get namespaced into our fetched prefix.
+        assert_eq!(local_ref("main"), format!("{FETCHED_REF_PREFIX}main"));
+    }
+
+    #[test]
+    fn fetch_arg_chooses_refspec_for_branches() {
+        // No fetch needed for HEAD-relative refs.
+        assert_eq!(fetch_arg("HEAD"), None);
+        assert_eq!(fetch_arg("HEAD~3"), None);
+        // SHAs get fetched by SHA directly.
+        let sha = "b".repeat(40);
+        assert_eq!(fetch_arg(&sha), Some(sha.clone()));
+        // Branch names use a refspec so the result lands at a
+        // local ref name we can target later in `git diff`.
+        assert_eq!(
+            fetch_arg("main"),
+            Some(format!("+main:{FETCHED_REF_PREFIX}main")),
+        );
+    }
+}

--- a/crates/mergify-ci/src/scopes_detect/config.rs
+++ b/crates/mergify-ci/src/scopes_detect/config.rs
@@ -1,0 +1,223 @@
+//! YAML schema for the `scopes:` block in `.mergify.yml`.
+//!
+//! Mirrors `mergify_cli/ci/scopes/config/scopes.py`. Loaded once
+//! at the top of [`super::run`] from whichever Mergify config the
+//! user pointed at (explicit flag, env var, or auto-detected).
+
+use mergify_core::CliError;
+use serde::Deserialize;
+
+/// Top-level Mergify config: we only care about the `scopes:`
+/// block — every other section (queue rules, pull-request rules,
+/// …) is forwarded to the engine and irrelevant here.
+#[derive(Debug, Default, Deserialize)]
+pub struct MergifyConfig {
+    #[serde(default)]
+    pub scopes: Scopes,
+}
+
+/// The `scopes:` block. Both fields have explicit defaults so a
+/// minimal `scopes: {}` (or no `scopes:` at all) deserializes to
+/// "no sources configured" + the default merge-queue scope name.
+#[derive(Debug, Deserialize)]
+pub struct Scopes {
+    /// Where scopes come from. `None` disables source-based
+    /// detection entirely (the command then only ever reports
+    /// the merge-queue scope, if applicable).
+    #[serde(default)]
+    pub source: Option<Source>,
+
+    /// Scope name automatically applied to merge-queue PRs.
+    /// Defaults to `"merge-queue"`; matches Python. The explicit
+    /// `Default` impl below keeps the constant in one place —
+    /// `#[derive(Default)]` would silently produce `String::new()`
+    /// when the whole `scopes:` block is missing from the YAML.
+    #[serde(default = "default_merge_queue_scope")]
+    pub merge_queue_scope: String,
+}
+
+impl Default for Scopes {
+    fn default() -> Self {
+        Self {
+            source: None,
+            merge_queue_scope: default_merge_queue_scope(),
+        }
+    }
+}
+
+fn default_merge_queue_scope() -> String {
+    "merge-queue".to_string()
+}
+
+/// `source:` is a one-of: either a file-pattern map or the
+/// `manual: null` sentinel that means "scopes are sent via
+/// `scopes-send` or the API directly".
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum Source {
+    Files(SourceFiles),
+    Manual(SourceManual),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceFiles {
+    /// Scope-name → file filters. `BTreeMap` gives us sorted-by-key
+    /// iteration for free — Python sorts scope names before
+    /// printing anyway, so this both matches behavior and keeps the
+    /// human output deterministic without pulling in `indexmap`.
+    pub files: std::collections::BTreeMap<String, FileFilters>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceManual {
+    /// Sentinel field — the YAML literal is `manual: null`. Stored
+    /// as `Option<()>` so the field is optional and explicit-null
+    /// both parse.
+    #[allow(dead_code)]
+    pub manual: Option<()>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FileFilters {
+    /// Glob patterns of files to include. Empty means "include
+    /// everything before exclusions" (matches Python's default
+    /// of `("**/*",)` — we keep the same default here).
+    #[serde(default = "default_include")]
+    pub include: Vec<String>,
+
+    /// Glob patterns of files to exclude. Applied after `include`
+    /// and takes precedence.
+    #[serde(default)]
+    pub exclude: Vec<String>,
+}
+
+fn default_include() -> Vec<String> {
+    vec!["**/*".to_string()]
+}
+
+/// Parse a Mergify config file from `path`, surfacing parse
+/// errors as [`CliError::Configuration`] so the binary exits with
+/// the right code (8) and an obvious "your YAML is broken"
+/// message.
+pub fn load(path: &std::path::Path) -> Result<MergifyConfig, CliError> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| CliError::Configuration(format!("cannot read {}: {e}", path.display())))?;
+    serde_yaml_ng::from_str(&text)
+        .map_err(|e| CliError::Configuration(format!("invalid YAML in {}: {e}", path.display())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(yaml: &str) -> MergifyConfig {
+        serde_yaml_ng::from_str(yaml).expect("yaml parses")
+    }
+
+    #[test]
+    fn empty_yaml_yields_defaults() {
+        // No `scopes:` block at all — the deserializer must still
+        // produce a usable `MergifyConfig` with `source: None` and
+        // the default merge-queue scope name.
+        let cfg: MergifyConfig = parse("{}");
+        assert!(cfg.scopes.source.is_none());
+        assert_eq!(cfg.scopes.merge_queue_scope, "merge-queue");
+    }
+
+    #[test]
+    fn source_files_round_trip() {
+        let cfg = parse(
+            r"
+scopes:
+  source:
+    files:
+      backend:
+        include: ['mergify_cli/**']
+        exclude: ['mergify_cli/tests/**']
+      frontend:
+        include: ['web/**']
+",
+        );
+        let Some(Source::Files(files)) = cfg.scopes.source else {
+            panic!("expected files source");
+        };
+        assert_eq!(files.files.len(), 2);
+        assert_eq!(
+            files.files["backend"].include,
+            vec!["mergify_cli/**".to_string()],
+        );
+        assert_eq!(
+            files.files["backend"].exclude,
+            vec!["mergify_cli/tests/**".to_string()],
+        );
+        assert_eq!(files.files["frontend"].include, vec!["web/**".to_string()]);
+        assert!(files.files["frontend"].exclude.is_empty());
+    }
+
+    #[test]
+    fn source_files_defaults_include_to_everything() {
+        // Mirror Python's `default_factory=lambda: ("**/*",)` —
+        // omitting `include` means "include everything before
+        // exclusions".
+        let cfg = parse(
+            r"
+scopes:
+  source:
+    files:
+      everything:
+        exclude: ['*.md']
+",
+        );
+        let Some(Source::Files(files)) = cfg.scopes.source else {
+            panic!("expected files source");
+        };
+        assert_eq!(files.files["everything"].include, vec!["**/*".to_string()]);
+    }
+
+    #[test]
+    fn source_manual_round_trip() {
+        let cfg = parse(
+            r"
+scopes:
+  source:
+    manual: null
+",
+        );
+        assert!(matches!(cfg.scopes.source, Some(Source::Manual(_))));
+    }
+
+    #[test]
+    fn merge_queue_scope_override() {
+        let cfg = parse(
+            r"
+scopes:
+  merge_queue_scope: mq-bypass
+",
+        );
+        assert_eq!(cfg.scopes.merge_queue_scope, "mq-bypass");
+    }
+
+    #[test]
+    fn unknown_field_in_files_block_rejected() {
+        // `deny_unknown_fields` on `SourceFiles` catches typos
+        // like `file:` instead of `files:` — the parse must fail,
+        // not silently fall back to an empty map.
+        let err = serde_yaml_ng::from_str::<MergifyConfig>(
+            r"
+scopes:
+  source:
+    file:
+      backend: {}
+",
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("did not match any variant") || msg.contains("unknown field"),
+            "unexpected error message: {msg}"
+        );
+    }
+}

--- a/crates/mergify-ci/src/scopes_detect/matching.rs
+++ b/crates/mergify-ci/src/scopes_detect/matching.rs
@@ -1,0 +1,201 @@
+//! Glob-pattern matching: file path → matching scopes.
+//!
+//! Python uses `glob.translate` + `re.fullmatch`; we use `globset`.
+//! The `**` recursive wildcard and the `?` / `[…]` character class
+//! syntax match Python's `glob` semantics for the patterns Mergify
+//! configs actually use (file globs anchored to repo root). One
+//! intentional behavior: a pattern with an empty `include` list
+//! follows Python and matches every path (the scope's exclude list
+//! then decides) — the YAML deserializer fills the default
+//! `["**/*"]` for us, so this fallthrough is mostly defensive.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use globset::GlobBuilder;
+use globset::GlobMatcher;
+use mergify_core::CliError;
+
+use super::config::FileFilters;
+
+/// Pre-built matchers for one scope.
+#[derive(Debug)]
+pub struct ScopeMatcher {
+    pub name: String,
+    include: Vec<GlobMatcher>,
+    exclude: Vec<GlobMatcher>,
+}
+
+impl ScopeMatcher {
+    fn matches(&self, path: &str) -> bool {
+        // Mirrors the Python branch: if both lists are empty the
+        // scope is inert. With the YAML default in place,
+        // `include` is never actually empty here, but the guard is
+        // kept so a programmatic caller with `FileFilters::default
+        // ()` doesn't get every file classified into the scope.
+        if self.include.is_empty() && self.exclude.is_empty() {
+            return false;
+        }
+        let positive = if self.include.is_empty() {
+            true
+        } else {
+            self.include.iter().any(|g| g.is_match(path))
+        };
+        if !positive {
+            return false;
+        }
+        !self.exclude.iter().any(|g| g.is_match(path))
+    }
+}
+
+/// Compile every scope's include/exclude lists once up front so
+/// the per-file loop below isn't doing repeated glob construction.
+pub fn compile(filters: &BTreeMap<String, FileFilters>) -> Result<Vec<ScopeMatcher>, CliError> {
+    filters
+        .iter()
+        .map(|(name, f)| {
+            Ok(ScopeMatcher {
+                name: name.clone(),
+                include: compile_list(name, &f.include)?,
+                exclude: compile_list(name, &f.exclude)?,
+            })
+        })
+        .collect()
+}
+
+fn compile_list(scope: &str, patterns: &[String]) -> Result<Vec<GlobMatcher>, CliError> {
+    patterns.iter().map(|pat| build_glob(scope, pat)).collect()
+}
+
+fn build_glob(scope: &str, pattern: &str) -> Result<GlobMatcher, CliError> {
+    // `literal_separator(false)` makes `*` and `**` cross `/`
+    // boundaries, which is how Python's `glob.translate(...,
+    // recursive=True)` behaves. `case_insensitive(false)` is the
+    // default but stated for the record — file paths are case-
+    // sensitive on the platforms Mergify cares about.
+    GlobBuilder::new(pattern)
+        .literal_separator(false)
+        .case_insensitive(false)
+        .build()
+        .map(|g| g.compile_matcher())
+        .map_err(|e| {
+            CliError::Configuration(format!(
+                "invalid glob {pattern:?} under scope {scope:?}: {e}"
+            ))
+        })
+}
+
+/// Result of routing a set of changed files through every scope
+/// matcher. `hit` is the set of scope names with at least one
+/// match; `by_scope` maps each hit scope to the files that hit
+/// it (used for the verbose `ACTIONS_STEP_DEBUG=true` listing).
+pub struct MatchResult {
+    pub hit: BTreeSet<String>,
+    pub by_scope: BTreeMap<String, Vec<String>>,
+}
+
+pub fn route<'a, I>(files: I, matchers: &[ScopeMatcher]) -> MatchResult
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let mut hit: BTreeSet<String> = BTreeSet::new();
+    let mut by_scope: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for file in files {
+        for m in matchers {
+            if m.matches(file) {
+                hit.insert(m.name.clone());
+                by_scope
+                    .entry(m.name.clone())
+                    .or_default()
+                    .push(file.to_string());
+            }
+        }
+    }
+    MatchResult { hit, by_scope }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn filters(include: &[&str], exclude: &[&str]) -> FileFilters {
+        FileFilters {
+            include: include.iter().map(|s| (*s).to_string()).collect(),
+            exclude: exclude.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    fn compile_one(include: &[&str], exclude: &[&str]) -> Vec<ScopeMatcher> {
+        let mut m = BTreeMap::new();
+        m.insert("s".to_string(), filters(include, exclude));
+        compile(&m).expect("globs compile")
+    }
+
+    #[test]
+    fn double_star_matches_across_path_separators() {
+        // `mergify_cli/**` must catch nested files like
+        // `mergify_cli/ci/scopes/cli.py`. This is the main
+        // expectation of `glob.translate(..., recursive=True)`:
+        // `**` traverses arbitrarily many directories.
+        let ms = compile_one(&["mergify_cli/**"], &[]);
+        let res = route(["mergify_cli/ci/scopes/cli.py"], &ms);
+        assert!(res.hit.contains("s"), "expected hit, got {:?}", res.hit);
+    }
+
+    #[test]
+    fn exclude_takes_precedence_over_include() {
+        // File matches include but also matches exclude — must
+        // NOT be assigned the scope.
+        let ms = compile_one(&["src/**"], &["src/vendor/**"]);
+        let res = route(["src/vendor/legacy.py"], &ms);
+        assert!(res.hit.is_empty(), "unexpected hit: {:?}", res.hit);
+    }
+
+    #[test]
+    fn include_required_when_present() {
+        // A file outside `src/**` must not slip in just because
+        // the exclude list doesn't catch it. (Regression guard
+        // for the "if include is non-empty, file must match it"
+        // branch.)
+        let ms = compile_one(&["src/**"], &["**/tests/**"]);
+        let res = route(["docs/readme.md"], &ms);
+        assert!(res.hit.is_empty(), "unexpected hit: {:?}", res.hit);
+    }
+
+    #[test]
+    fn empty_filters_match_nothing() {
+        // A scope with no include and no exclude is inert — same
+        // as Python's `if not scope_config.include and not
+        // scope_config.exclude: continue` branch. (FileFilters'
+        // default fills include with `["**/*"]` so this case is
+        // only reachable via direct construction.)
+        let ms = compile_one(&[], &[]);
+        let res = route(["anything.py"], &ms);
+        assert!(res.hit.is_empty());
+    }
+
+    #[test]
+    fn multiple_files_aggregate_per_scope() {
+        // Two files matching the same scope both land in
+        // `by_scope`; the scope name appears once in `hit`.
+        let ms = compile_one(&["src/**"], &[]);
+        let res = route(["src/a.py", "src/b.py"], &ms);
+        assert_eq!(res.hit.len(), 1);
+        assert_eq!(
+            res.by_scope.get("s").map(Vec::as_slice),
+            Some(["src/a.py".to_string(), "src/b.py".to_string()].as_slice()),
+        );
+    }
+
+    #[test]
+    fn invalid_glob_surfaces_configuration_error() {
+        // An obviously-bad pattern (unterminated bracket
+        // expression) should fail config validation rather than
+        // crash at match time.
+        let mut m = BTreeMap::new();
+        m.insert("s".to_string(), filters(&["[unterminated"], &[]));
+        let err = compile(&m).unwrap_err();
+        assert!(matches!(err, CliError::Configuration(_)));
+        assert!(err.to_string().contains("invalid glob"), "got {err}");
+    }
+}

--- a/crates/mergify-ci/src/scopes_detect/mod.rs
+++ b/crates/mergify-ci/src/scopes_detect/mod.rs
@@ -1,0 +1,399 @@
+//! `mergify ci scopes` — detect which scopes a build's changes
+//! touch, based on file-pattern rules declared in `.mergify.yml`.
+//!
+//! The command is locally evaluated (no Mergify API call): it
+//! loads the YAML config, figures out the `(base, head)` git
+//! refs, diffs them for changed files, and walks each file
+//! through every scope's include/exclude globs. The output is a
+//! list of "touched" scopes plus a handful of CI-environment
+//! side effects:
+//!
+//! - `$GITHUB_OUTPUT` — JSON dict `{scope: "true"|"false"}` under
+//!   the `scopes` key, written as a multi-line heredoc.
+//! - `$BUILDKITE` is `"true"` — same dict via `buildkite-agent
+//!   meta-data set mergify-ci.scopes`.
+//! - `$GITHUB_STEP_SUMMARY` — markdown table.
+//! - `$BUILDKITE` is `"true"` — markdown via `buildkite-agent
+//!   annotate` at both job and build scope.
+//!
+//! `--write <PATH>` writes a `{"scopes": [...]}` JSON file the
+//! companion `ci scopes-send` command can consume — that's the
+//! shape `DetectedScope` declares.
+
+pub mod changed_files;
+pub mod config;
+pub mod matching;
+pub mod outputs;
+
+use std::env;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+
+use mergify_core::CliError;
+use mergify_core::Output;
+use serde::Serialize;
+
+use crate::git_refs;
+use crate::git_refs::References;
+use crate::git_refs::ReferencesSource;
+
+pub struct ScopesOptions<'a> {
+    /// Explicit `--config <PATH>`. `None` triggers the
+    /// fallback chain (env var `MERGIFY_CONFIG_PATH`, then auto-
+    /// detection of `.mergify.yml` / `.mergify/config.yml` /
+    /// `.github/mergify.yml`).
+    pub config: Option<&'a Path>,
+    /// Optional `--base`. Combined with `--head` to take the
+    /// "manual" References branch.
+    pub base: Option<&'a str>,
+    /// Optional `--head`.
+    pub head: Option<&'a str>,
+    /// `--write/-w <PATH>` — write the detected scopes as JSON
+    /// here. Skipped when `None`.
+    pub write: Option<&'a Path>,
+}
+
+/// Wire-shape consumed by `ci scopes-send --scopes-json`.
+/// Same JSON layout as Python's `DetectedScope` (a single
+/// `scopes` array; the order is sorted because the in-memory
+/// representation is a `BTreeSet`).
+#[derive(Serialize)]
+struct DetectedScope {
+    scopes: Vec<String>,
+}
+
+/// Run the `ci scopes` command.
+//
+// `opts` is taken by value to match every other ported command's
+// `run()` shape — clippy's `needless_pass_by_value` flags it
+// because every field is a `Copy` reference, but flipping to
+// `&ScopesOptions` here would make the dispatch table at the
+// binary boundary asymmetric for no real win.
+#[allow(clippy::needless_pass_by_value)]
+pub fn run(opts: ScopesOptions<'_>, output: &mut dyn Output) -> Result<(), CliError> {
+    let ScopesOptions {
+        config,
+        base,
+        head,
+        write,
+    } = opts;
+    let config_path = resolve_config_path(config)?;
+    let cfg = config::load(&config_path)?;
+
+    let refs = resolve_refs(base, head, output)?;
+    emit_refs_header(&refs, output)?;
+
+    let (all_scopes, mut scopes_hit, by_scope) = detect_scopes(&cfg.scopes, &refs, output)?;
+
+    // Merge-queue scope is additive: it's part of `all_scopes`
+    // unconditionally and gets added to `scopes_hit` only when the
+    // refs came from MQ detection.
+    let mut all_scopes = all_scopes;
+    if !cfg.scopes.merge_queue_scope.is_empty() {
+        all_scopes.insert(cfg.scopes.merge_queue_scope.clone());
+        if refs.source == ReferencesSource::MergeQueue {
+            scopes_hit.insert(cfg.scopes.merge_queue_scope.clone());
+        }
+    }
+
+    emit_scopes_listing(&scopes_hit, &by_scope, output)?;
+
+    outputs::maybe_write_github_outputs(&all_scopes, &scopes_hit)?;
+    outputs::maybe_write_buildkite_metadata(&all_scopes, &scopes_hit)?;
+    outputs::maybe_write_github_step_summary(&refs, &all_scopes, &scopes_hit)?;
+    outputs::maybe_write_buildkite_annotation(&refs, &all_scopes, &scopes_hit);
+
+    if let Some(write_path) = write {
+        write_detected_scopes(write_path, &scopes_hit)?;
+    }
+
+    Ok(())
+}
+
+/// Auto-detection mirrors Python's
+/// `detector.get_mergify_config_path` (which is the same triple
+/// `.mergify.yml`, `.mergify/config.yml`, `.github/mergify.yml`
+/// that `mergify config validate` uses), with `MERGIFY_CONFIG_PATH`
+/// honored ahead of it. Empty env var falls back to auto-detect
+/// — matches Python.
+fn resolve_config_path(explicit: Option<&Path>) -> Result<PathBuf, CliError> {
+    if let Some(path) = explicit {
+        if path.is_file() {
+            return Ok(path.to_path_buf());
+        }
+        return Err(CliError::Configuration(format!(
+            "config file '{}' does not exist",
+            path.display(),
+        )));
+    }
+    if let Ok(env_path) = env::var("MERGIFY_CONFIG_PATH") {
+        if !env_path.is_empty() {
+            let p = PathBuf::from(&env_path);
+            if !p.is_file() {
+                return Err(CliError::Configuration(format!(
+                    "MERGIFY_CONFIG_PATH={env_path} does not point at a regular file",
+                )));
+            }
+            return Ok(p);
+        }
+    }
+    mergify_config::paths::resolve_config_path(None)
+}
+
+/// `(base, head)` resolution mirrors Python's branch in
+/// `scopes/cli.py`:
+///
+/// - At least one of `--base` / `--head` provided → "manual"
+///   source, `head` defaults to `"HEAD"`.
+/// - Neither provided → `git_refs::detect` with the production
+///   notes reader (handles GHA / Buildkite / fallback).
+fn resolve_refs(
+    base: Option<&str>,
+    head: Option<&str>,
+    output: &mut dyn Output,
+) -> Result<References, CliError> {
+    if base.is_some() || head.is_some() {
+        return Ok(References {
+            base: base.map(ToString::to_string),
+            head: head.unwrap_or("HEAD").to_string(),
+            source: ReferencesSource::Manual,
+        });
+    }
+    git_refs::detect(output, &git_refs::real_notes_reader)
+}
+
+/// Print the `Base: … / Head: … / Source: …` header lines via
+/// the status sink (stderr in human mode, no-op in JSON mode).
+/// Matches Python's `click.echo` of the same three lines.
+fn emit_refs_header(refs: &References, output: &mut dyn Output) -> std::io::Result<()> {
+    if let Some(base) = &refs.base {
+        output.status(&format!("Base: {base}"))?;
+    }
+    output.status(&format!("Head: {head}", head = refs.head))?;
+    output.status(&format!("Source: {source}", source = refs.source.as_str()))
+}
+
+type DetectResult = (
+    std::collections::BTreeSet<String>,
+    std::collections::BTreeSet<String>,
+    std::collections::BTreeMap<String, Vec<String>>,
+);
+
+fn detect_scopes(
+    scopes_cfg: &config::Scopes,
+    refs: &References,
+    output: &mut dyn Output,
+) -> Result<DetectResult, CliError> {
+    use std::collections::BTreeMap;
+    use std::collections::BTreeSet;
+
+    match &scopes_cfg.source {
+        None => Ok((BTreeSet::new(), BTreeSet::new(), BTreeMap::new())),
+        Some(config::Source::Manual(_)) => Err(CliError::Configuration(
+            "source `manual` has been set, scopes must be sent with `scopes-send` or API"
+                .to_string(),
+        )),
+        Some(config::Source::Files(files)) => {
+            let all: BTreeSet<String> = files.files.keys().cloned().collect();
+
+            // No base → "select all" branch, no git diff needed.
+            // Matches Python's `if references.base is None`.
+            let Some(base) = refs.base.as_deref() else {
+                output.status("No base provided, selecting all scopes")?;
+                return Ok((all.clone(), all, BTreeMap::new()));
+            };
+
+            let changed = changed_files::git_changed_files(base, &refs.head)?;
+            output.status("Changed files detected:")?;
+            for f in &changed {
+                output.status(&format!("- {f}"))?;
+            }
+            let matchers = matching::compile(&files.files)?;
+            let matching::MatchResult { hit, by_scope } =
+                matching::route(changed.iter().map(String::as_str), &matchers);
+            Ok((all, hit, by_scope))
+        }
+    }
+}
+
+/// Print "Scopes touched:" + sorted scope names, with the
+/// per-file detail under `ACTIONS_STEP_DEBUG=true` (matches
+/// Python's behavior so existing CI verbose-logs read the same).
+fn emit_scopes_listing(
+    hit: &std::collections::BTreeSet<String>,
+    by_scope: &std::collections::BTreeMap<String, Vec<String>>,
+    output: &mut dyn Output,
+) -> Result<(), CliError> {
+    let actions_debug = env::var("ACTIONS_STEP_DEBUG").as_deref() == Ok("true");
+    if hit.is_empty() {
+        output.status("No scopes matched.")?;
+        return Ok(());
+    }
+
+    // Push the "Scopes touched:" block to stdout (so a downstream
+    // pipe captures it) and the per-file dump to stderr — the
+    // primary signal for downstream tooling is the list of
+    // touched scopes.
+    output.emit(&(), &mut |w: &mut dyn Write| {
+        writeln!(w, "Scopes touched:")?;
+        for s in hit {
+            writeln!(w, "- {s}")?;
+        }
+        Ok(())
+    })?;
+
+    if actions_debug {
+        for s in hit {
+            if let Some(files) = by_scope.get(s) {
+                for f in files {
+                    output.status(&format!("    {f}"))?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn write_detected_scopes(
+    path: &Path,
+    scopes: &std::collections::BTreeSet<String>,
+) -> Result<(), CliError> {
+    let payload = DetectedScope {
+        scopes: scopes.iter().cloned().collect(),
+    };
+    let json = serde_json::to_string(&payload)
+        .map_err(|e| CliError::Generic(format!("failed to serialize scopes JSON: {e}")))?;
+    std::fs::write(path, json)
+        .map_err(|e| CliError::Configuration(format!("cannot write {}: {e}", path.display())))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::with_ci_env;
+    use mergify_test_support::Captured;
+
+    #[test]
+    fn resolve_config_path_errors_on_missing_explicit() {
+        let err = resolve_config_path(Some(Path::new("/no/such/file.yml"))).unwrap_err();
+        assert!(matches!(err, CliError::Configuration(_)));
+        assert!(err.to_string().contains("does not exist"));
+    }
+
+    #[test]
+    fn write_detected_scopes_emits_sorted_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = tmp.path().join("scopes.json");
+        let mut set = std::collections::BTreeSet::new();
+        set.insert("zebra".to_string());
+        set.insert("alpha".to_string());
+        write_detected_scopes(&out, &set).unwrap();
+        let raw = std::fs::read_to_string(&out).unwrap();
+        // BTreeSet iteration is sorted; the JSON reflects it.
+        assert_eq!(raw, r#"{"scopes":["alpha","zebra"]}"#);
+    }
+
+    #[test]
+    fn run_selects_all_when_no_base_provided() {
+        // Hermetic mirror of the live smoke test
+        // `test_ci_scopes_select_all_when_no_base`: with
+        // `--head HEAD` and no `--base`, the command takes the
+        // "select all scopes" branch and reports every
+        // configured scope as touched. No git operations.
+        //
+        // The `with_ci_env` wrapper scrubs `GITHUB_OUTPUT` so a
+        // GHA runner executing the suite doesn't see `run()`
+        // append a heredoc to its real step-output file (which
+        // would break the runner step with "Matching delimiter
+        // not found").
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tmp.path().join("mergify.yml");
+        std::fs::write(
+            &cfg,
+            "scopes:\n  source:\n    files:\n      backend:\n        include: ['src/**']\n      frontend:\n        include: ['web/**']\n",
+        )
+        .unwrap();
+        let mut cap = Captured::human();
+        with_ci_env(&[], || {
+            run(
+                ScopesOptions {
+                    config: Some(&cfg),
+                    base: None,
+                    head: Some("HEAD"),
+                    write: None,
+                },
+                &mut cap.output,
+            )
+            .unwrap();
+        });
+        let combined = cap.stdout() + &cap.stderr();
+        for scope in ["backend", "frontend"] {
+            assert!(combined.contains(scope), "missing scope: {combined}");
+        }
+        assert!(combined.contains("No base provided"));
+    }
+
+    #[test]
+    fn run_errors_on_manual_source() {
+        // `source: manual` is the "scopes-send / API only" mode;
+        // running `ci scopes` against that config must abort
+        // with a clear message (matches Python's
+        // `ScopesError("source `manual` has been set ...")`).
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tmp.path().join("mergify.yml");
+        std::fs::write(&cfg, "scopes:\n  source:\n    manual: null\n").unwrap();
+        let mut cap = Captured::human();
+        let err = with_ci_env(&[], || {
+            run(
+                ScopesOptions {
+                    config: Some(&cfg),
+                    base: None,
+                    head: Some("HEAD"),
+                    write: None,
+                },
+                &mut cap.output,
+            )
+            .unwrap_err()
+        });
+        assert!(matches!(err, CliError::Configuration(_)));
+        assert!(err.to_string().contains("scopes-send"), "got {err}");
+    }
+
+    #[test]
+    fn run_writes_json_when_write_set() {
+        // `--write <PATH>` writes a `{"scopes": [...]}` JSON
+        // file the companion `ci scopes-send --scopes-json`
+        // consumes. The no-base "select all" path is the easiest
+        // way to populate scopes_hit without git operations.
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tmp.path().join("mergify.yml");
+        std::fs::write(
+            &cfg,
+            "scopes:\n  source:\n    files:\n      a:\n        include: ['*']\n      b:\n        include: ['*']\n",
+        )
+        .unwrap();
+        let out = tmp.path().join("detected.json");
+        let mut cap = Captured::human();
+        with_ci_env(&[], || {
+            run(
+                ScopesOptions {
+                    config: Some(&cfg),
+                    base: None,
+                    head: Some("HEAD"),
+                    write: Some(&out),
+                },
+                &mut cap.output,
+            )
+            .unwrap();
+        });
+        let raw = std::fs::read_to_string(&out).unwrap();
+        // BTreeSet ordering → alphabetical scopes in the file.
+        // `merge-queue` is also added because the default
+        // `merge_queue_scope` lands in `all_scopes` regardless.
+        // But `scopes_hit` only includes it when the refs source
+        // is MergeQueue, which isn't the case here.
+        assert_eq!(raw, r#"{"scopes":["a","b"]}"#);
+    }
+}

--- a/crates/mergify-ci/src/scopes_detect/outputs.rs
+++ b/crates/mergify-ci/src/scopes_detect/outputs.rs
@@ -1,0 +1,298 @@
+//! Side-effect emitters for `ci scopes`: GHA outputs, Buildkite
+//! metadata, GitHub step summary, Buildkite annotation.
+//!
+//! All four mirror their Python counterparts in
+//! `mergify_cli/ci/scopes/cli.py` and stay quiet when their
+//! respective environment knob is absent.
+
+use std::collections::BTreeSet;
+use std::env;
+use std::fmt::Write as _;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Stdio;
+
+use mergify_core::CliError;
+
+use crate::git_refs::References;
+
+const GITHUB_ACTIONS_OUTPUT_NAME: &str = "scopes";
+const BUILDKITE_SCOPES_METADATA_KEY: &str = "mergify-ci.scopes";
+const BUILDKITE_ANNOTATION_CONTEXT: &str = "mergify-ci-scopes";
+
+/// Build the GHA-style scopes payload: `{scope: "true"|"false"}`
+/// with stable string-valued booleans. Mirrors Python's
+/// "GHA outputs are strings; copying a bool through workflows
+/// converts to the literal string `false|true`, so we make it a
+/// string up front to avoid the user-visible mismatch."
+fn scopes_dict_json(all: &BTreeSet<String>, hit: &BTreeSet<String>) -> String {
+    // Build by hand so the key order is the sorted ordering from
+    // the BTreeSet — `serde_json::Map` randomizes hash maps and
+    // a serialized object's key order would drift between runs.
+    let mut out = String::from("{");
+    for (i, scope) in all.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        // `serde_json::to_string` on a `&str` quotes + escapes per
+        // JSON rules — safer than manual `\"{scope}\"` for scope
+        // names with control characters (the schema disallows
+        // them, but defense in depth costs nothing).
+        let key = serde_json::to_string(scope).expect("scope name serializes");
+        let value = if hit.contains(scope) { "true" } else { "false" };
+        let _ = write!(&mut out, "{key}: \"{value}\"");
+    }
+    out.push('}');
+    out
+}
+
+/// Append `scopes<<delimiter\n{json}\ndelimiter\n` to
+/// `$GITHUB_OUTPUT` when the env var is set. No-op otherwise.
+pub fn maybe_write_github_outputs(
+    all: &BTreeSet<String>,
+    hit: &BTreeSet<String>,
+) -> Result<(), CliError> {
+    let Some(path) = env::var("GITHUB_OUTPUT").ok().filter(|s| !s.is_empty()) else {
+        return Ok(());
+    };
+    let delimiter = format!("ghadelimiter_{}", random_delimiter_suffix()?);
+    let payload = scopes_dict_json(all, hit);
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(PathBuf::from(path))?;
+    writeln!(file, "{GITHUB_ACTIONS_OUTPUT_NAME}<<{delimiter}")?;
+    writeln!(file, "{payload}")?;
+    writeln!(file, "{delimiter}")?;
+    Ok(())
+}
+
+/// `buildkite-agent meta-data set mergify-ci.scopes <json>` when
+/// `$BUILDKITE` is `"true"`. No-op otherwise.
+pub fn maybe_write_buildkite_metadata(
+    all: &BTreeSet<String>,
+    hit: &BTreeSet<String>,
+) -> Result<(), CliError> {
+    if env::var("BUILDKITE").as_deref() != Ok("true") {
+        return Ok(());
+    }
+    let payload = scopes_dict_json(all, hit);
+    let status = Command::new("buildkite-agent")
+        .args(["meta-data", "set", BUILDKITE_SCOPES_METADATA_KEY, &payload])
+        .status()
+        .map_err(|e| CliError::Generic(format!("failed to spawn `buildkite-agent`: {e}")))?;
+    if !status.success() {
+        return Err(CliError::Generic(format!(
+            "`buildkite-agent meta-data set` exited with status {status}",
+        )));
+    }
+    Ok(())
+}
+
+fn build_summary_markdown(
+    refs: &References,
+    all: &BTreeSet<String>,
+    hit: &BTreeSet<String>,
+) -> String {
+    let mut md = String::from("## Mergify CI Scope Matching Results");
+    if let Some(base) = refs.base.as_deref() {
+        // Python truncates each ref to 7 chars (git's standard
+        // abbreviated SHA). When the ref is shorter than 7 chars
+        // (e.g. `HEAD`) we'd panic; clamp the slice length.
+        let base_short = &base[..base.len().min(7)];
+        let head_short = &refs.head[..refs.head.len().min(7)];
+        let source = refs.source.as_str();
+        let _ = write!(
+            &mut md,
+            " for `{base_short}...{head_short}` (source: `{source}`)",
+        );
+    }
+    md.push_str("\n\n| 🎯 Scope | ✅ Match |\n|:--|:--|\n");
+    for scope in all {
+        let emoji = if hit.contains(scope) { "✅" } else { "❌" };
+        let _ = writeln!(&mut md, "| `{scope}` | {emoji} |");
+    }
+    md
+}
+
+/// Append the scope-matching markdown table to
+/// `$GITHUB_STEP_SUMMARY` when the env var is set. No-op
+/// otherwise.
+pub fn maybe_write_github_step_summary(
+    refs: &References,
+    all: &BTreeSet<String>,
+    hit: &BTreeSet<String>,
+) -> Result<(), CliError> {
+    let Some(path) = env::var("GITHUB_STEP_SUMMARY")
+        .ok()
+        .filter(|s| !s.is_empty())
+    else {
+        return Ok(());
+    };
+    let md = build_summary_markdown(refs, all, hit);
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(PathBuf::from(path))?;
+    file.write_all(md.as_bytes())?;
+    Ok(())
+}
+
+/// `buildkite-agent annotate` with the same markdown, at both job
+/// and build scope. Failures are non-fatal — warns on stderr and
+/// continues, matching Python. The repeated context guarantees
+/// re-runs update in place rather than duplicate.
+pub fn maybe_write_buildkite_annotation(
+    refs: &References,
+    all: &BTreeSet<String>,
+    hit: &BTreeSet<String>,
+) {
+    if env::var("BUILDKITE").as_deref() != Ok("true") {
+        return;
+    }
+    let md = build_summary_markdown(refs, all, hit);
+    for (scope_label, extra_arg) in &[("job", Some("--scope=job")), ("build", None)] {
+        let mut cmd = Command::new("buildkite-agent");
+        cmd.args([
+            "annotate",
+            "--style",
+            "info",
+            "--context",
+            BUILDKITE_ANNOTATION_CONTEXT,
+        ]);
+        if let Some(arg) = extra_arg {
+            cmd.arg(arg);
+        }
+        let result = cmd
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn();
+        let mut child = match result {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!(
+                    "warning: failed to spawn buildkite-agent annotate ({scope_label} scope): {e}",
+                );
+                continue;
+            }
+        };
+        if let Some(mut stdin) = child.stdin.take() {
+            if let Err(e) = stdin.write_all(md.as_bytes()) {
+                eprintln!(
+                    "warning: failed to pipe markdown to buildkite-agent annotate \
+                     ({scope_label} scope): {e}",
+                );
+                // fall through to wait() so the child is reaped
+            }
+        }
+        let output = match child.wait_with_output() {
+            Ok(o) => o,
+            Err(e) => {
+                eprintln!(
+                    "warning: failed to wait for buildkite-agent annotate \
+                     ({scope_label} scope): {e}",
+                );
+                continue;
+            }
+        };
+        if !output.status.success() {
+            let detail = String::from_utf8_lossy(&output.stderr);
+            eprintln!(
+                "warning: failed to write Buildkite annotation ({scope_label} scope): {}",
+                detail.trim(),
+            );
+        }
+    }
+}
+
+/// 32 random hex chars from the OS RNG. Same approach as
+/// `ci queue-info` for the heredoc delimiter — `uuid` would do
+/// the job but carries more crate surface than we need for a
+/// throwaway delimiter.
+fn random_delimiter_suffix() -> Result<String, CliError> {
+    let mut buf = [0u8; 16];
+    getrandom::fill(&mut buf)
+        .map_err(|e| CliError::Generic(format!("OS random source unavailable: {e}")))?;
+    let mut hex = String::with_capacity(buf.len() * 2);
+    for b in buf {
+        let _ = write!(hex, "{b:02x}");
+    }
+    Ok(hex)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::git_refs::ReferencesSource;
+
+    fn refs(base: Option<&str>, head: &str, source: ReferencesSource) -> References {
+        References {
+            base: base.map(ToString::to_string),
+            head: head.to_string(),
+            source,
+        }
+    }
+
+    #[test]
+    fn scopes_dict_json_keys_sorted_alphabetically() {
+        let all: BTreeSet<String> = ["zebra", "alpha", "mid"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        let hit: BTreeSet<String> = ["mid"].iter().map(|s| (*s).to_string()).collect();
+        let out = scopes_dict_json(&all, &hit);
+        // BTreeSet sorts; the JSON must reflect that.
+        assert_eq!(
+            out,
+            r#"{"alpha": "false", "mid": "true", "zebra": "false"}"#,
+        );
+    }
+
+    #[test]
+    fn summary_markdown_omits_range_when_no_base() {
+        // `ci scopes --head HEAD` (no `--base`) takes the
+        // "select all" branch; the markdown should still render
+        // but skip the `for `……` (source: …)` suffix because
+        // there's no range to point at.
+        let r = refs(None, "HEAD", ReferencesSource::Manual);
+        let all: BTreeSet<String> = ["a", "b"].iter().map(|s| (*s).to_string()).collect();
+        let hit: BTreeSet<String> = ["a"].iter().map(|s| (*s).to_string()).collect();
+        let md = build_summary_markdown(&r, &all, &hit);
+        assert!(
+            md.starts_with("## Mergify CI Scope Matching Results\n\n"),
+            "got:\n{md}",
+        );
+        assert!(md.contains("| `a` | ✅ |"), "got:\n{md}");
+        assert!(md.contains("| `b` | ❌ |"), "got:\n{md}");
+    }
+
+    #[test]
+    fn summary_markdown_includes_range_when_base_present() {
+        let r = refs(
+            Some("0123456789abcdef0123456789abcdef01234567"),
+            "fedcba9876543210fedcba9876543210fedcba98",
+            ReferencesSource::GithubEventPullRequest,
+        );
+        let all: BTreeSet<String> = ["a"].iter().map(|s| (*s).to_string()).collect();
+        let hit: BTreeSet<String> = BTreeSet::new();
+        let md = build_summary_markdown(&r, &all, &hit);
+        assert!(
+            md.contains("for `0123456...fedcba9` (source: `github_event_pull_request`)"),
+            "got:\n{md}",
+        );
+    }
+
+    #[test]
+    fn summary_markdown_short_ref_does_not_panic() {
+        // `HEAD` and `HEAD^` are shorter than 7 chars; the slice
+        // must clamp instead of panicking. Regression guard for
+        // `&base[..7]` on short refs.
+        let r = refs(Some("HEAD^"), "HEAD", ReferencesSource::Manual);
+        let all: BTreeSet<String> = ["a"].iter().map(|s| (*s).to_string()).collect();
+        let hit = BTreeSet::new();
+        let _md = build_summary_markdown(&r, &all, &hit);
+    }
+}

--- a/crates/mergify-cli/Cargo.toml
+++ b/crates/mergify-cli/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 mergify-ci = { path = "../mergify-ci" }
 mergify-config = { path = "../mergify-config" }
 mergify-core = { path = "../mergify-core" }

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -142,6 +142,7 @@ fn inject_global_flags(debug: bool, argv: Vec<String>) -> Vec<String> {
 const NATIVE_COMMANDS: &[(&str, &str)] = &[
     ("config", "validate"),
     ("config", "simulate"),
+    ("ci", "scopes"),
     ("ci", "scopes-send"),
     ("ci", "git-refs"),
     ("ci", "queue-info"),
@@ -161,6 +162,7 @@ const NATIVE_COMMANDS: &[(&str, &str)] = &[
 enum NativeCommand {
     ConfigValidate { config_file: Option<PathBuf> },
     ConfigSimulate(ConfigSimulateOpts),
+    CiScopes(CiScopesOpts),
     CiScopesSend(CiScopesSendOpts),
     CiGitRefs { format: GitRefsFormat },
     CiQueueInfo,
@@ -180,6 +182,13 @@ struct ConfigSimulateOpts {
     pull_request: PullRequestRef,
     token: Option<String>,
     api_url: Option<String>,
+}
+
+struct CiScopesOpts {
+    config: Option<PathBuf>,
+    base: Option<String>,
+    head: Option<String>,
+    write: Option<PathBuf>,
 }
 
 struct CiScopesSendOpts {
@@ -365,11 +374,19 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
             Dispatch::Shim(inject_global_flags(debug, prepend_one("stack", args)))
         }
         Subcommands::Ci(CiArgs {
-            command: CiSubcommand::Scopes(ShimmedArgs { args }),
-        }) => Dispatch::Shim(inject_global_flags(
-            debug,
-            prepend_two("ci", "scopes", args),
-        )),
+            command:
+                CiSubcommand::Scopes(ScopesCliArgs {
+                    config,
+                    base,
+                    head,
+                    write,
+                }),
+        }) => Dispatch::Native(NativeCommand::CiScopes(CiScopesOpts {
+            config,
+            base,
+            head,
+            write,
+        })),
         Subcommands::Ci(CiArgs {
             command: CiSubcommand::JunitProcess(ShimmedArgs { args }),
         }) => Dispatch::Shim(inject_global_flags(
@@ -666,6 +683,16 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
             NativeCommand::CiQueueInfo => {
                 mergify_ci::queue_info::run(&mut output).map(|()| mergify_core::ExitCode::Success)
             }
+            NativeCommand::CiScopes(opts) => mergify_ci::scopes_detect::run(
+                mergify_ci::scopes_detect::ScopesOptions {
+                    config: opts.config.as_deref(),
+                    base: opts.base.as_deref(),
+                    head: opts.head.as_deref(),
+                    write: opts.write.as_deref(),
+                },
+                &mut output,
+            )
+            .map(|()| mergify_core::ExitCode::Success),
             NativeCommand::TestsShow(opts) => {
                 mergify_ci::tests_show::run(
                     TestsShowOptions {
@@ -905,7 +932,7 @@ enum CiSubcommand {
     #[command(name = "queue-info")]
     QueueInfo,
     /// Give the list of scopes impacted by changed files.
-    Scopes(ShimmedArgs),
+    Scopes(ScopesCliArgs),
     /// Upload `JUnit` XML reports and ignore failed tests with
     /// Mergify's CI Insights Quarantine.
     #[command(name = "junit-process")]
@@ -926,6 +953,29 @@ struct GitRefsCliArgs {
         value_parser = mergify_ci::git_refs::Format::parse,
     )]
     format: GitRefsFormat,
+}
+
+#[derive(clap::Args)]
+struct ScopesCliArgs {
+    /// Path to YAML config file. Falls back to
+    /// ``MERGIFY_CONFIG_PATH`` env var, then auto-detects
+    /// `.mergify.yml`, `.mergify/config.yml`, or
+    /// `.github/mergify.yml`.
+    #[arg(long, env = "MERGIFY_CONFIG_PATH")]
+    config: Option<PathBuf>,
+
+    /// Base git reference to use to look for changed files.
+    #[arg(long)]
+    base: Option<String>,
+
+    /// Head git reference to use to look for changed files.
+    #[arg(long)]
+    head: Option<String>,
+
+    /// Write the detected scopes to a file (JSON, consumed by
+    /// `ci scopes-send --scopes-json`).
+    #[arg(long = "write", short = 'w')]
+    write: Option<PathBuf>,
 }
 
 #[derive(clap::Args)]
@@ -1288,12 +1338,12 @@ mod tests {
 
     #[test]
     fn shimmed_dispatch_reinjects_debug_for_ci_subcommand() {
-        // The two-token shim paths (`ci scopes`, `ci junit-process`,
+        // The remaining two-token shim paths (`ci junit-process`,
         // `ci junit-upload`) need the same treatment as the
         // single-token `stack` shim — every shim arm must re-inject
-        // `--debug` so the Python side honors it.
+        // `--debug` so the Python side honors it. `ci scopes` is now
+        // native and follows the native dispatch path.
         for (group, sub, tail) in &[
-            ("ci", "scopes", vec!["--base", "main"]),
             ("ci", "junit-process", vec!["--files", "a.xml"]),
             ("ci", "junit-upload", vec!["--files", "a.xml"]),
         ] {


### PR DESCRIPTION
`mergify ci scopes` is now handled by the Rust binary: load the
`.mergify.yml` `scopes:` block, resolve `(base, head)` via the
existing `git_refs::detect` machinery (or `--base`/`--head` for
"manual" mode), shell out to `git diff` for changed files, and
route each path through every scope's include/exclude globs to
produce the touched-scope set.

The implementation lands in `mergify-ci::scopes_detect` as a
five-file module:

  - `config.rs` — YAML schema (`Scopes` / `Source::Files` / `Source::Manual`
    / `FileFilters`), with `BTreeMap` for sorted iteration that
    keeps human output deterministic without `indexmap`.
  - `matching.rs` — `globset`-backed file → scope routing, with
    Python-equivalent `**` recursive semantics
    (`literal_separator(false)`).
  - `changed_files.rs` — `git diff base...head --name-only
    --diff-filter=ACMRTD`, with the progressive `--deepen`
    fetching dance Python uses to dig out a merge base on shallow
    CI clones.
  - `outputs.rs` — side effects: `$GITHUB_OUTPUT` JSON dict,
    `buildkite-agent meta-data set`, `$GITHUB_STEP_SUMMARY`
    markdown table, `buildkite-agent annotate` at job + build
    scope. Each one is a no-op when its environment knob isn't
    set.
  - `mod.rs` — the `run()` entry point plus the
    `--write <PATH>` JSON emitter consumed by
    `ci scopes-send --scopes-json`.

Wired into the binary as a real `Subcommands::Ci(CiSubcommand::
Scopes(...))` variant (replacing the previous shim stub) and
added to `NATIVE_COMMANDS`. clap gains the `env` feature so
`MERGIFY_CONFIG_PATH` is honored on `--config` directly. Adds
`globset` and a workspace-internal edge `mergify-ci →
mergify-config` for the auto-detection of `.mergify.yml` /
`.mergify/config.yml` / `.github/mergify.yml`. Also makes
`git_refs::ReferencesSource::as_str` public so the markdown
emitter can reuse the wire-format names without re-encoding the
mapping.

Live smoke test from the previous commit
(`test_ci_scopes_select_all_when_no_base`) now exercises the
Rust binary's "no base provided" branch end-to-end. 88
`mergify-ci` unit tests pass (was 75; +13 for `scopes_detect`).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>