### PR TITLE
fix(stack): prevent stale notes ref lease on push

### DIFF
--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -96,25 +96,50 @@ def format_pull_description(
     return message + depends_on_header
 
 
+async def _merge_remote_notes(remote: str) -> None:
+    """Fetch and merge the remote notes ref into the local one."""
+    tmp_ref = "refs/notes/mergify/stack-incoming"
+    await utils.git(
+        "fetch",
+        remote,
+        "--no-write-fetch-head",
+        f"+{NOTES_REF}:{tmp_ref}",
+    )
+    try:
+        await utils.git(
+            "notes",
+            f"--ref={NOTES_REF}",
+            "merge",
+            "--strategy=union",
+            tmp_ref,
+        )
+    finally:
+        try:
+            await utils.git("update-ref", "-d", tmp_ref)
+        except utils.CommandError:
+            pass
+
+
 async def fetch_notes_ref(remote: str) -> bool:
-    """Fetch ``refs/notes/mergify/stack`` from *remote* when the local ref
-    does not already exist.
+    """Fetch ``refs/notes/mergify/stack`` from *remote*.
 
     Returns True when the local ref is present (either pre-existing or
     newly fetched) so a lease SHA is available for the subsequent push.
     Returns False only on first push (ref absent both locally and remotely).
 
-    If the local ref already exists (e.g. from a prior ``stack note`` that
-    hasn't been pushed yet), the fetch is skipped to avoid clobbering
-    unpushed local notes. A divergent remote is then caught by the
-    ``--force-with-lease`` check at push time.
+    When the local ref already exists (e.g. from a prior ``stack note``),
+    the remote notes are merged in so the lease SHA stays current while
+    preserving any unpushed local notes.
     """
     try:
         await utils.git("rev-parse", "--verify", NOTES_REF)
     except utils.CommandError:
         pass
     else:
-        # Local ref exists; don't overwrite.
+        try:
+            await _merge_remote_notes(remote)
+        except utils.CommandError:
+            pass
         return True
 
     try:

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -2487,21 +2487,33 @@ async def test_stack_push_fetches_notes_ref(
     )
 
 
-async def test_fetch_notes_ref_skips_fetch_when_local_ref_exists(
+async def test_fetch_notes_ref_merges_when_local_ref_exists(
     git_mock: test_utils.GitMock,
 ) -> None:
-    """fetch_notes_ref returns True without fetching when the local ref already exists."""
+    """fetch_notes_ref merges remote notes when the local ref already exists."""
     git_mock.mock("rev-parse", "--verify", "refs/notes/mergify/stack", output="abc123")
 
-    result = await push.fetch_notes_ref("origin")
+    with mock.patch.object(push, "_merge_remote_notes") as merge_mock:
+        result = await push.fetch_notes_ref("origin")
 
     assert result is True
-    assert not git_mock.has_been_called_with(
-        "fetch",
-        "origin",
-        "--no-write-fetch-head",
-        "refs/notes/mergify/stack:refs/notes/mergify/stack",
-    )
+    merge_mock.assert_awaited_once_with("origin")
+
+
+async def test_fetch_notes_ref_merge_failure_is_non_fatal(
+    git_mock: test_utils.GitMock,
+) -> None:
+    """fetch_notes_ref returns True even when the remote merge fails."""
+    git_mock.mock("rev-parse", "--verify", "refs/notes/mergify/stack", output="abc123")
+
+    with mock.patch.object(
+        push,
+        "_merge_remote_notes",
+        side_effect=utils.CommandError(("fetch",), 1, b"network error"),
+    ):
+        result = await push.fetch_notes_ref("origin")
+
+    assert result is True
 
 
 async def test_push_branches_pushes_notes_ref_atomically(


### PR DESCRIPTION
When another push updates refs/notes/mergify/stack between our fetch
and push, --force-with-lease fails. Fix the root cause: fetch_notes_ref
now merges remote notes (via git notes merge --strategy=union) when the
local ref already exists, keeping the lease SHA current while preserving
any unpushed local notes from `stack note`.

Closes: MRGFY-7397

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>