### PR TITLE
chore(plugin): polish description for marketplace listing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "mergify",
       "source": "./",
-      "description": "Mergify CLI integration for stacked PRs, merge queues, CI insights, scheduled freezes, and configuration management"
+      "description": "Skills for the Mergify CLI: manage merge queues, stacked pull requests, Test Insights (flaky tests, quarantine), merge protections, and Mergify configuration directly from the terminal."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mergify",
-  "description": "Mergify CLI integration for stacked PRs, merge queues, CI insights, scheduled freezes, and configuration management",
+  "description": "Skills for the Mergify CLI: manage merge queues, stacked pull requests, Test Insights (flaky tests, quarantine), merge protections, and Mergify configuration directly from the terminal.",
   "author": {
     "name": "Mergify"
   },
@@ -10,6 +10,9 @@
     "stacked-prs",
     "merge-queue",
     "ci",
+    "test-insights",
+    "flaky-tests",
+    "quarantine",
     "freeze",
     "config",
     "push",
@@ -20,5 +23,6 @@
     "workflow"
   ],
   "license": "Apache-2.0",
+  "homepage": "https://mergify.com",
   "repository": "https://github.com/Mergifyio/mergify-cli"
 }


### PR DESCRIPTION
Rewrite the description in plugin.json and marketplace.json to accurately
describe what the plugin's skills enable: managing merge queues, stacked
pull requests, CI Insights (flaky tests, quarantine), merge protections,
and Mergify configuration via the Mergify CLI.

Add `homepage` and three keywords (ci-insights, flaky-tests, quarantine)
that match what users search for in the plugin directory.

Skip the `version` field. Per the plugin docs, when `version` is omitted
the commit SHA is used and every commit counts as a new version. That
is what we want for this repo: plugin updates track the CLI release
cadence automatically, without a separate semver bump process.

Validated locally with `claude plugin validate --strict`.

Prep for submission to anthropics/claude-plugins-community.