### PR TITLE
refactor(core): add `env::var_non_empty` helper to centralise the empty-as-unset trap

### DIFF
--- a/crates/mergify-ci/src/junit_process/command.rs
+++ b/crates/mergify-ci/src/junit_process/command.rs
@@ -17,9 +17,9 @@
 // kind of templated text emission.
 #![allow(clippy::format_push_string)]
 
-use std::env;
 use std::path::{Path, PathBuf};
 
+use mergify_core::env::var_non_empty;
 use mergify_core::{CliError, ExitCode, Output};
 use url::Url;
 
@@ -132,9 +132,7 @@ pub async fn run(
     let metadata = UploadMetadata {
         test_framework: opts.test_framework.map(str::to_string),
         test_language: opts.test_language.map(str::to_string),
-        mergify_test_job_name: env::var("MERGIFY_TEST_JOB_NAME")
-            .ok()
-            .filter(|s| !s.is_empty()),
+        mergify_test_job_name: var_non_empty("MERGIFY_TEST_JOB_NAME"),
         quarantined: quarantine_result
             .quarantined
             .iter()
@@ -207,15 +205,11 @@ fn emit(output: &mut dyn Output, report: &str) -> Result<(), CliError> {
 }
 
 fn resolve_api_url(explicit: Option<&str>) -> String {
-    if let Some(v) = explicit.filter(|s| !s.is_empty()) {
-        return v.to_string();
-    }
-    if let Ok(v) = env::var("MERGIFY_API_URL") {
-        if !v.is_empty() {
-            return v;
-        }
-    }
-    "https://api.mergify.com".to_string()
+    explicit
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+        .or_else(|| var_non_empty("MERGIFY_API_URL"))
+        .unwrap_or_else(|| "https://api.mergify.com".to_string())
 }
 
 /// Resolve `--test-exit-code` / `MERGIFY_TEST_EXIT_CODE`. Empty
@@ -230,23 +224,21 @@ fn resolve_test_exit_code(explicit: Option<i32>) -> Result<Option<i32>, CliError
     if explicit.is_some() {
         return Ok(explicit);
     }
-    match env::var("MERGIFY_TEST_EXIT_CODE") {
-        Ok(v) if !v.is_empty() => v.parse::<i32>().map(Some).map_err(|e| {
-            CliError::Configuration(format!(
-                "MERGIFY_TEST_EXIT_CODE={v:?} is not a valid integer: {e}",
-            ))
-        }),
-        _ => Ok(None),
-    }
+    let Some(raw) = var_non_empty("MERGIFY_TEST_EXIT_CODE") else {
+        return Ok(None);
+    };
+    raw.parse::<i32>().map(Some).map_err(|e| {
+        CliError::Configuration(format!(
+            "MERGIFY_TEST_EXIT_CODE={raw:?} is not a valid integer: {e}",
+        ))
+    })
 }
 
 fn resolve_token(explicit: Option<&str>) -> Result<String, CliError> {
-    if let Some(v) = explicit.filter(|s| !s.is_empty()) {
-        return Ok(v.to_string());
-    }
-    env::var("MERGIFY_TOKEN")
-        .ok()
+    explicit
         .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+        .or_else(|| var_non_empty("MERGIFY_TOKEN"))
         .ok_or_else(|| {
             CliError::Configuration(
                 "--token not provided and MERGIFY_TOKEN env var is empty".to_string(),

--- a/crates/mergify-ci/src/scopes_detect/mod.rs
+++ b/crates/mergify-ci/src/scopes_detect/mod.rs
@@ -32,6 +32,7 @@ use std::path::PathBuf;
 
 use mergify_core::CliError;
 use mergify_core::Output;
+use mergify_core::env::var_non_empty;
 use serde::Serialize;
 
 use crate::git_refs;
@@ -127,16 +128,14 @@ fn resolve_config_path(explicit: Option<&Path>) -> Result<PathBuf, CliError> {
             path.display(),
         )));
     }
-    if let Ok(env_path) = env::var("MERGIFY_CONFIG_PATH") {
-        if !env_path.is_empty() {
-            let p = PathBuf::from(&env_path);
-            if !p.is_file() {
-                return Err(CliError::Configuration(format!(
-                    "MERGIFY_CONFIG_PATH={env_path} does not point at a regular file",
-                )));
-            }
-            return Ok(p);
+    if let Some(env_path) = var_non_empty("MERGIFY_CONFIG_PATH") {
+        let p = PathBuf::from(&env_path);
+        if !p.is_file() {
+            return Err(CliError::Configuration(format!(
+                "MERGIFY_CONFIG_PATH={env_path} does not point at a regular file",
+            )));
         }
+        return Ok(p);
     }
     mergify_config::paths::resolve_config_path(None)
 }

--- a/crates/mergify-core/src/auth.rs
+++ b/crates/mergify-core/src/auth.rs
@@ -18,12 +18,12 @@
 //! and `mergify-queue::auth` were missing the `gh auth token` and
 //! `git config` fallbacks — that's why this module exists.
 
-use std::env;
 use std::process::Command;
 
 use url::Url;
 
 use crate::CliError;
+use crate::env::var_non_empty;
 
 const DEFAULT_API_URL: &str = "https://api.mergify.com";
 
@@ -37,10 +37,8 @@ pub fn resolve_token(explicit: Option<&str>) -> Result<String, CliError> {
         return Ok(value.to_string());
     }
     for env_name in ["MERGIFY_TOKEN", "GITHUB_TOKEN"] {
-        if let Ok(value) = env::var(env_name) {
-            if !value.is_empty() {
-                return Ok(value);
-            }
+        if let Some(value) = var_non_empty(env_name) {
+            return Ok(value);
         }
     }
     if let Ok(token) = gh_auth_token() {
@@ -60,9 +58,9 @@ pub fn resolve_token(explicit: Option<&str>) -> Result<String, CliError> {
 /// `https://api.mergify.com`.
 pub fn resolve_api_url(explicit: Option<&str>) -> Result<Url, CliError> {
     let raw = explicit
-        .map(str::to_string)
-        .or_else(|| env::var("MERGIFY_API_URL").ok())
         .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| var_non_empty("MERGIFY_API_URL"))
         .unwrap_or_else(|| DEFAULT_API_URL.to_string());
     Url::parse(&raw).map_err(|e| CliError::Configuration(format!("invalid --api-url {raw:?}: {e}")))
 }
@@ -76,10 +74,8 @@ pub fn resolve_repository(explicit: Option<&str>) -> Result<String, CliError> {
     if let Some(value) = explicit.filter(|s| !s.is_empty()) {
         return Ok(value.to_string());
     }
-    if let Ok(value) = env::var("GITHUB_REPOSITORY") {
-        if !value.is_empty() {
-            return Ok(value);
-        }
+    if let Some(value) = var_non_empty("GITHUB_REPOSITORY") {
+        return Ok(value);
     }
     if let Some(remote) = git_remote_origin_url() {
         if let Some(slug) = parse_slug(&remote) {

--- a/crates/mergify-core/src/env.rs
+++ b/crates/mergify-core/src/env.rs
@@ -1,0 +1,62 @@
+//! Environment-variable helpers shared across commands.
+//!
+//! The CLI's resolver pattern (`flag → env → default`) treats the
+//! empty string as "not set", because callers in the wild — most
+//! notably the `gha-mergify-ci` GitHub Action — `export VAR=""`
+//! when no value is available. Inlining
+//! `std::env::var(NAME).ok().filter(|s| !s.is_empty())` on every call
+//! site looks innocuous but invites the same bug we've now hit
+//! twice (monorepo#33423, `MERGIFY_CONFIG_PATH` and
+//! `MERGIFY_TEST_EXIT_CODE`): a contributor adds clap's
+//! `env = "MERGIFY_FOO"` attribute on a flag instead, and clap's
+//! parser treats an empty env value as a present-but-empty flag
+//! value, aborting parsing before any of our code can fall back.
+//!
+//! Use [`var_non_empty`] for the env-var leg of any `flag → env
+//! → default` chain. Do **not** wire env vars through clap's
+//! `env = ...` attribute for any of the `MERGIFY_*` namespace.
+
+use std::env;
+
+/// Read an environment variable and return its value if it's set
+/// to a non-empty string. Unset or empty both collapse to `None`.
+///
+/// This is the standard primitive for the env-var leg of the
+/// `--flag → env → default` resolver chain across every ported
+/// command. See the module doc for the empty-as-unset rationale.
+#[must_use]
+pub fn var_non_empty(name: &str) -> Option<String> {
+    env::var(name).ok().filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_some_for_non_empty_value() {
+        let got = temp_env::with_var("MERGIFY_TEST_HELPER_X", Some("hello"), || {
+            var_non_empty("MERGIFY_TEST_HELPER_X")
+        });
+        assert_eq!(got.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn returns_none_for_empty_value() {
+        // The whole point of this helper: an empty env var is
+        // treated as if it were not set. Regression-prone enough
+        // that we pin it explicitly.
+        let got = temp_env::with_var("MERGIFY_TEST_HELPER_Y", Some(""), || {
+            var_non_empty("MERGIFY_TEST_HELPER_Y")
+        });
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn returns_none_when_unset() {
+        let got = temp_env::with_var_unset("MERGIFY_TEST_HELPER_Z", || {
+            var_non_empty("MERGIFY_TEST_HELPER_Z")
+        });
+        assert_eq!(got, None);
+    }
+}

--- a/crates/mergify-core/src/lib.rs
+++ b/crates/mergify-core/src/lib.rs
@@ -17,6 +17,7 @@
 
 pub mod auth;
 pub mod command_context;
+pub mod env;
 pub mod error;
 pub mod exit_code;
 pub mod http;


### PR DESCRIPTION
The flag-→-env-→-default resolver chain across every ported
command treats an empty env value as "unset", because callers in
the wild — most notably the `gha-mergify-ci` GitHub Action —
`export VAR=""` when no value is available. Inlining
`env::var(NAME).ok().filter(|s| !s.is_empty())` on every call
site looks innocuous but invites the bug we've now hit twice: a
contributor reaches for clap's `env = "MERGIFY_FOO"` attribute
instead, and clap's parser treats an empty env value as a
present-but-empty flag value, aborting parsing before the
fallback code runs. Symptom: `a value is required for
'--config'` (PR #1497) and `invalid value '' for
'--test-exit-code': cannot parse integer from empty string`
(PR #1499). Both broke `gha-mergify-ci` consumers via
monorepo#33423.

Centralise the primitive as `mergify_core::env::var_non_empty`
and migrate every existing flag-→-env resolver:

- `mergify_core::auth::resolve_token` (MERGIFY_TOKEN, GITHUB_TOKEN)
- `mergify_core::auth::resolve_api_url` (MERGIFY_API_URL)
- `mergify_core::auth::resolve_repository` (GITHUB_REPOSITORY)
- `mergify_ci::junit_process::command::resolve_api_url`
- `mergify_ci::junit_process::command::resolve_token`
- `mergify_ci::junit_process::command::resolve_test_exit_code`
- `mergify_ci::junit_process::command::run` (MERGIFY_TEST_JOB_NAME)
- `mergify_ci::scopes_detect::resolve_config_path` (MERGIFY_CONFIG_PATH)

The module-level docstring on `mergify_core::env` spells out the
trap and is the canonical place to point future contributors who
reach for clap's `env = ...` attribute on a `MERGIFY_*` flag.