### PR TITLE
fix(ci): treat empty MERGIFY_TEST_EXIT_CODE as unset for `ci junit-process`

### DIFF
--- a/crates/mergify-ci/src/junit_process/command.rs
+++ b/crates/mergify-ci/src/junit_process/command.rs
@@ -73,6 +73,7 @@ pub async fn run(
     let token = resolve_token(opts.token)?;
     let repository = resolve_repository(opts.repository)?;
     let tests_target_branch = resolve_tests_target_branch(opts.tests_target_branch)?;
+    let test_exit_code = resolve_test_exit_code(opts.test_exit_code)?;
     let files = expand_files(opts.files)?;
 
     // ── Header (printed regardless of outcome).
@@ -179,7 +180,7 @@ pub async fn run(
     // non-zero but the JUnit report has no failures, the runner
     // probably crashed — fail loudly so the user knows the report
     // is incomplete.
-    if let Some(exit_code) = opts.test_exit_code {
+    if let Some(exit_code) = test_exit_code {
         if exit_code != 0 && nb_failures == 0 {
             write_silent_failure(&mut report, exit_code);
             emit(output, &report)?;
@@ -222,6 +223,28 @@ fn resolve_api_url(explicit: Option<&str>) -> String {
         }
     }
     "https://api.mergify.com".to_string()
+}
+
+/// Resolve `--test-exit-code` / `MERGIFY_TEST_EXIT_CODE`. Empty
+/// env value is treated as "unset" so callers like the
+/// `gha-mergify-ci` action can export `MERGIFY_TEST_EXIT_CODE=""`
+/// to mean "no exit code available" without tripping a clap
+/// parse error — the env-var resolution intentionally does not
+/// go through clap's `env = ...` attribute, see the
+/// `JunitProcessCliArgs::test_exit_code` field for the full
+/// rationale.
+fn resolve_test_exit_code(explicit: Option<i32>) -> Result<Option<i32>, CliError> {
+    if explicit.is_some() {
+        return Ok(explicit);
+    }
+    match env::var("MERGIFY_TEST_EXIT_CODE") {
+        Ok(v) if !v.is_empty() => v.parse::<i32>().map(Some).map_err(|e| {
+            CliError::Configuration(format!(
+                "MERGIFY_TEST_EXIT_CODE={v:?} is not a valid integer: {e}",
+            ))
+        }),
+        _ => Ok(None),
+    }
 }
 
 fn resolve_token(explicit: Option<&str>) -> Result<String, CliError> {
@@ -604,6 +627,60 @@ mod tests {
             status,
             failure: Failure::default(),
         }
+    }
+
+    #[test]
+    fn resolve_test_exit_code_returns_explicit_value_when_provided() {
+        // Explicit `--test-exit-code 0` must win over whatever the
+        // env var says — including the empty-string sentinel the
+        // `gha-mergify-ci` action uses when no runner exit code is
+        // available. Pin so a future refactor can't accidentally
+        // invert the precedence.
+        let got = temp_env::with_var("MERGIFY_TEST_EXIT_CODE", Some("42"), || {
+            resolve_test_exit_code(Some(0)).unwrap()
+        });
+        assert_eq!(got, Some(0));
+    }
+
+    #[test]
+    fn resolve_test_exit_code_treats_empty_env_var_as_unset() {
+        // Regression for the downstream `gha-mergify-ci` break
+        // (monorepo#33423, second symptom): the action exports
+        // `MERGIFY_TEST_EXIT_CODE=""` when the previous step
+        // didn't produce a runner exit code. Previously the clap
+        // `env = "MERGIFY_TEST_EXIT_CODE"` attribute on
+        // `--test-exit-code` tried to parse the empty value as
+        // `i32` and aborted parsing with `cannot parse integer
+        // from empty string`, before this function ever ran. The
+        // fix drops the clap `env` hook and routes the env var
+        // through here — empty must collapse to `None`, the
+        // same shape no env var would produce.
+        let got = temp_env::with_var("MERGIFY_TEST_EXIT_CODE", Some(""), || {
+            resolve_test_exit_code(None).unwrap()
+        });
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn resolve_test_exit_code_parses_non_empty_env_var() {
+        let got = temp_env::with_var("MERGIFY_TEST_EXIT_CODE", Some("7"), || {
+            resolve_test_exit_code(None).unwrap()
+        });
+        assert_eq!(got, Some(7));
+    }
+
+    #[test]
+    fn resolve_test_exit_code_errors_when_env_var_is_non_empty_garbage() {
+        // A non-empty env var that isn't a valid integer is a
+        // real misconfiguration, not a "no value" sentinel —
+        // error loudly with the offending value in the message so
+        // the user can spot the typo without having to dig.
+        let err = temp_env::with_var("MERGIFY_TEST_EXIT_CODE", Some("not-an-int"), || {
+            resolve_test_exit_code(None).unwrap_err()
+        });
+        let msg = err.to_string();
+        assert!(msg.contains("MERGIFY_TEST_EXIT_CODE="), "got: {msg}");
+        assert!(msg.contains("not-an-int"), "got: {msg}");
     }
 
     #[test]

--- a/crates/mergify-ci/src/testing.rs
+++ b/crates/mergify-ci/src/testing.rs
@@ -84,6 +84,12 @@ const CI_ENV_VARS: &[&str] = &[
     // attributes; explicitly scrubbed so tests that don't set it
     // get a deterministic `mergify.test.job.name` (absent).
     "MERGIFY_TEST_JOB_NAME",
+    // Consumed by `junit_process::command::resolve_test_exit_code`
+    // (silent-failure detection). Scrub so the orchestrator tests
+    // don't pick up a developer's local export or a CI host that
+    // happens to set it, which would change which verdict branch
+    // the assertions land in.
+    "MERGIFY_TEST_EXIT_CODE",
 ];
 
 fn merged_overrides(extra: &[(&str, Option<&str>)]) -> Vec<(String, Option<String>)> {

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -1538,7 +1538,18 @@ struct JunitProcessCliArgs {
     /// Exit code of the test runner. When this is non-zero but no
     /// failures appear in the JUnit report, the run is flagged
     /// as a silent failure. Falls back to ``MERGIFY_TEST_EXIT_CODE``.
-    #[arg(long = "test-exit-code", short = 'e', env = "MERGIFY_TEST_EXIT_CODE")]
+    //
+    // The env-var fallback is intentionally NOT delegated to
+    // clap's `env = ...` attribute: callers (notably the
+    // `gha-mergify-ci` action) set `MERGIFY_TEST_EXIT_CODE=""`
+    // when no exit code is available, meaning "no value". Clap
+    // would try to parse the empty string as `i32` and exit
+    // parsing with `invalid value '' for '--test-exit-code':
+    // cannot parse integer from empty string`. The env var is
+    // consulted inside `junit_process::command::resolve_test_exit_code`
+    // instead, where empty correctly maps to `None`. Same trap
+    // hit the `--config` flag — see `ScopesCliArgs::config`.
+    #[arg(long = "test-exit-code", short = 'e')]
     test_exit_code: Option<i32>,
 
     /// JUnit XML files or glob patterns (e.g.
@@ -1922,6 +1933,42 @@ mod tests {
         // not surface as a value (which would change the
         // downstream resolver's branch).
         assert!(opts.config.is_none(), "got: {:?}", opts.config);
+    }
+
+    #[test]
+    fn ci_junit_process_parses_when_mergify_test_exit_code_env_var_is_empty() {
+        // Second instance of the same class of regression as
+        // `ci_scopes_parses_when_…`: `gha-mergify-ci` exports
+        // `MERGIFY_TEST_EXIT_CODE=""` when the previous step
+        // didn't produce a runner exit code. Previously the clap
+        // `env = "MERGIFY_TEST_EXIT_CODE"` attribute on
+        // `--test-exit-code` tried to parse `""` as `i32` and
+        // exited parsing with `invalid value '' for
+        // '--test-exit-code': cannot parse integer from empty
+        // string`. The clap env hook has been dropped — env
+        // lookup lives in `junit_process::command::resolve_test_exit_code`
+        // where empty is correctly treated as `None`. Pin that
+        // here so the hook can't sneak back in.
+        let parsed = temp_env::with_var("MERGIFY_TEST_EXIT_CODE", Some(""), || {
+            CliRoot::try_parse_from([
+                "mergify".to_string(),
+                "ci".to_string(),
+                "junit-process".to_string(),
+                "report.xml".to_string(),
+            ])
+            .expect("argv parses with empty MERGIFY_TEST_EXIT_CODE")
+        });
+        let Dispatch::Native(NativeCommand::CiJunitProcess(opts)) = dispatch_from_parsed(parsed)
+        else {
+            panic!("ci junit-process must dispatch natively");
+        };
+        // `--test-exit-code` was never supplied; the empty env
+        // var must not surface as a value.
+        assert!(
+            opts.test_exit_code.is_none(),
+            "got: {:?}",
+            opts.test_exit_code,
+        );
     }
 
     #[test]


### PR DESCRIPTION
Second instance of the regression class fixed by #1497 (empty
`MERGIFY_CONFIG_PATH`): the `gha-mergify-ci` action exports
`MERGIFY_TEST_EXIT_CODE=""` from `action.yml` when the previous
step didn't produce a runner exit code, treating empty as "no
value available". The Rust port wired the env var through clap's
`env = "MERGIFY_TEST_EXIT_CODE"` attribute on
`JunitProcessCliArgs::test_exit_code`, which tried to parse the
empty value as `i32` and exited parsing with `invalid value ''
for '--test-exit-code': cannot parse integer from empty string`
— before the `junit_process` command could apply any fallback.
Surfaced in monorepo#33423 as a second symptom after #1497
landed.

Drop the `env = ...` attribute and add a `resolve_test_exit_code`
helper inside `junit_process::command` alongside `resolve_api_url`
/ `resolve_token` / `resolve_repository`. The helper treats an
empty env value as "unset" (mapping to `None`), parses a
non-empty value as `i32`, and surfaces a clear
`MERGIFY_TEST_EXIT_CODE=<value> is not a valid integer` error
for non-empty garbage so a misconfiguration doesn't get silently
dropped.

Pinning both layers:

- `crates/mergify-cli/src/main.rs::tests::ci_junit_process_parses_when_mergify_test_exit_code_env_var_is_empty`
  drives the failing CLI argv shape under
  `MERGIFY_TEST_EXIT_CODE=""` and asserts the parse succeeds
  (= no clap exit-2) and `opts.test_exit_code` lands as `None`.
- `crates/mergify-ci/src/junit_process/command.rs::tests::resolve_test_exit_code_*`
  covers the resolver itself: explicit-wins, empty-as-unset,
  parsed non-empty, and the loud-error-on-garbage paths.

The `JunitProcessCliArgs::test_exit_code` field carries a `//`
comment cross-referencing `ScopesCliArgs::config` so the next
contributor adding an `env = ...` to a new arg sees the trap
documented at the call site.