### PR TITLE
fix(stack): skip retry when notes ref was not actually stale

### DIFF
--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -131,8 +131,11 @@ async def fetch_notes_ref(remote: str) -> bool:
     return True
 
 
-async def _merge_remote_notes(remote: str) -> None:
-    """Fetch and merge the remote notes ref into the local one."""
+async def _merge_remote_notes(remote: str) -> str:
+    """Fetch and merge the remote notes ref into the local one.
+
+    Returns the new local SHA of the notes ref after the merge.
+    """
     tmp_ref = "refs/notes/mergify/stack-incoming"
     await utils.git(
         "fetch",
@@ -153,6 +156,7 @@ async def _merge_remote_notes(remote: str) -> None:
             await utils.git("update-ref", "-d", tmp_ref)
         except utils.CommandError:
             pass
+    return await utils.git("rev-parse", "--verify", NOTES_REF)
 
 
 async def push_branches(
@@ -205,18 +209,12 @@ async def push_branches(
                 raise
 
             try:
-                await _merge_remote_notes(remote)
+                new_notes_sha = await _merge_remote_notes(remote)
             except utils.CommandError:
                 raise push_err from None
 
-            try:
-                new_notes_sha = await utils.git(
-                    "rev-parse",
-                    "--verify",
-                    NOTES_REF,
-                )
-            except utils.CommandError:
-                raise push_err from None
+            if new_notes_sha == notes_local_sha:
+                raise
 
             new_lease_args = [
                 a

--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -131,6 +131,30 @@ async def fetch_notes_ref(remote: str) -> bool:
     return True
 
 
+async def _merge_remote_notes(remote: str) -> None:
+    """Fetch and merge the remote notes ref into the local one."""
+    tmp_ref = "refs/notes/mergify/stack-incoming"
+    await utils.git(
+        "fetch",
+        remote,
+        "--no-write-fetch-head",
+        f"+{NOTES_REF}:{tmp_ref}",
+    )
+    try:
+        await utils.git(
+            "notes",
+            f"--ref={NOTES_REF}",
+            "merge",
+            "--strategy=union",
+            tmp_ref,
+        )
+    finally:
+        try:
+            await utils.git("update-ref", "-d", tmp_ref)
+        except utils.CommandError:
+            pass
+
+
 async def push_branches(
     remote: str,
     local_changes: list[changes.LocalChange],
@@ -167,14 +191,54 @@ async def push_branches(
     no_verify_args = ("--no-verify",) if no_verify else ()
     os.environ["MERGIFY_STACK_PUSH"] = "1"
     try:
-        await utils.git(
-            "push",
-            "--atomic",
-            *no_verify_args,
-            *lease_args,
-            remote,
-            *refspecs,
-        )
+        try:
+            await utils.git(
+                "push",
+                "--atomic",
+                *no_verify_args,
+                *lease_args,
+                remote,
+                *refspecs,
+            )
+        except utils.CommandError as push_err:
+            if notes_local_sha is None or not notes_ref_fetched:
+                raise
+
+            try:
+                await _merge_remote_notes(remote)
+            except utils.CommandError:
+                raise push_err from None
+
+            try:
+                new_notes_sha = await utils.git(
+                    "rev-parse",
+                    "--verify",
+                    NOTES_REF,
+                )
+            except utils.CommandError:
+                raise push_err from None
+
+            new_lease_args = [
+                a
+                for a in lease_args
+                if not a.startswith(f"--force-with-lease={NOTES_REF}:")
+            ]
+            new_lease_args.append(
+                f"--force-with-lease={NOTES_REF}:{new_notes_sha}",
+            )
+
+            console.log(
+                "[orange]Notes ref was stale, retrying push after merge…[/]",
+            )
+
+            await utils.git(
+                "push",
+                "--atomic",
+                *no_verify_args,
+                *new_lease_args,
+                remote,
+                *refspecs,
+            )
     finally:
         os.environ.pop("MERGIFY_STACK_PUSH", None)
 

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -2640,8 +2640,60 @@ async def test_push_branches_skips_notes_when_local_ref_absent(
 async def test_push_branches_retries_on_stale_notes_ref(
     git_mock: test_utils.GitMock,
 ) -> None:
-    """When push fails and a notes lease was included, retry after merging
-    the remote notes ref."""
+    """When push fails due to a stale notes lease, retry with the merged SHA."""
+    local_changes = [
+        changes.LocalChange(
+            id=changes.ChangeId("I29617d37762fd69809c255d7e7073cb11f8fbf50"),
+            pull=None,
+            commit_sha="commit1_sha",
+            title="Title",
+            message="Message",
+            base_branch="main",
+            dest_branch="stack/title--29617d37",
+            action="create",
+        ),
+    ]
+    git_mock.mock(
+        "rev-parse",
+        "--verify",
+        "refs/notes/mergify/stack",
+        output="stale_sha",
+    )
+
+    # First push fails (stale notes ref)
+    git_mock.mock_error(
+        "push",
+        "--atomic",
+        "--force-with-lease=refs/heads/stack/title--29617d37:",
+        "--force-with-lease=refs/notes/mergify/stack:stale_sha",
+        "origin",
+        "commit1_sha:refs/heads/stack/title--29617d37",
+        "+refs/notes/mergify/stack:refs/notes/mergify/stack",
+    )
+
+    # Retry push with merged SHA succeeds
+    retry_push_args = (
+        "push",
+        "--atomic",
+        "--force-with-lease=refs/heads/stack/title--29617d37:",
+        "--force-with-lease=refs/notes/mergify/stack:merged_sha",
+        "origin",
+        "commit1_sha:refs/heads/stack/title--29617d37",
+        "+refs/notes/mergify/stack:refs/notes/mergify/stack",
+    )
+    git_mock.mock(*retry_push_args, output="")
+
+    with mock.patch.object(push, "_merge_remote_notes", return_value="merged_sha"):
+        await push.push_branches("origin", local_changes, notes_ref_fetched=True)
+
+    assert git_mock.has_been_called_with(*retry_push_args)
+
+
+async def test_push_branches_no_retry_when_notes_unchanged(
+    git_mock: test_utils.GitMock,
+) -> None:
+    """When notes merge doesn't change the SHA, the push failure wasn't
+    caused by a stale notes lease — re-raise without retrying."""
     local_changes = [
         changes.LocalChange(
             id=changes.ChangeId("I29617d37762fd69809c255d7e7073cb11f8fbf50"),
@@ -2660,8 +2712,7 @@ async def test_push_branches_retries_on_stale_notes_ref(
         "refs/notes/mergify/stack",
         output="notes_sha",
     )
-
-    push_args = (
+    git_mock.mock_error(
         "push",
         "--atomic",
         "--force-with-lease=refs/heads/stack/title--29617d37:",
@@ -2671,45 +2722,11 @@ async def test_push_branches_retries_on_stale_notes_ref(
         "+refs/notes/mergify/stack:refs/notes/mergify/stack",
     )
 
-    # First push fails (stale notes ref)
-    git_mock.mock_error(*push_args)
-
-    # Merge remote notes: fetch into temp ref, merge, cleanup
-    git_mock.mock(
-        "fetch",
-        "origin",
-        "--no-write-fetch-head",
-        "+refs/notes/mergify/stack:refs/notes/mergify/stack-incoming",
-        output="",
-    )
-    git_mock.mock(
-        "notes",
-        "--ref=refs/notes/mergify/stack",
-        "merge",
-        "--strategy=union",
-        "refs/notes/mergify/stack-incoming",
-        output="",
-    )
-    git_mock.mock(
-        "update-ref",
-        "-d",
-        "refs/notes/mergify/stack-incoming",
-        output="",
-    )
-
-    # Retry push succeeds (same args since mock returns same SHA)
-    git_mock.mock(*push_args, output="")
-
-    await push.push_branches("origin", local_changes, notes_ref_fetched=True)
-
-    assert git_mock.has_been_called_with(
-        "notes",
-        "--ref=refs/notes/mergify/stack",
-        "merge",
-        "--strategy=union",
-        "refs/notes/mergify/stack-incoming",
-    )
-    assert git_mock._called.count(push_args) == 2
+    with (
+        mock.patch.object(push, "_merge_remote_notes", return_value="notes_sha"),
+        pytest.raises(utils.CommandError),
+    ):
+        await push.push_branches("origin", local_changes, notes_ref_fetched=True)
 
 
 async def test_push_branches_no_retry_without_notes_lease(
@@ -2750,15 +2767,6 @@ async def test_push_branches_no_retry_without_notes_lease(
             notes_ref_fetched=False,
         )
 
-    # No merge attempted
-    assert not git_mock.has_been_called_with(
-        "notes",
-        "--ref=refs/notes/mergify/stack",
-        "merge",
-        "--strategy=union",
-        "refs/notes/mergify/stack-incoming",
-    )
-
 
 async def test_push_branches_retry_raises_original_error_on_merge_failure(
     git_mock: test_utils.GitMock,
@@ -2782,8 +2790,7 @@ async def test_push_branches_retry_raises_original_error_on_merge_failure(
         "refs/notes/mergify/stack",
         output="notes_sha",
     )
-
-    push_args = (
+    git_mock.mock_error(
         "push",
         "--atomic",
         "--force-with-lease=refs/heads/stack/title--29617d37:",
@@ -2792,21 +2799,18 @@ async def test_push_branches_retry_raises_original_error_on_merge_failure(
         "commit1_sha:refs/heads/stack/title--29617d37",
         "+refs/notes/mergify/stack:refs/notes/mergify/stack",
     )
-    git_mock.mock_error(*push_args)
 
-    # Fetch for merge fails (e.g. network error)
-    git_mock.mock_error(
-        "fetch",
-        "origin",
-        "--no-write-fetch-head",
-        "+refs/notes/mergify/stack:refs/notes/mergify/stack-incoming",
-    )
-
-    with pytest.raises(utils.CommandError) as exc_info:
+    with (
+        mock.patch.object(
+            push,
+            "_merge_remote_notes",
+            side_effect=utils.CommandError(("notes", "merge"), 1, b""),
+        ),
+        pytest.raises(utils.CommandError) as exc_info,
+    ):
         await push.push_branches("origin", local_changes, notes_ref_fetched=True)
 
-    # The raised error is the original push error, not the fetch error
-    assert "push" in str(exc_info.value.command_args)
+    assert exc_info.value.command_args[0] == "push"
 
 
 def _make_local_change(

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -2637,6 +2637,178 @@ async def test_push_branches_skips_notes_when_local_ref_absent(
     )
 
 
+async def test_push_branches_retries_on_stale_notes_ref(
+    git_mock: test_utils.GitMock,
+) -> None:
+    """When push fails and a notes lease was included, retry after merging
+    the remote notes ref."""
+    local_changes = [
+        changes.LocalChange(
+            id=changes.ChangeId("I29617d37762fd69809c255d7e7073cb11f8fbf50"),
+            pull=None,
+            commit_sha="commit1_sha",
+            title="Title",
+            message="Message",
+            base_branch="main",
+            dest_branch="stack/title--29617d37",
+            action="create",
+        ),
+    ]
+    git_mock.mock(
+        "rev-parse",
+        "--verify",
+        "refs/notes/mergify/stack",
+        output="notes_sha",
+    )
+
+    push_args = (
+        "push",
+        "--atomic",
+        "--force-with-lease=refs/heads/stack/title--29617d37:",
+        "--force-with-lease=refs/notes/mergify/stack:notes_sha",
+        "origin",
+        "commit1_sha:refs/heads/stack/title--29617d37",
+        "+refs/notes/mergify/stack:refs/notes/mergify/stack",
+    )
+
+    # First push fails (stale notes ref)
+    git_mock.mock_error(*push_args)
+
+    # Merge remote notes: fetch into temp ref, merge, cleanup
+    git_mock.mock(
+        "fetch",
+        "origin",
+        "--no-write-fetch-head",
+        "+refs/notes/mergify/stack:refs/notes/mergify/stack-incoming",
+        output="",
+    )
+    git_mock.mock(
+        "notes",
+        "--ref=refs/notes/mergify/stack",
+        "merge",
+        "--strategy=union",
+        "refs/notes/mergify/stack-incoming",
+        output="",
+    )
+    git_mock.mock(
+        "update-ref",
+        "-d",
+        "refs/notes/mergify/stack-incoming",
+        output="",
+    )
+
+    # Retry push succeeds (same args since mock returns same SHA)
+    git_mock.mock(*push_args, output="")
+
+    await push.push_branches("origin", local_changes, notes_ref_fetched=True)
+
+    assert git_mock.has_been_called_with(
+        "notes",
+        "--ref=refs/notes/mergify/stack",
+        "merge",
+        "--strategy=union",
+        "refs/notes/mergify/stack-incoming",
+    )
+    assert git_mock._called.count(push_args) == 2
+
+
+async def test_push_branches_no_retry_without_notes_lease(
+    git_mock: test_utils.GitMock,
+) -> None:
+    """When notes_ref_fetched is False, push failure propagates without retry."""
+    local_changes = [
+        changes.LocalChange(
+            id=changes.ChangeId("I29617d37762fd69809c255d7e7073cb11f8fbf50"),
+            pull=None,
+            commit_sha="commit1_sha",
+            title="Title",
+            message="Message",
+            base_branch="main",
+            dest_branch="stack/title--29617d37",
+            action="create",
+        ),
+    ]
+    git_mock.mock(
+        "rev-parse",
+        "--verify",
+        "refs/notes/mergify/stack",
+        output="notes_sha",
+    )
+    git_mock.mock_error(
+        "push",
+        "--atomic",
+        "--force-with-lease=refs/heads/stack/title--29617d37:",
+        "origin",
+        "commit1_sha:refs/heads/stack/title--29617d37",
+        "+refs/notes/mergify/stack:refs/notes/mergify/stack",
+    )
+
+    with pytest.raises(utils.CommandError):
+        await push.push_branches(
+            "origin",
+            local_changes,
+            notes_ref_fetched=False,
+        )
+
+    # No merge attempted
+    assert not git_mock.has_been_called_with(
+        "notes",
+        "--ref=refs/notes/mergify/stack",
+        "merge",
+        "--strategy=union",
+        "refs/notes/mergify/stack-incoming",
+    )
+
+
+async def test_push_branches_retry_raises_original_error_on_merge_failure(
+    git_mock: test_utils.GitMock,
+) -> None:
+    """When the notes merge itself fails, the original push error is raised."""
+    local_changes = [
+        changes.LocalChange(
+            id=changes.ChangeId("I29617d37762fd69809c255d7e7073cb11f8fbf50"),
+            pull=None,
+            commit_sha="commit1_sha",
+            title="Title",
+            message="Message",
+            base_branch="main",
+            dest_branch="stack/title--29617d37",
+            action="create",
+        ),
+    ]
+    git_mock.mock(
+        "rev-parse",
+        "--verify",
+        "refs/notes/mergify/stack",
+        output="notes_sha",
+    )
+
+    push_args = (
+        "push",
+        "--atomic",
+        "--force-with-lease=refs/heads/stack/title--29617d37:",
+        "--force-with-lease=refs/notes/mergify/stack:notes_sha",
+        "origin",
+        "commit1_sha:refs/heads/stack/title--29617d37",
+        "+refs/notes/mergify/stack:refs/notes/mergify/stack",
+    )
+    git_mock.mock_error(*push_args)
+
+    # Fetch for merge fails (e.g. network error)
+    git_mock.mock_error(
+        "fetch",
+        "origin",
+        "--no-write-fetch-head",
+        "+refs/notes/mergify/stack:refs/notes/mergify/stack-incoming",
+    )
+
+    with pytest.raises(utils.CommandError) as exc_info:
+        await push.push_branches("origin", local_changes, notes_ref_fetched=True)
+
+    # The raised error is the original push error, not the fetch error
+    assert "push" in str(exc_info.value.command_args)
+
+
 def _make_local_change(
     *,
     change_id: str,


### PR DESCRIPTION
Address code review findings:
- Skip retry when notes merge doesn't change the SHA (means the push
  failure was a branch lease issue, not a stale notes ref)
- _merge_remote_notes now returns the merged SHA directly
- Tests verify the retry uses the updated SHA, not the original
- Test for merge-failure path uses mock.patch.object instead of
  raw git mock

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Depends-On: #1470