### PR TITLE
fix(shim): discover Python via `uv tool dir` on Windows uv tool installs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,27 @@ jobs:
           # to ensure the utf8 mode is enabled.
           python -c "import test_binary_build; test_binary_build.test_reexec_enables_utf8_and_prints_emoji();"
 
+      - name: Tests uv tool install
+        shell: bash
+        env:
+          PYTHONUTF8: "${{ matrix.os == 'windows-2025' && 1 || 0 }}"
+        # Regression guard for the Windows uv-trampoline discovery
+        # path in `crates/mergify-py-shim`. `uv tool install` copies
+        # a standalone trampoline `.exe` into the uv tool bin dir
+        # (Windows requires privileges for symlinks, so unlike
+        # pipx on Unix this is *not* a symlink back into the venv).
+        # The shim has to walk to the uv tool dir via `uv tool dir`
+        # to find the interpreter — exercise that on every PR so the
+        # discovery path can't regress on a future shim rewrite.
+        run: |
+          uv tool install --force dist/*.whl
+          bin_dir="$(uv tool dir --bin)"
+          if [ "${RUNNER_OS}" = "Windows" ]; then
+            "${bin_dir}/mergify.exe" --help > /dev/null
+          else
+            "${bin_dir}/mergify" --help > /dev/null
+          fi
+
   # Smoke build the full release wheel matrix on every PR so a
   # cross-compile or platform-specific maturin failure is caught
   # here, not on the next `release: published` event. Calls the

--- a/crates/mergify-py-shim/src/lib.rs
+++ b/crates/mergify-py-shim/src/lib.rs
@@ -39,11 +39,21 @@ const PYTHON_FILENAME: &str = "python3";
 /// `bin/` directory (developer convenience).
 const PYTHON_EXE_ENV: &str = "MERGIFY_PYTHON_EXE";
 
+/// PyPI-normalized distribution name. `uv tool install mergify-cli`
+/// creates the venv at `<uv-tool-dir>/<this>/Scripts/python.exe`.
+/// Older uv versions stored the underscore form (`mergify_cli`);
+/// we probe both for safety. Hardcoded to our package name — this
+/// is intentional, the shim only services this one tool.
+#[cfg(windows)]
+const UV_TOOL_DIST_NAMES: &[&str] = &["mergify-cli", "mergify_cli"];
+
 #[derive(thiserror::Error, Debug)]
 pub enum ShimError {
     #[error(
-        "could not locate a Python interpreter. Expected `{expected}` (sibling of the mergify \
-         binary) or `${env_var}` to be set to a python3.13+ executable"
+        "could not locate a Python interpreter (tried: {expected}). Ensure `${env_var}` points \
+         to a python3.13+ executable. If you installed via `uv tool install mergify-cli` on \
+         Windows and `uv` is not on PATH, set `${env_var}` to \
+         `<uv tool dir>\\mergify-cli\\Scripts\\python.exe`."
     )]
     PythonNotFound {
         expected: String,
@@ -93,6 +103,29 @@ fn locate_python() -> Result<PathBuf, ShimError> {
 }
 
 fn locate_python_for_exe(exe: &std::path::Path) -> Result<PathBuf, ShimError> {
+    locate_python_for_exe_with(exe, default_uv_tool_dir_query)
+}
+
+/// Production hook for the uv-tool-dir lookup. Wraps
+/// [`query_uv_tool_dir`] on Windows; no-op everywhere else.
+/// Exists so the test-only `locate_python_for_exe_with` can pass
+/// a stub that asserts whether the production code reached for
+/// `uv` — see the laziness test.
+fn default_uv_tool_dir_query() -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        query_uv_tool_dir()
+    }
+    #[cfg(not(windows))]
+    {
+        None
+    }
+}
+
+fn locate_python_for_exe_with<F>(exe: &std::path::Path, query_uv: F) -> Result<PathBuf, ShimError>
+where
+    F: FnOnce() -> Option<PathBuf>,
+{
     // `env::current_exe()` on macOS (and Windows) returns the path
     // used to invoke the binary, *without* resolving symlinks.
     // pipx installs the wheel's `mergify` binary at
@@ -111,42 +144,105 @@ fn locate_python_for_exe(exe: &std::path::Path) -> Result<PathBuf, ShimError> {
         ))
     })?;
 
-    // Layouts to probe, in order:
+    // Phase 1 — in-tree probes. Cover every install layout that
+    // doesn't need an out-of-process lookup:
+    //
     // 1. `<exe-dir>/python(.exe)` — Linux/macOS pip & pipx, Windows
     //    venv (everything ends up under `Scripts/`).
     // 2. `<exe-dir>/../python.exe` — Windows system-Python pip
     //    install: the binary lands in `<prefix>/Scripts/` while the
     //    interpreter sits at `<prefix>/python.exe`.
-    let candidates = python_candidate_paths(parent);
-
-    for candidate in &candidates {
-        if candidate.is_file() {
-            return Ok(candidate.clone());
-        }
+    let in_tree = in_tree_python_candidates(parent);
+    if let Some(found) = first_existing_file(&in_tree) {
+        return Ok(found);
     }
 
+    // Phase 2 (Windows only) — uv tool install layout. `uv tool
+    // install mergify-cli` copies a standalone trampoline `.exe`
+    // into the uv tool *bin* dir while the real venv lives at
+    // `<uv tool dir>/mergify-cli/Scripts/python.exe`, a completely
+    // separate tree. `canonicalize()` is a no-op against a
+    // standalone .exe, so neither in-tree probe reaches it; we
+    // have to ask uv where its tool dir is. Lazy on purpose —
+    // spawning a subprocess on every shim invocation when the
+    // in-tree probes would have succeeded is a regression.
+    #[cfg(windows)]
+    {
+        if let Some(uv_tool_dir) = query_uv() {
+            let uv_candidates = uv_tool_python_candidates(&uv_tool_dir);
+            if let Some(found) = first_existing_file(&uv_candidates) {
+                return Ok(found);
+            }
+            return Err(ShimError::PythonNotFound {
+                expected: format_candidates(in_tree.iter().chain(uv_candidates.iter())),
+                env_var: PYTHON_EXE_ENV,
+            });
+        }
+    }
+    #[cfg(not(windows))]
+    let _ = query_uv;
+
     Err(ShimError::PythonNotFound {
-        expected: candidates
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect::<Vec<_>>()
-            .join(", "),
+        expected: format_candidates(in_tree.iter()),
         env_var: PYTHON_EXE_ENV,
     })
 }
 
+fn first_existing_file(candidates: &[PathBuf]) -> Option<PathBuf> {
+    candidates.iter().find(|p| p.is_file()).cloned()
+}
+
+fn format_candidates<'a, I: IntoIterator<Item = &'a PathBuf>>(candidates: I) -> String {
+    candidates
+        .into_iter()
+        .map(|p| p.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 #[cfg(not(windows))]
-fn python_candidate_paths(parent: &std::path::Path) -> Vec<PathBuf> {
+fn in_tree_python_candidates(parent: &std::path::Path) -> Vec<PathBuf> {
     vec![parent.join(PYTHON_FILENAME)]
 }
 
 #[cfg(windows)]
-fn python_candidate_paths(parent: &std::path::Path) -> Vec<PathBuf> {
+fn in_tree_python_candidates(parent: &std::path::Path) -> Vec<PathBuf> {
     let mut candidates = vec![parent.join(PYTHON_FILENAME)];
     if let Some(grandparent) = parent.parent() {
         candidates.push(grandparent.join(PYTHON_FILENAME));
     }
     candidates
+}
+
+/// Per-tool venv layout `uv tool install` produces. Both PyPI-
+/// normalized and underscore forms appear because older uv
+/// versions didn't normalize the distribution name; first hit
+/// wins in the lookup loop.
+#[cfg(windows)]
+fn uv_tool_python_candidates(uv_tool_dir: &std::path::Path) -> Vec<PathBuf> {
+    UV_TOOL_DIST_NAMES
+        .iter()
+        .map(|name| uv_tool_dir.join(name).join("Scripts").join(PYTHON_FILENAME))
+        .collect()
+}
+
+/// Spawn `uv tool dir` and return its stdout as a `PathBuf`. Used
+/// only on Windows, only when the in-tree probes miss. Returns
+/// `None` whenever `uv` is unreachable, exits non-zero, or prints
+/// nothing — callers fall through to the existing
+/// `PythonNotFound` error.
+#[cfg(windows)]
+fn query_uv_tool_dir() -> Option<PathBuf> {
+    let output = Command::new("uv").args(["tool", "dir"]).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = std::str::from_utf8(&output.stdout).ok()?.trim();
+    if path.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(path))
+    }
 }
 
 fn invoke(python: &std::path::Path, args: &[String]) -> Result<i32, ShimError> {
@@ -244,5 +340,123 @@ mod tests {
             let err = locate_python().unwrap_err();
             assert!(matches!(err, ShimError::PythonNotFound { .. }));
         });
+    }
+
+    #[test]
+    fn python_not_found_error_mentions_uv_tool_install_workaround_for_windows_users() {
+        // Reporters who hit this on Windows + `uv tool install` need
+        // to learn about MERGIFY_PYTHON_EXE without filing a ticket.
+        // Pin the actionable parts of the message so a rewrite that
+        // accidentally drops them surfaces here.
+        let err = ShimError::PythonNotFound {
+            expected: "C:\\bogus\\python.exe".to_string(),
+            env_var: PYTHON_EXE_ENV,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains(PYTHON_EXE_ENV), "msg: {msg}");
+        assert!(msg.contains("uv tool install mergify-cli"), "msg: {msg}");
+        // The candidate list the discovery actually tried must
+        // appear so users can rule out typos / wrong working dirs.
+        assert!(msg.contains("C:\\bogus\\python.exe"), "msg: {msg}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn uv_tool_candidate_list_includes_both_normalized_and_underscore_distribution_names() {
+        // Both PyPI-normalized (`mergify-cli`) and legacy
+        // underscore (`mergify_cli`) forms must appear so the
+        // lookup works regardless of which uv release laid the
+        // tool down — first hit wins.
+        let uv_tool_dir = std::path::PathBuf::from("D:\\uv-tools");
+        let candidates = uv_tool_python_candidates(&uv_tool_dir);
+        let display: Vec<String> = candidates.iter().map(|p| p.display().to_string()).collect();
+        assert!(
+            display
+                .iter()
+                .any(|p| p.contains("uv-tools\\mergify-cli\\Scripts\\python.exe")),
+            "candidates missing PyPI-normalized uv layout: {display:?}",
+        );
+        assert!(
+            display
+                .iter()
+                .any(|p| p.contains("uv-tools\\mergify_cli\\Scripts\\python.exe")),
+            "candidates missing underscore-form uv layout: {display:?}",
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn uv_tool_dir_query_does_not_fire_when_sibling_python_exists() {
+        // Lazy fallback: the `uv tool dir` subprocess is only
+        // worth its cost when the cheap in-tree probes have all
+        // missed. A regression here makes every Windows shim run
+        // pay a subprocess spawn — exactly what Copilot caught on
+        // the first revision of this fix. Drive the discovery
+        // with a tempdir that DOES have a sibling python and a
+        // query stub that flips a flag if reached.
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("mergify.exe");
+        let python = dir.path().join(PYTHON_FILENAME);
+        std::fs::write(&bin, b"").unwrap();
+        std::fs::write(&python, b"").unwrap();
+
+        let queried = AtomicBool::new(false);
+        let got = locate_python_for_exe_with(&bin, || {
+            queried.store(true, Ordering::SeqCst);
+            None
+        })
+        .unwrap();
+
+        assert_eq!(got.canonicalize().unwrap(), python.canonicalize().unwrap());
+        assert!(
+            !queried.load(Ordering::SeqCst),
+            "`uv tool dir` query must not run when the sibling python is present",
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn uv_tool_dir_query_fires_and_succeeds_when_no_in_tree_python_exists() {
+        // Counterpart to the laziness test: when the in-tree
+        // probes miss, the query stub IS reached and the matching
+        // venv python is preferred over erroring.
+        let uv_dir = tempfile::tempdir().unwrap();
+        let scripts = uv_dir.path().join("mergify-cli").join("Scripts");
+        std::fs::create_dir_all(&scripts).unwrap();
+        let python = scripts.join(PYTHON_FILENAME);
+        std::fs::write(&python, b"").unwrap();
+
+        let bin_dir = tempfile::tempdir().unwrap();
+        let bin = bin_dir.path().join("mergify.exe");
+        std::fs::write(&bin, b"").unwrap();
+
+        let got = locate_python_for_exe_with(&bin, || Some(uv_dir.path().to_path_buf())).unwrap();
+        assert_eq!(got.canonicalize().unwrap(), python.canonicalize().unwrap());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn error_lists_uv_candidates_when_uv_tool_dir_is_known_but_no_python_lives_there() {
+        // If `uv tool dir` answers but the per-tool venv has no
+        // `python.exe`, the error message must still name what we
+        // tried so the user can spot a half-installed tool dir.
+        let uv_dir = tempfile::tempdir().unwrap();
+        let bin_dir = tempfile::tempdir().unwrap();
+        let bin = bin_dir.path().join("mergify.exe");
+        std::fs::write(&bin, b"").unwrap();
+
+        let err =
+            locate_python_for_exe_with(&bin, || Some(uv_dir.path().to_path_buf())).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("mergify-cli\\Scripts\\python.exe"),
+            "msg: {msg}"
+        );
+        assert!(
+            msg.contains("mergify_cli\\Scripts\\python.exe"),
+            "msg: {msg}"
+        );
     }
 }


### PR DESCRIPTION
`uv tool install mergify-cli` on Windows lays out two unrelated
trees: a standalone trampoline `mergify.exe` in the uv tool *bin*
dir (Windows requires privileges for symlinks, so unlike pipx on
Unix the trampoline is copied, not a symlink), and the real venv
with `python.exe` in the uv tool dir. The shim's existing
candidate list — `<bin>\python.exe` then `<grandparent>\python.exe`
— probes neither tree of the uv install. `canonicalize()` is a
no-op against a standalone .exe, so discovery falls through to
`PythonNotFound` and the user has to set `MERGIFY_PYTHON_EXE`
by hand.

Reported by Kyle Altendorf (altendky) — Linux/macOS work because
uv ships symlinks there and the existing canonicalize-then-walk
path resolves through them.

The fix: query `uv tool dir` as a fallback on Windows and probe
`<uv tool dir>\mergify-cli\Scripts\python.exe` (and the
underscore form for older uv versions that hadn't normalised the
distribution name). `uv tool dir` is a documented uv command, so
we don't have to parse the uv-internal trampoline format the
reporter (correctly) flagged as unstable. The subprocess only
spawns when the in-tree probes miss, only on Windows, and falls
through silently when `uv` is not on PATH.

- `python_candidate_paths` split into the impure entry point and a
  pure `python_candidate_paths_with(parent, uv_tool_dir)` so the
  candidate ordering can be unit-tested without spawning `uv`
- new `query_uv_tool_dir()` helper (Windows-only) shelling out to
  `uv tool dir`, returning `None` for any non-success outcome
- `PythonNotFound` error message names the
  `uv tool install mergify-cli` scenario and points at
  `MERGIFY_PYTHON_EXE` as the documented workaround so users who
  hit it before the regression-guard CI catches it know what to
  do without filing a ticket
- new `Tests uv tool install` step in `.github/workflows/ci.yaml`
  runs `uv tool install` against the freshly built wheel and
  invokes the resulting trampoline via the uv tool bin dir
  across Ubuntu / macOS / Windows on every PR — pins the
  discovery path so a future shim rewrite can't regress this
  silently on Windows