### PR TITLE
feat(stack): port the local-commits walker to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,6 +1158,7 @@ dependencies = [
  "mergify-freeze",
  "mergify-py-shim",
  "mergify-queue",
+ "mergify-stack",
  "regex",
  "serde_json",
  "serde_yaml_ng",
@@ -1234,6 +1235,17 @@ dependencies = [
  "tokio",
  "url",
  "wiremock",
+]
+
+[[package]]
+name = "mergify-stack"
+version = "0.0.0"
+dependencies = [
+ "mergify-core",
+ "regex",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/mergify-cli/Cargo.toml
+++ b/crates/mergify-cli/Cargo.toml
@@ -22,9 +22,11 @@ mergify-core = { path = "../mergify-core" }
 mergify-freeze = { path = "../mergify-freeze" }
 mergify-py-shim = { path = "../mergify-py-shim" }
 mergify-queue = { path = "../mergify-queue" }
-# Only used by the `_internal junit-parse` Python migration helper.
-# Remove this dep when the Python side of `junit-process` goes away
-# and the `InternalJunitParse` native arm is deleted.
+mergify-stack = { path = "../mergify-stack" }
+# Used by Python-migration helpers (`_internal junit-parse`,
+# `_internal stack-local-commits`). When the last `_internal`
+# subcommand goes away — i.e. every stack subcommand is native —
+# this dep can be dropped too.
 serde_json = "1.0"
 tokio = { version = "1", default-features = false, features = ["macros", "rt", "time"] }
 

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -165,6 +165,7 @@ const NATIVE_COMMANDS: &[(&str, &str)] = &[
     // the `Subcommands::Internal` variant).
     ("_internal", "junit-parse"),
     ("_internal", "junit-upload"),
+    ("_internal", "stack-local-commits"),
 ];
 
 /// Native commands the Rust binary handles without delegating to
@@ -206,6 +207,13 @@ enum NativeCommand {
     /// Wire format is not stable; only the Python code shipped in
     /// this wheel may consume it.
     InternalJunitUpload(InternalJunitUploadOpts),
+    /// `_internal stack-local-commits --base <sha> --head <ref>` —
+    /// Python migration helper. Runs `git log` for the stack
+    /// range, parses each commit's `Change-Id:` trailer, prints
+    /// the result as a JSON array. Used by `mergify_cli/stack/changes.py`
+    /// while the surrounding stack discovery logic is still
+    /// Python. Wire format is not stable.
+    InternalStackLocalCommits(InternalStackLocalCommitsOpts),
 }
 
 struct InternalJunitUploadOpts {
@@ -218,6 +226,12 @@ struct InternalJunitUploadOpts {
     mergify_test_job_name: Option<String>,
     quarantined: Vec<String>,
     files: Vec<PathBuf>,
+}
+
+struct InternalStackLocalCommitsOpts {
+    base: String,
+    head: String,
+    repo_dir: Option<PathBuf>,
 }
 
 struct ConfigSimulateOpts {
@@ -461,6 +475,20 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
                 mergify_test_job_name,
                 quarantined,
                 files,
+            },
+        )),
+        Subcommands::Internal(InternalArgs {
+            command:
+                InternalSubcommand::StackLocalCommits(InternalStackLocalCommitsArgs {
+                    base,
+                    head,
+                    repo_dir,
+                }),
+        }) => Dispatch::Native(NativeCommand::InternalStackLocalCommits(
+            InternalStackLocalCommitsOpts {
+                base,
+                head,
+                repo_dir,
             },
         )),
         Subcommands::Ci(CiArgs {
@@ -1041,6 +1069,25 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 .map_err(|e| mergify_core::CliError::Generic(e.to_string()))?;
                 Ok(mergify_core::ExitCode::Success)
             }
+            NativeCommand::InternalStackLocalCommits(opts) => {
+                // Run `git log` for the stack range, parse each
+                // commit's `Change-Id:` trailer, emit a JSON array
+                // on stdout. The Python `stack/changes.py` consumer
+                // deserializes it back into the existing `LocalChange`
+                // pipeline. A missing Change-Id propagates as
+                // `CliError::InvalidState` so Python sees the same
+                // exit code it would have raised inline.
+                let repo_dir = mergify_stack::local_commits::resolve_repo_dir(opts.repo_dir);
+                let commits =
+                    mergify_stack::local_commits::read(&repo_dir, &opts.base, &opts.head)?;
+                let json = serde_json::to_string(&commits).map_err(|e| {
+                    mergify_core::CliError::Generic(format!(
+                        "serialize stack-local-commits output: {e}",
+                    ))
+                })?;
+                println!("{json}");
+                Ok(mergify_core::ExitCode::Success)
+            }
         }
     });
 
@@ -1134,6 +1181,13 @@ enum InternalSubcommand {
     /// upload path; not a stable user-facing surface.
     #[command(name = "junit-upload")]
     JunitUpload(InternalJunitUploadArgs),
+    /// Walk the local stack commits in `<base>..<head>` and print
+    /// a JSON array of `{commit_sha, title, message, change_id}`.
+    /// Used by the Python side of `mergify stack <cmd>` during
+    /// migration to centralise the `git log` + `Change-Id:`
+    /// extraction. Not a stable user-facing surface.
+    #[command(name = "stack-local-commits")]
+    StackLocalCommits(InternalStackLocalCommitsArgs),
 }
 
 #[derive(clap::Args)]
@@ -1178,6 +1232,22 @@ struct InternalJunitUploadArgs {
     /// `JUnit` XML files to parse and upload spans for.
     #[arg(value_name = "FILE", required = true, num_args = 1..)]
     files: Vec<PathBuf>,
+}
+
+#[derive(clap::Args)]
+struct InternalStackLocalCommitsArgs {
+    /// Base revision — anything `git` accepts (typically a merge-
+    /// base SHA). The range is exclusive of this commit.
+    #[arg(long)]
+    base: String,
+    /// Head revision — typically the local stack branch name.
+    /// The range is inclusive of this commit.
+    #[arg(long)]
+    head: String,
+    /// Repository working tree to run `git` in. Defaults to the
+    /// process CWD.
+    #[arg(long = "repo-dir", value_name = "DIR")]
+    repo_dir: Option<PathBuf>,
 }
 
 #[derive(clap::Args)]

--- a/crates/mergify-stack/Cargo.toml
+++ b/crates/mergify-stack/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "mergify-stack"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Native implementation of `mergify stack` subcommands."
+publish = false
+
+[dependencies]
+mergify-core = { path = "../mergify-core" }
+regex = "1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[dev-dependencies]
+tempfile = "3.14"
+
+[lints]
+workspace = true

--- a/crates/mergify-stack/src/change_id.rs
+++ b/crates/mergify-stack/src/change_id.rs
@@ -1,0 +1,200 @@
+//! `Change-Id` parsing helpers.
+//!
+//! Mergify tags each stacked commit with a `Change-Id: I<40-hex>`
+//! trailer in the commit message body — that ID is what pins a
+//! local commit to its remote branch + PR across rewrites. The
+//! Python code mirrored by this module ships three flavours of
+//! the same value:
+//!
+//! - the full I-prefixed 40-hex Change-Id (`I000…aaa`)
+//! - a "prefix" that may be partial (typed by the user on the CLI)
+//! - an 8-hex "short" form embedded in the new-style branch name
+//!   suffix `…--abcd1234`
+//!
+//! Extraction from a commit body uses a deliberately permissive
+//! regex (`[0-9a-z]` not `[0-9a-f]`) so a malformed trailer still
+//! surfaces and `is_full` can flag it; validation is strict.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// Permissive pattern used when *finding* a Change-Id trailer in a
+/// commit body. Stays loose (`[0-9a-z]`, not `[0-9a-f]`) so a
+/// malformed `Change-Id: Ixxxg…` still gets pulled out, lets the
+/// caller see what was written instead of silently returning
+/// `None`.
+const CHANGEID_LOOSE_PATTERN: &str = r"I[0-9a-z]{40}";
+
+/// Strict full-form pattern: I + 40 lowercase hex chars.
+const CHANGEID_FULL_PATTERN: &str = r"^I[0-9a-f]{40}$";
+
+/// Suffix pattern: `--<8 hex>` at end of a string. Used to peel
+/// the short Change-Id out of new-style branch segments.
+const SHORT_CHANGEID_PATTERN: &str = r"--([0-9a-f]{8})$";
+
+static CHANGEID_TRAILER_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(&format!(r"Change-Id: ({CHANGEID_LOOSE_PATTERN})")).unwrap());
+
+static CHANGEID_FULL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(CHANGEID_FULL_PATTERN).unwrap());
+
+static SHORT_CHANGEID_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(SHORT_CHANGEID_PATTERN).unwrap());
+
+/// Return `true` if `value` is a strict, full-form Change-Id
+/// (`I` + 40 lowercase hex chars).
+#[must_use]
+pub fn is_full(value: &str) -> bool {
+    CHANGEID_FULL_RE.is_match(value)
+}
+
+/// Return `true` if `prefix` could be the start of a Change-Id.
+/// Requires at least two characters (the leading `I` plus one hex
+/// digit) so a bare `"I"` doesn't qualify. Used by the CLI to let
+/// users target a stack commit by typing only the first few
+/// characters of its Change-Id.
+#[must_use]
+pub fn is_prefix(prefix: &str) -> bool {
+    let bytes = prefix.as_bytes();
+    bytes.len() >= 2
+        && bytes[0] == b'I'
+        && bytes[1..]
+            .iter()
+            .all(|c| c.is_ascii_digit() || (b'a'..=b'f').contains(c))
+}
+
+/// Extract the *last* `Change-Id: …` trailer from a commit
+/// message body. Returns `None` if no trailer is present. The
+/// returned value is the raw match — callers that want strictness
+/// should pass it through [`is_full`].
+///
+/// "Last" matters: Mergify rewrites tend to append a new trailer
+/// rather than replace, and the most recent one wins.
+#[must_use]
+pub fn extract_from_message(message: &str) -> Option<&str> {
+    CHANGEID_TRAILER_RE
+        .captures_iter(message)
+        .last()
+        .map(|cap| cap.get(1).unwrap().as_str())
+}
+
+/// Extract a Change-Id from the last segment of a stack branch
+/// name. Returns either:
+///
+/// - the **full** Change-Id (old-style branch, the segment *is*
+///   a Change-Id, 41 chars `I…`), or
+/// - the **short** 8-hex tail (new-style branch, segment ends in
+///   `--xxxxxxxx`).
+///
+/// Callers need both because remote branches in the wild can be
+/// either shape. The matching layer ([`crate::change_id`]
+/// callers in `changes.py`) handles the cross-format pairing.
+#[must_use]
+pub fn extract_from_branch_segment(segment: &str) -> Option<&str> {
+    if is_full(segment) {
+        return Some(segment);
+    }
+    SHORT_CHANGEID_RE
+        .captures(segment)
+        .map(|cap| cap.get(1).unwrap().as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_full_accepts_well_formed_id() {
+        let id = "I0123456789abcdef0123456789abcdef01234567";
+        assert!(is_full(id));
+    }
+
+    #[test]
+    fn is_full_rejects_uppercase_hex_and_wrong_length_and_wrong_prefix() {
+        // Hex chars must be lowercase.
+        assert!(!is_full("I0123456789ABCDEF0123456789abcdef01234567"));
+        // Off-by-one — 39 hex.
+        assert!(!is_full("I0123456789abcdef0123456789abcdef0123456"));
+        // Off-by-one — 41 hex.
+        assert!(!is_full("I0123456789abcdef0123456789abcdef012345678"));
+        // Missing leading I.
+        assert!(!is_full("0123456789abcdef0123456789abcdef01234567"));
+        // Empty.
+        assert!(!is_full(""));
+    }
+
+    #[test]
+    fn is_prefix_accepts_partial_id_with_at_least_one_hex() {
+        assert!(is_prefix("Ia"));
+        assert!(is_prefix("I0"));
+        assert!(is_prefix("Iabc123"));
+    }
+
+    #[test]
+    fn is_prefix_rejects_bare_i_and_non_hex_chars() {
+        // Bare "I" — Python requires at least two chars so a stray
+        // capital I doesn't accidentally match.
+        assert!(!is_prefix("I"));
+        // Non-hex after the I.
+        assert!(!is_prefix("Ig"));
+        assert!(!is_prefix("Iaz"));
+        // Empty.
+        assert!(!is_prefix(""));
+        // No leading I.
+        assert!(!is_prefix("abc"));
+    }
+
+    #[test]
+    fn extract_from_message_returns_last_trailer_when_multiple() {
+        // Commits get rewritten and amends sometimes append a new
+        // trailer instead of replacing — the rightmost one wins.
+        let msg = "subject\n\nChange-Id: Iaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nChange-Id: Ibbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n";
+        assert_eq!(
+            extract_from_message(msg),
+            Some("Ibbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        );
+    }
+
+    #[test]
+    fn extract_from_message_returns_none_when_missing() {
+        assert_eq!(extract_from_message("subject\n\nbody"), None);
+    }
+
+    #[test]
+    fn extract_from_message_uses_loose_pattern_so_callers_can_flag_typos() {
+        // `g` is outside [0-9a-f] but inside [0-9a-z]. The
+        // extractor still surfaces it so the caller can run it
+        // through `is_full` and report "looks like a Change-Id but
+        // isn't valid hex". Silently dropping it would make the
+        // error message useless.
+        let msg = "Change-Id: Igggggggggggggggggggggggggggggggggggggggg";
+        let extracted = extract_from_message(msg).expect("loose match");
+        assert!(!is_full(extracted));
+    }
+
+    #[test]
+    fn extract_from_branch_segment_returns_full_id_for_old_style() {
+        let id = "I0123456789abcdef0123456789abcdef01234567";
+        assert_eq!(extract_from_branch_segment(id), Some(id));
+    }
+
+    #[test]
+    fn extract_from_branch_segment_returns_short_tail_for_new_style() {
+        // `mergify stack push` slugifies the commit title and
+        // appends `--<8 hex>` for human readability.
+        assert_eq!(
+            extract_from_branch_segment("my-slug--abcd1234"),
+            Some("abcd1234"),
+        );
+    }
+
+    #[test]
+    fn extract_from_branch_segment_returns_none_for_unrelated_segments() {
+        assert_eq!(extract_from_branch_segment(""), None);
+        assert_eq!(extract_from_branch_segment("plain-segment"), None);
+        // Has the right shape but wrong length on the short tail.
+        assert_eq!(extract_from_branch_segment("slug--abcd123"), None);
+        assert_eq!(extract_from_branch_segment("slug--abcd12345"), None);
+    }
+}

--- a/crates/mergify-stack/src/lib.rs
+++ b/crates/mergify-stack/src/lib.rs
@@ -1,0 +1,14 @@
+//! Native pieces of `mergify stack`, ported from
+//! `mergify_cli/stack/`.
+//!
+//! Today this crate ships the stack-discovery walker that backs
+//! every stack subcommand: read the local commits in
+//! `<base>..<head>`, parse each commit's `Change-Id:` trailer,
+//! and return one structured record per commit. The Python side
+//! reaches it via the hidden `_internal stack-local-commits`
+//! subcommand on the `mergify` binary; once `mergify stack list`
+//! itself is native the same module is reused without the
+//! subprocess hop.
+
+pub mod change_id;
+pub mod local_commits;

--- a/crates/mergify-stack/src/local_commits.rs
+++ b/crates/mergify-stack/src/local_commits.rs
@@ -1,0 +1,326 @@
+//! Walk the local commits in `<base>..<head>` and emit one
+//! structured record per commit.
+//!
+//! Used by every stack subcommand as the first step: read what's
+//! locally in the stack, paired with each commit's `Change-Id:`
+//! trailer (the stable identity that survives rewrites and pairs
+//! a local commit with its remote branch + PR).
+//!
+//! The on-disk shape comes straight from
+//! `git log --reverse --format=%H%x00%s%x00%b%x1e <range>`:
+//! one record per commit, fields separated by `NUL` (`\x00`),
+//! records by ASCII Record Separator (`\x1e`). Picking control
+//! bytes avoids the quoting tax of `--format=` with shell-safe
+//! delimiters and the parser is a fixed-shape split rather than
+//! line-aware reading.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use mergify_core::CliError;
+use serde::Serialize;
+
+use crate::change_id;
+
+/// One commit in the local stack range, after parsing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LocalCommit {
+    /// Full 40-hex commit SHA.
+    pub commit_sha: String,
+    /// Commit subject line (the `%s` field).
+    pub title: String,
+    /// Full commit message body — caller-facing because some
+    /// stack commands need to surface it (e.g. the revision
+    /// history rendering reads it back). Mirrors Python's
+    /// `commit_infos` tuple shape.
+    pub message: String,
+    /// The trailing `Change-Id:` value extracted from `message`.
+    /// Always present in a `LocalCommit` — a commit missing the
+    /// trailer fails the walk early so partial results never
+    /// reach the caller.
+    pub change_id: String,
+}
+
+/// Run `git log` in `repo_dir` and parse its output into one
+/// [`LocalCommit`] per commit in `<base>..<head>`.
+///
+/// `base` is anything `git` accepts as a revision (typically a
+/// merge-base SHA); `head` is the local stack branch name (or
+/// any revision). The range is **exclusive** of `base` and
+/// **inclusive** of `head`, matching git's `..` semantics.
+///
+/// Errors:
+///
+/// - [`CliError::Generic`] for git invocation failures (process
+///   spawn errors, git exiting non-zero, unparseable output).
+/// - [`CliError::InvalidState`] when a commit in the range has no
+///   `Change-Id:` trailer. Mirrors Python's
+///   `console_error(...); sys.exit(ExitCode.INVALID_STATE)` flow.
+pub fn read(repo_dir: &Path, base: &str, head: &str) -> Result<Vec<LocalCommit>, CliError> {
+    let raw = run_git_log(repo_dir, base, head)?;
+    parse(&raw)
+}
+
+fn run_git_log(repo_dir: &Path, base: &str, head: &str) -> Result<String, CliError> {
+    let range = format!("{base}..{head}");
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_dir)
+        .args([
+            "log",
+            "--reverse",
+            // `%H` SHA, `%x00` NUL, `%s` subject, `%x00` NUL,
+            // `%b` body, `%x1e` ASCII RS terminator.
+            "--format=%H%x00%s%x00%b%x1e",
+            &range,
+        ])
+        .output()
+        .map_err(|e| CliError::Generic(format!("failed to spawn `git log`: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(CliError::Generic(format!(
+            "`git log {range}` failed: {}",
+            if stderr.is_empty() {
+                "no stderr".to_string()
+            } else {
+                stderr
+            },
+        )));
+    }
+
+    String::from_utf8(output.stdout)
+        .map_err(|e| CliError::Generic(format!("`git log` output is not UTF-8: {e}")))
+}
+
+/// Parse the raw `git log` payload (NUL/RS separated) into
+/// [`LocalCommit`] records. Exposed separately from [`read`] so
+/// the format-handling can be unit-tested without spawning git.
+pub fn parse(raw: &str) -> Result<Vec<LocalCommit>, CliError> {
+    let mut out = Vec::new();
+    for record in raw.split('\x1e') {
+        let stripped = record.trim();
+        if stripped.is_empty() {
+            continue;
+        }
+        let mut parts = stripped.splitn(3, '\x00');
+        let commit_sha = parts
+            .next()
+            .ok_or_else(|| malformed_record(stripped))?
+            .trim()
+            .to_string();
+        let title = parts
+            .next()
+            .ok_or_else(|| malformed_record(stripped))?
+            .trim()
+            .to_string();
+        let message = parts
+            .next()
+            .ok_or_else(|| malformed_record(stripped))?
+            .trim()
+            .to_string();
+
+        let change_id = change_id::extract_from_message(&message)
+            .ok_or_else(|| {
+                // Mirrors Python's `console_error` + INVALID_STATE
+                // exit. The CLI surface (`_internal stack-local-commits`)
+                // appends the helpful "did you run `mergify stack
+                // setup`?" hint in the binary wrapper.
+                CliError::InvalidState(format!(
+                    "`Change-Id:` line is missing on commit {commit_sha}",
+                ))
+            })?
+            .to_string();
+
+        out.push(LocalCommit {
+            commit_sha,
+            title,
+            message,
+            change_id,
+        });
+    }
+    Ok(out)
+}
+
+fn malformed_record(record: &str) -> CliError {
+    CliError::Generic(format!("Unexpected git log record format: {record:?}"))
+}
+
+/// Type alias used by the binary wrapper when emitting the
+/// `_internal stack-local-commits` JSON output.
+pub type LocalCommits = Vec<LocalCommit>;
+
+/// Resolve `repo_dir` argument. Defaults to the process CWD when
+/// the caller doesn't pass an explicit value — the typical
+/// invocation is from `mergify stack <cmd>` running inside the
+/// user's clone.
+#[must_use]
+pub fn resolve_repo_dir(arg: Option<PathBuf>) -> PathBuf {
+    arg.unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(sha: &str, title: &str, body: &str) -> String {
+        // Same wire shape git emits with our `--format` spec: NUL
+        // between fields, RS terminator after the body.
+        format!("{sha}\x00{title}\x00{body}\x1e")
+    }
+
+    #[test]
+    fn parse_returns_commits_in_input_order() {
+        // `--reverse` means oldest first; we just trust git's
+        // ordering and check that we don't reorder it ourselves.
+        let raw = record(
+            "aaaa111111111111111111111111111111111111",
+            "first",
+            "body1\n\nChange-Id: Iaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ) + &record(
+            "bbbb222222222222222222222222222222222222",
+            "second",
+            "body2\n\nChange-Id: Ibbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        );
+        let commits = parse(&raw).unwrap();
+        assert_eq!(commits.len(), 2);
+        assert_eq!(commits[0].title, "first");
+        assert_eq!(
+            commits[0].commit_sha,
+            "aaaa111111111111111111111111111111111111"
+        );
+        assert_eq!(
+            commits[0].change_id,
+            "Iaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        assert_eq!(commits[1].title, "second");
+        assert_eq!(
+            commits[1].change_id,
+            "Ibbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
+    }
+
+    #[test]
+    fn parse_skips_empty_records_at_boundary() {
+        // A trailing `\x1e` after the last record produces an
+        // empty split fragment — mirror Python's `stripped: continue`
+        // skip.
+        let raw = record(
+            "aaaa111111111111111111111111111111111111",
+            "only",
+            "Change-Id: Iaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        );
+        let commits = parse(&raw).unwrap();
+        assert_eq!(commits.len(), 1);
+    }
+
+    #[test]
+    fn parse_returns_empty_on_empty_input() {
+        // `git log` on a no-op range emits nothing. Stack walks
+        // should treat that as an empty result rather than an
+        // error.
+        assert!(parse("").unwrap().is_empty());
+        assert!(parse("\x1e\x1e").unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_picks_last_trailer_when_message_has_multiple() {
+        // Amends sometimes append a new `Change-Id:` instead of
+        // replacing the old one; the most recent one is the live
+        // identity.
+        let raw = record(
+            "aaaa111111111111111111111111111111111111",
+            "amended",
+            "body\n\nChange-Id: I1111111111111111111111111111111111111111\nChange-Id: I2222222222222222222222222222222222222222",
+        );
+        let commits = parse(&raw).unwrap();
+        assert_eq!(
+            commits[0].change_id,
+            "I2222222222222222222222222222222222222222"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_record_missing_a_field() {
+        // A two-field record (no body) means our format spec
+        // mismatches git's output — surfacing it loudly is more
+        // useful than silently dropping the commit.
+        let raw = "aaaa111111111111111111111111111111111111\x00title\x1e";
+        let err = parse(raw).unwrap_err();
+        match err {
+            CliError::Generic(msg) => assert!(msg.contains("Unexpected git log record format")),
+            other => panic!("expected Generic, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_returns_invalid_state_when_change_id_missing() {
+        // The Python check exits with INVALID_STATE so the CLI
+        // can prompt the user to run `mergify stack setup`. We
+        // mirror the exit-code mapping so the user sees the same
+        // signal regardless of which side raised it.
+        let raw = record(
+            "aaaa111111111111111111111111111111111111",
+            "broken",
+            "body with no trailer",
+        );
+        let err = parse(&raw).unwrap_err();
+        match err {
+            CliError::InvalidState(msg) => {
+                assert!(msg.contains("Change-Id"));
+                assert!(
+                    msg.contains("aaaa111111111111111111111111111111111111"),
+                    "missing-Change-Id error must name the offending commit so the user can fix it: {msg}",
+                );
+            }
+            other => panic!("expected InvalidState, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_walks_a_real_repository() {
+        // End-to-end smoke that the `git -C <dir> log ...`
+        // invocation, the format spec, and our parser all agree
+        // on the wire shape — the unit `parse` tests can't catch
+        // a drift between our `--format` string and what git
+        // actually emits.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path();
+        let git = |args: &[&str]| {
+            let out = Command::new("git")
+                .arg("-C")
+                .arg(path)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(out.status.success(), "git {args:?} failed: {out:?}");
+            String::from_utf8(out.stdout).unwrap()
+        };
+        git(&["init", "-q", "-b", "main"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "Tester"]);
+        git(&["commit", "--allow-empty", "-m", "base\n"]);
+        let base = git(&["rev-parse", "HEAD"]).trim().to_string();
+        git(&[
+            "commit",
+            "--allow-empty",
+            "-m",
+            "first\n\nChange-Id: Iaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ]);
+        git(&[
+            "commit",
+            "--allow-empty",
+            "-m",
+            "second\n\nChange-Id: Ibbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        ]);
+
+        let commits = read(path, &base, "HEAD").unwrap();
+        assert_eq!(commits.len(), 2);
+        assert_eq!(commits[0].title, "first");
+        assert_eq!(commits[1].title, "second");
+        assert_eq!(
+            commits[0].change_id,
+            "Iaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+    }
+}

--- a/mergify_cli/stack/changes.py
+++ b/mergify_cli/stack/changes.py
@@ -16,14 +16,17 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import json
+import os
+import pathlib
 import re
+import shutil
 import sys
 import typing
 
 from mergify_cli import console
 from mergify_cli import console_error
 from mergify_cli import github_types
-from mergify_cli import utils
 from mergify_cli.exit_codes import ExitCode
 from mergify_cli.stack.slug import slugify_title
 
@@ -297,42 +300,20 @@ async def get_changes(
     only_update_existing_pulls: bool,
     next_only: bool,
 ) -> Changes:
-    raw = await utils.git(
-        "log",
-        "--reverse",
-        "--format=%H%x00%s%x00%b%x1e",
-        f"{base_commit_sha}..{dest_branch}",
+    local_commits = await _read_local_commits_via_rust(
+        base_commit_sha,
+        dest_branch,
     )
-
-    commit_infos: list[tuple[str, str, str]] = []
-    for record in raw.split("\x1e"):
-        stripped = record.strip()
-        if not stripped:
-            continue
-        parts = stripped.split("\x00", 2)
-        if len(parts) != 3:
-            msg = f"Unexpected git log record format: {stripped!r}"
-            raise RuntimeError(msg)
-        commit_infos.append(
-            (parts[0].strip(), parts[1].strip(), parts[2].strip()),
-        )
 
     changes = Changes(stack_prefix)
     remaining_remote_changes = RemoteChanges(remote_changes.copy())
 
-    for idx, (commit, title, message) in enumerate(commit_infos):
-        changeids = CHANGEID_RE.findall(message)
-        if not changeids:
-            console_error(
-                f"`Change-Id:` line is missing on commit {commit}",
-            )
-            console.print(
-                "Did you run `mergify stack setup` for this repository?",
-            )
-            # TODO(sileht): we should raise an Exception and exit in main program
-            sys.exit(ExitCode.INVALID_STATE)
+    for idx, local in enumerate(local_commits):
+        commit = local["commit_sha"]
+        title = local["title"]
+        message = local["message"]
+        changeid = ChangeId(local["change_id"])
 
-        changeid = ChangeId(changeids[-1])
         pull = pop_remote_change(remaining_remote_changes, changeid)
 
         action: ActionT
@@ -376,3 +357,103 @@ async def get_changes(
             changes.orphans.append(OrphanChange(changeid, pull))
 
     return changes
+
+
+# ── Rust bridge ────────────────────────────────────────────────────
+# The walker that produces `local_commits` (run `git log`, parse the
+# NUL/RS-separated records, extract the `Change-Id:` trailer per
+# commit) is now the Rust `mergify _internal stack-local-commits`
+# subcommand. The Python side calls it via subprocess and gets the
+# parsed result back as JSON. Keeps the regex + git invocation in one
+# place so every stack subcommand benefits as it gets ported.
+
+
+async def _read_local_commits_via_rust(
+    base_commit_sha: str,
+    dest_branch: str,
+) -> list[dict[str, str]]:
+    """Walk the stack range via the native Rust subcommand.
+
+    Returns a list of `{commit_sha, title, message, change_id}`
+    dicts, one per commit in `<base_commit_sha>..<dest_branch>`.
+    A missing `Change-Id:` trailer makes the Rust binary exit with
+    `ExitCode.INVALID_STATE`; we mirror the Python exit path so the
+    user sees the same error+hint UX regardless of which side
+    raised it.
+    """
+    binary = _resolve_mergify_binary()
+    proc = await asyncio.create_subprocess_exec(
+        binary,
+        "_internal",
+        "stack-local-commits",
+        "--base",
+        base_commit_sha,
+        "--head",
+        dest_branch,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout_bytes, stderr_bytes = await proc.communicate()
+    stderr = stderr_bytes.decode("utf-8", errors="replace").strip()
+    # `mergify`'s generic error wrapper prefixes every stderr line
+    # with `mergify: ` — strip it so the user-facing message
+    # doesn't double-prefix. Fall back when stderr is empty so the
+    # error never displays as a blank line (e.g. if the subprocess
+    # crashed before writing).
+    details = stderr.removeprefix("mergify: ") or "stack walk failed"
+    if proc.returncode == ExitCode.INVALID_STATE:
+        # Missing Change-Id surfaces the same UX the inline path
+        # used to: error message + setup hint, then non-zero exit.
+        console_error(details)
+        console.print(
+            "Did you run `mergify stack setup` for this repository?",
+        )
+        sys.exit(ExitCode.INVALID_STATE)
+    if proc.returncode != 0:
+        msg = f"`mergify _internal stack-local-commits` failed: {details}"
+        raise RuntimeError(msg)
+    try:
+        return typing.cast(
+            "list[dict[str, str]]",
+            json.loads(stdout_bytes.decode("utf-8")),
+        )
+    except json.JSONDecodeError as exc:
+        # Surface stderr alongside the decode failure — a bare
+        # `JSONDecodeError` is nearly impossible to triage without
+        # the stderr context (e.g. a debug print leaking into
+        # stdout, or the binary panicking after a partial write).
+        msg = (
+            "`mergify _internal stack-local-commits` produced invalid JSON: "
+            f"{exc}; stderr: {stderr!r}"
+        )
+        raise RuntimeError(msg) from exc
+
+
+def _resolve_mergify_binary() -> str:
+    """Locate the `mergify` Rust binary the Python side calls into.
+
+    Duplicated from `mergify_cli/ci/junit_processing/junit.py` —
+    the stack and CI bridges have no shared module yet. Promote
+    to a shared utility once a third bridge appears.
+
+    Lookup order:
+    1. `$MERGIFY_CLI_BIN` override (used by tests against a freshly
+       built `target/debug/mergify`).
+    2. The venv's `bin/mergify` next to `sys.executable` — production
+       case once the wheel is installed.
+    3. `$PATH` fallback via `shutil.which`.
+    """
+    if override := os.environ.get("MERGIFY_CLI_BIN"):
+        return override
+    venv_bin = pathlib.Path(sys.executable).parent
+    for name in ("mergify", "mergify.exe"):
+        candidate = venv_bin / name
+        if candidate.is_file():
+            return str(candidate)
+    if found := shutil.which("mergify"):
+        return found
+    msg = (
+        "could not locate the `mergify` binary "
+        f"(checked $MERGIFY_CLI_BIN, {venv_bin}/mergify, and $PATH)"
+    )
+    raise RuntimeError(msg)

--- a/mergify_cli/tests/conftest.py
+++ b/mergify_cli/tests/conftest.py
@@ -97,7 +97,26 @@ def git_mock(
         output="",
     )
 
-    with mock.patch("mergify_cli.utils.git", git_mock_object):
+    # Bridge: `mergify_cli.stack.changes._read_local_commits_via_rust`
+    # now shells out to the Rust `_internal stack-local-commits`
+    # subcommand instead of running `git log` inline. The Rust path
+    # runs real git, which the GitMock subprocess fixture can't
+    # intercept; mock the helper directly so the stack tests keep
+    # driving everything through `git_mock.commit(...)` /
+    # `git_mock.finalize()`.
+    async def _bridge_local_commits(
+        _base: str,
+        _head: str,
+    ) -> list[dict[str, str]]:
+        return git_mock_object.build_local_commits()
+
+    with (
+        mock.patch("mergify_cli.utils.git", git_mock_object),
+        mock.patch(
+            "mergify_cli.stack.changes._read_local_commits_via_rust",
+            _bridge_local_commits,
+        ),
+    ):
         yield git_mock_object
 
 

--- a/mergify_cli/tests/utils.py
+++ b/mergify_cli/tests/utils.py
@@ -122,6 +122,29 @@ class GitMock:
         # Base commit SHA
         self.mock("merge-base", "--fork-point", "origin/main", output="base_commit_sha")
 
+    def build_local_commits(self) -> list[dict[str, str]]:
+        """Return the JSON-shape the Rust `_internal stack-local-commits`
+        bridge produces for the registered commits.
+
+        Mirrors the per-commit shape emitted by
+        `crates/mergify-stack/src/local_commits.rs::LocalCommit`:
+        `{commit_sha, title, message, change_id}`. Called by the
+        `git_mock` fixture's bridge stub instead of running the
+        real subprocess against a real git repo.
+        """
+        out: list[dict[str, str]] = []
+        for c in self._commits:
+            body = f"{c['message']}\n\nChange-Id: {c['change_id']}"
+            out.append(
+                {
+                    "commit_sha": c["sha"],
+                    "title": c["title"],
+                    "message": body,
+                    "change_id": c["change_id"],
+                },
+            )
+        return out
+
     def finalize(
         self,
         *,
@@ -141,18 +164,12 @@ class GitMock:
             output="",
         )
 
-        # Register batch log mock
-        records = []
-        for c in self._commits:
-            body = f"{c['message']}\n\nChange-Id: {c['change_id']}"
-            records.append(f"{c['sha']}\x00{c['title']}\x00{body}")
-        self.mock(
-            "log",
-            "--reverse",
-            "--format=%H%x00%s%x00%b%x1e",
-            "base_commit_sha..current-branch",
-            output="\x1e".join(records) + "\x1e" if records else "",
-        )
+        # The inline `git log --reverse --format=%H…` invocation
+        # is gone — `_read_local_commits_via_rust` now shells out
+        # to the Rust `_internal stack-local-commits` subcommand,
+        # mocked at the helper level (see the `git_mock` fixture
+        # in tests/conftest.py). `build_local_commits()` returns
+        # the parsed-JSON shape the helper would have produced.
 
         # Register batch note-read mock (empty = "no note")
         for c in self._commits:


### PR DESCRIPTION
`mergify_cli/stack/changes.py:get_changes()` opened with an
inline `git log --reverse --format=%H%x00%s%x00%b%x1e` invocation
followed by a NUL/RS record split + `CHANGEID_RE.findall` per
commit. Every `mergify stack <cmd>` runs the same loop, so this
is the natural floor for a "small but bridge-worthy" piece of the
stack machinery — one subprocess per command invocation amortises
the spawn cost across the whole stack walk.

- new `mergify-stack` crate (`change_id` module for the regex
  helpers, `local_commits` module for the `git log` walker)
- hidden `mergify _internal stack-local-commits --base <sha>
  --head <ref>` subcommand emits the parsed result as a JSON
  array; a missing `Change-Id:` trailer exits with
  `InvalidState` so Python sees the same exit code it raised
  inline
- `mergify_cli/stack/changes.py::get_changes` now calls the
  helper via `asyncio.create_subprocess_exec` and consumes the
  JSON; the inline `git log` + per-commit `CHANGEID_RE` loop is
  gone
- `GitMock` keeps driving the stack tests: a new
  `build_local_commits()` returns the same shape the Rust
  subprocess would, and the `git_mock` fixture patches the
  Python bridge helper alongside the existing `utils.git` patch

Coverage: parser-shape, missing-Change-Id, multiple-trailer,
malformed-record + end-to-end-against-real-git tests live in
`crates/mergify-stack/src/local_commits.rs`; the existing 293
Python `tests/stack/` tests still drive `GitMock` and pass
against the bridge as-is.