### PR TITLE
fix(ci): treat empty MERGIFY_CONFIG_PATH as auto-detect for `ci scopes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,6 +1169,7 @@ dependencies = [
  "regex",
  "serde_json",
  "serde_yaml_ng",
+ "temp-env",
  "tokio",
 ]
 

--- a/crates/mergify-ci/src/scopes_detect/mod.rs
+++ b/crates/mergify-ci/src/scopes_detect/mod.rs
@@ -283,6 +283,51 @@ mod tests {
     }
 
     #[test]
+    fn resolve_config_path_treats_empty_env_var_as_unset() {
+        // Regression for the downstream `gha-mergify-ci` break
+        // (monorepo#33423): the action sets `MERGIFY_CONFIG_PATH=""`
+        // when no path was given, expecting auto-detect. Previously
+        // clap's `env = "MERGIFY_CONFIG_PATH"` attribute on
+        // `ci scopes --config` treated the empty env value as a
+        // present-but-empty `--config` flag and aborted parsing
+        // with "a value is required for '--config'", before this
+        // function ever ran. The fix dropped the clap `env` hook
+        // so this function owns the lookup — and the empty branch
+        // here must fall through to autodetect rather than report
+        // a malformed env var.
+        let result = temp_env::with_var("MERGIFY_CONFIG_PATH", Some(""), || {
+            resolve_config_path(None)
+        });
+        // Either autodetect found a real config (cargo test runs
+        // from a workspace that contains `.mergify.yml`, so this is
+        // the expected branch here) or it didn't — but the
+        // env-var-specific error must not surface either way,
+        // since "empty" means "not set" by contract.
+        if let Err(err) = &result {
+            let msg = err.to_string();
+            assert!(
+                !msg.contains("MERGIFY_CONFIG_PATH="),
+                "empty env var leaked into the error message: {msg}",
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_config_path_errors_with_env_var_specific_message_when_set_but_invalid() {
+        // Counterpart to the empty-env test: when the user (or a
+        // wrapper script) sets `MERGIFY_CONFIG_PATH` to a real
+        // value that doesn't exist, the error must name the env
+        // var + the bogus path so the user can spot the typo
+        // without having to dig.
+        let err = temp_env::with_var("MERGIFY_CONFIG_PATH", Some("/no/such/.mergify.yml"), || {
+            resolve_config_path(None).unwrap_err()
+        });
+        let msg = err.to_string();
+        assert!(msg.contains("MERGIFY_CONFIG_PATH="), "got: {msg}");
+        assert!(msg.contains("/no/such/.mergify.yml"), "got: {msg}");
+    }
+
+    #[test]
     fn write_detected_scopes_emits_sorted_json() {
         let tmp = tempfile::tempdir().unwrap();
         let out = tmp.path().join("scopes.json");

--- a/crates/mergify-cli/Cargo.toml
+++ b/crates/mergify-cli/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { version = "1", default-features = false, features = ["macros", "rt", "
 [dev-dependencies]
 regex = "1"
 serde_yaml_ng = "0.10"
+temp-env = "0.3"
 
 [lints]
 workspace = true

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -1422,11 +1422,26 @@ struct GitRefsCliArgs {
 
 #[derive(clap::Args)]
 struct ScopesCliArgs {
-    /// Path to YAML config file. Falls back to
-    /// ``MERGIFY_CONFIG_PATH`` env var, then auto-detects
+    /// Path to YAML config file. Falls back to the
+    /// `MERGIFY_CONFIG_PATH` env var, then auto-detects
     /// `.mergify.yml`, `.mergify/config.yml`, or
     /// `.github/mergify.yml`.
-    #[arg(long, env = "MERGIFY_CONFIG_PATH")]
+    //
+    // The env var lookup is intentionally *not* delegated to
+    // clap's `env = ...` attribute: callers (notably the
+    // `gha-mergify-ci` action) set `MERGIFY_CONFIG_PATH=""` to
+    // mean "auto-detect", and clap's `env` parser treats an
+    // empty env value as a present-but-empty flag value, which
+    // fails the parse with `a value is required for '--config'`.
+    // The env var is consulted inside
+    // `mergify_ci::scopes_detect::resolve_config_path` instead,
+    // where empty correctly falls through to auto-detect. The
+    // matching regression tests are
+    // `ci_scopes_parses_when_mergify_config_path_env_var_is_empty`
+    // (clap parse) and
+    // `resolve_config_path_treats_empty_env_var_as_unset`
+    // (lower-level resolver).
+    #[arg(long)]
     config: Option<PathBuf>,
 
     /// Base git reference to use to look for changed files.
@@ -1874,6 +1889,39 @@ mod tests {
             std::iter::once("mergify".to_string()).chain(argv.iter().map(|s| (*s).to_string())),
         )
         .expect("argv parses")
+    }
+
+    #[test]
+    fn ci_scopes_parses_when_mergify_config_path_env_var_is_empty() {
+        // Regression for monorepo#33423 / gha-mergify-ci:
+        // the action sets `MERGIFY_CONFIG_PATH=""` (empty) when
+        // the caller didn't pin a config path, expecting
+        // auto-detect. The previous `ScopesCliArgs::config`
+        // declaration used `env = "MERGIFY_CONFIG_PATH"` on
+        // clap's side, which interpreted the empty env value as
+        // a present-but-empty `--config` flag and exited parsing
+        // with `a value is required for '--config'`. The clap
+        // env hook has been dropped — env lookup lives inside
+        // `scopes_detect::resolve_config_path` where empty is
+        // correctly treated as unset. Pin that here so the hook
+        // can't sneak back in.
+        let parsed = temp_env::with_var("MERGIFY_CONFIG_PATH", Some(""), || {
+            CliRoot::try_parse_from([
+                "mergify".to_string(),
+                "ci".to_string(),
+                "scopes".to_string(),
+                "--write".to_string(),
+                "scopes.json".to_string(),
+            ])
+            .expect("argv parses with empty MERGIFY_CONFIG_PATH")
+        });
+        let Dispatch::Native(NativeCommand::CiScopes(opts)) = dispatch_from_parsed(parsed) else {
+            panic!("ci scopes must dispatch natively");
+        };
+        // `--config` was never supplied; the empty env var must
+        // not surface as a value (which would change the
+        // downstream resolver's branch).
+        assert!(opts.config.is_none(), "got: {:?}", opts.config);
     }
 
     #[test]


### PR DESCRIPTION
The Python `ci scopes` command had explicit fallback semantics:
when `MERGIFY_CONFIG_PATH` was set to an empty string, Click's
`scopes` handler reset it to `None` and ran auto-detection. The
`gha-mergify-ci` GitHub Action relies on this — it exports
`MERGIFY_CONFIG_PATH=""` from `action.yml` whenever the caller
hasn't pinned a config path, on the assumption that the CLI will
discover `.mergify.yml` itself.

The Rust port wired the env var through clap's `env = ...`
attribute on `ScopesCliArgs::config`. Clap, when given an empty
env value for an `Option<PathBuf>` flag, interprets it as a
present-but-empty `--config` value and exits parsing with
`a value is required for '--config'` before the `scopes_detect`
run handler can apply its own fallback. End result:
`mergify ci scopes --write ...` with `MERGIFY_CONFIG_PATH=""`
broke every downstream `gha-mergify-ci` consumer (surfaced in
monorepo#33423 / the v20 action run).

Drop the `env = ...` attribute. `scopes_detect::resolve_config_path`
already reads the env var directly and correctly treats empty as
"unset → auto-detect" (mirroring the Python branch in
`mergify_cli/ci/cli.py::scopes`).

Regression coverage pinning both layers so the env hook can't be
re-introduced without surfacing in tests:

- `mergify-cli/src/main.rs::tests::ci_scopes_parses_when_mergify_…`
  drives the actual CLI argv shape with `MERGIFY_CONFIG_PATH=""`
  and asserts the parse succeeds (= no clap `value required`
  exit) and that `opts.config` is `None`.
- `mergify-ci/src/scopes_detect/mod.rs::tests::resolve_config_path_…`
  covers both the empty-env-as-unset branch (must not surface as
  the env-var-specific error) and the set-to-bogus-path branch
  (must surface with the env var name + bogus path in the
  message so the user can spot the typo).