### PR TITLE
feat(stack): fold the `refs/notes/mergify/stack` read into the walker

### DIFF
--- a/crates/mergify-stack/src/local_commits.rs
+++ b/crates/mergify-stack/src/local_commits.rs
@@ -23,6 +23,13 @@ use serde::Serialize;
 use crate::change_id;
 use crate::slug;
 
+/// `refs/notes/mergify/stack` — the notes ref `mergify stack`
+/// uses to attach amend-reason notes to commits. Read alongside
+/// the commit body in the walker via `git log --notes=…` so the
+/// revision-history rendering doesn't need a per-commit subprocess
+/// round-trip.
+const STACK_NOTES_REF: &str = "refs/notes/mergify/stack";
+
 /// One commit in the local stack range, after parsing.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct LocalCommit {
@@ -47,6 +54,15 @@ pub struct LocalCommit {
     /// pre-computing it here keeps the slug algorithm in one place
     /// regardless of how many stack callers need it.
     pub slug: String,
+    /// Amend-reason note attached to the commit on the
+    /// `refs/notes/mergify/stack` ref, or an empty string when
+    /// the commit has no note. The walker reads notes through
+    /// `git log --notes=…` so this is a free piggyback on the
+    /// existing per-stack-op subprocess; before this field, the
+    /// Python orchestrator ran one extra `git notes show <sha>`
+    /// per commit (N round-trips). Consumed by the revision
+    /// history rendering on the PR comment.
+    pub note: String,
 }
 
 /// Run `git log` in `repo_dir` and parse its output into one
@@ -71,6 +87,7 @@ pub fn read(repo_dir: &Path, base: &str, head: &str) -> Result<Vec<LocalCommit>,
 
 fn run_git_log(repo_dir: &Path, base: &str, head: &str) -> Result<String, CliError> {
     let range = format!("{base}..{head}");
+    let notes_arg = format!("--notes={STACK_NOTES_REF}");
     let output = Command::new("git")
         .arg("-C")
         .arg(repo_dir)
@@ -78,8 +95,12 @@ fn run_git_log(repo_dir: &Path, base: &str, head: &str) -> Result<String, CliErr
             "log",
             "--reverse",
             // `%H` SHA, `%x00` NUL, `%s` subject, `%x00` NUL,
-            // `%b` body, `%x1e` ASCII RS terminator.
-            "--format=%H%x00%s%x00%b%x1e",
+            // `%b` body, `%x00` NUL, `%N` note, `%x1e` ASCII RS
+            // terminator. `%N` is empty when the commit has no
+            // note on the configured ref, so the field count is
+            // stable across both cases.
+            "--format=%H%x00%s%x00%b%x00%N%x1e",
+            &notes_arg,
             &range,
         ])
         .output()
@@ -111,7 +132,7 @@ pub fn parse(raw: &str) -> Result<Vec<LocalCommit>, CliError> {
         if stripped.is_empty() {
             continue;
         }
-        let mut parts = stripped.splitn(3, '\x00');
+        let mut parts = stripped.splitn(4, '\x00');
         let commit_sha = parts
             .next()
             .ok_or_else(|| malformed_record(stripped))?
@@ -123,6 +144,15 @@ pub fn parse(raw: &str) -> Result<Vec<LocalCommit>, CliError> {
             .trim()
             .to_string();
         let message = parts
+            .next()
+            .ok_or_else(|| malformed_record(stripped))?
+            .trim()
+            .to_string();
+        // `%N` is empty when no note exists on the configured ref.
+        // The field is still emitted by git so this never returns
+        // `None`; missing it means the record shape drifted, which
+        // is malformed.
+        let note = parts
             .next()
             .ok_or_else(|| malformed_record(stripped))?
             .trim()
@@ -147,6 +177,7 @@ pub fn parse(raw: &str) -> Result<Vec<LocalCommit>, CliError> {
             message,
             change_id,
             slug,
+            note,
         });
     }
     Ok(out)
@@ -174,9 +205,16 @@ mod tests {
     use super::*;
 
     fn record(sha: &str, title: &str, body: &str) -> String {
+        // Most parse tests don't care about the note field; default
+        // to empty (the shape git emits for commits without a note
+        // on the configured ref).
+        record_with_note(sha, title, body, "")
+    }
+
+    fn record_with_note(sha: &str, title: &str, body: &str, note: &str) -> String {
         // Same wire shape git emits with our `--format` spec: NUL
-        // between fields, RS terminator after the body.
-        format!("{sha}\x00{title}\x00{body}\x1e")
+        // between fields, RS terminator after the note.
+        format!("{sha}\x00{title}\x00{body}\x00{note}\x1e")
     }
 
     #[test]
@@ -252,15 +290,52 @@ mod tests {
 
     #[test]
     fn parse_rejects_record_missing_a_field() {
-        // A two-field record (no body) means our format spec
-        // mismatches git's output — surfacing it loudly is more
-        // useful than silently dropping the commit.
-        let raw = "aaaa111111111111111111111111111111111111\x00title\x1e";
+        // A three-field record (missing the note field) means our
+        // format spec drifted from what git emits — surfacing it
+        // loudly is more useful than silently dropping the
+        // commit. We expect 4 NUL-separated fields: SHA, title,
+        // body, note (note may be empty).
+        let raw = "aaaa111111111111111111111111111111111111\x00title\x00body\x1e";
         let err = parse(raw).unwrap_err();
         match err {
             CliError::Generic(msg) => assert!(msg.contains("Unexpected git log record format")),
             other => panic!("expected Generic, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_extracts_note_when_present() {
+        // The walker piggy-backs `git notes --ref=refs/notes/mergify/stack`
+        // onto the same `git log` call by appending `%N` to the
+        // format spec. Confirm a commit with a note surfaces it
+        // verbatim on the `LocalCommit.note` field — that's how
+        // the revision-history rendering will receive it without
+        // a per-commit subprocess round-trip.
+        let raw = record_with_note(
+            "aaaa111111111111111111111111111111111111",
+            "amend",
+            "body\n\nChange-Id: Iaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "address review feedback",
+        );
+        let commits = parse(&raw).unwrap();
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].note, "address review feedback");
+    }
+
+    #[test]
+    fn parse_returns_empty_note_when_absent() {
+        // Commits without a note still need a deterministic shape
+        // (the `%N` field is empty, but git still emits the NUL
+        // separator before the RS terminator). `record` defaults
+        // to empty note, exercising exactly this case.
+        let raw = record(
+            "aaaa111111111111111111111111111111111111",
+            "no-note",
+            "Change-Id: Iaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        );
+        let commits = parse(&raw).unwrap();
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].note, "");
     }
 
     #[test]
@@ -323,6 +398,19 @@ mod tests {
             "-m",
             "second\n\nChange-Id: Ibbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         ]);
+        // Attach an amend-reason note to the second commit only,
+        // so the assertions below can verify both branches —
+        // `note == "address review feedback"` for the second,
+        // `note == ""` for the first.
+        let second_sha = git(&["rev-parse", "HEAD"]).trim().to_string();
+        git(&[
+            "notes",
+            &format!("--ref={STACK_NOTES_REF}"),
+            "add",
+            "-m",
+            "address review feedback",
+            &second_sha,
+        ]);
 
         let commits = read(path, &base, "HEAD").unwrap();
         assert_eq!(commits.len(), 2);
@@ -332,5 +420,9 @@ mod tests {
             commits[0].change_id,
             "Iaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
+        // First commit has no note on the stack ref → empty
+        // string. Second has the note we just attached.
+        assert_eq!(commits[0].note, "");
+        assert_eq!(commits[1].note, "address review feedback");
     }
 }

--- a/mergify_cli/stack/changes.py
+++ b/mergify_cli/stack/changes.py
@@ -351,6 +351,13 @@ async def get_changes(
                 changes.locals[-1].dest_branch if changes.locals else base_branch,
                 dest_branch,
                 action,
+                # Amend-reason note from `refs/notes/mergify/stack`,
+                # already populated by the Rust walker via
+                # `git log --notes=…`. Empty string when no note is
+                # attached. Replaces the per-commit
+                # `read_reasons()` round-trip the orchestrator used
+                # to make in `stack_push`.
+                reason=local["note"],
             ),
         )
 
@@ -376,7 +383,7 @@ async def _read_local_commits_via_rust(
 ) -> list[dict[str, str]]:
     """Walk the stack range via the native Rust subcommand.
 
-    Returns a list of `{commit_sha, title, message, change_id, slug}`
+    Returns a list of `{commit_sha, title, message, change_id, slug, note}`
     dicts, one per commit in `<base_commit_sha>..<dest_branch>`.
     A missing `Change-Id:` trailer makes the Rust binary exit with
     `ExitCode.INVALID_STATE`; we mirror the Python exit path so the

--- a/mergify_cli/stack/push.py
+++ b/mergify_cli/stack/push.py
@@ -204,34 +204,6 @@ async def push_branches(
         os.environ.pop("MERGIFY_STACK_PUSH", None)
 
 
-async def read_reasons(local_changes: list[changes.LocalChange]) -> None:
-    """Populate ``c.reason`` from ``refs/notes/mergify/stack`` for each
-    change in ``create`` or ``update`` state.
-
-    Commits without a note get an empty string. Unexpected git errors
-    (missing binary, permission failures, corrupted object store, …)
-    propagate to the caller so real problems surface instead of being
-    silently swallowed.
-    """
-
-    async def read_one(c: changes.LocalChange) -> None:
-        if c.action not in {"create", "update"}:
-            return
-        try:
-            c.reason = await utils.git(
-                "notes",
-                f"--ref={NOTES_REF}",
-                "show",
-                c.commit_sha,
-            )
-        except utils.CommandError as exc:
-            if b"no note found" not in exc.stdout:
-                raise
-            c.reason = ""
-
-    await asyncio.gather(*(read_one(c) for c in local_changes))
-
-
 async def _git_patch_id(sha: str) -> str:
     """Get the patch-id of a commit, stable across rebases."""
     diff = await utils.git("show", sha)
@@ -607,8 +579,6 @@ async def stack_push(
                     old="skip-up-to-date",
                     new="update",
                 )
-
-        await read_reasons(planned_changes.locals)
 
         changes.display_plan(
             planned_changes,

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -2133,52 +2133,55 @@ def test_local_change_has_reason_default_empty() -> None:
     assert not c.reason
 
 
-async def test_read_reasons_reads_notes_for_updated_changes(
+async def test_local_change_reason_populated_from_walker_note(
     git_mock: test_utils.GitMock,
 ) -> None:
-    """read_reasons() fills LocalChange.reason from refs/notes/mergify/stack."""
-    from mergify_cli.stack.note import NOTES_REF
+    """`LocalChange.reason` is filled by the Rust walker (via the
+    `note` field on its JSON output) rather than by a separate
+    per-commit `git notes show` round-trip.
 
-    local_changes = [
-        changes.LocalChange(
-            id=changes.ChangeId("I1" + "a" * 39),
-            pull=None,
-            commit_sha="new1",
+    Used to be the `read_reasons()` orchestrator step in
+    `stack_push`; the function is gone — the walker reads
+    `refs/notes/mergify/stack` alongside the commit body via
+    `git log --notes=…` in a single subprocess. Pin the
+    walker→`reason` data path so a future refactor can't
+    silently re-introduce the N-round-trip pattern.
+    """
+    git_mock.commit(
+        test_utils.Commit(
+            sha="new1",
             title="T1",
             message="M",
-            base_branch="main",
-            dest_branch="stack/t1--deadbeef",
-            action="update",
+            change_id="I1" + "a" * 39,
+            note="reason one",
         ),
-        changes.LocalChange(
-            id=changes.ChangeId("I2" + "a" * 39),
-            pull=None,
-            commit_sha="new2",
+    )
+    git_mock.commit(
+        test_utils.Commit(
+            sha="new2",
             title="T2",
             message="M",
-            base_branch="main",
-            dest_branch="stack/t2--cafebabe",
-            action="update",
+            change_id="I2" + "a" * 39,
+            # No `note` → defaults to empty, matching git's `%N`
+            # output for commits with no entry on the stack notes ref.
         ),
-    ]
-    git_mock.mock(
-        "notes",
-        f"--ref={NOTES_REF}",
-        "show",
-        "new1",
-        output="reason one",
-    )
-    git_mock.mock(
-        "notes",
-        f"--ref={NOTES_REF}",
-        "show",
-        "new2",
-        output="",
     )
 
-    await push.read_reasons(local_changes)
+    result = await changes.get_changes(
+        base_commit_sha="base_commit_sha",
+        stack_prefix="stack",
+        base_branch="main",
+        dest_branch="current-branch",
+        remote_changes=changes.RemoteChanges({}),
+        only_update_existing_pulls=False,
+        next_only=False,
+    )
 
-    assert local_changes[0].reason == "reason one"
+    assert len(result.locals) == 2
+    assert result.locals[0].commit_sha == "new1"
+    assert result.locals[0].reason == "reason one"
+    assert result.locals[1].commit_sha == "new2"
+    assert not result.locals[1].reason
 
 
 def test_revision_history_comment_renders_reason_column() -> None:
@@ -2347,8 +2350,6 @@ async def test_revision_comment_includes_reason_from_local_change(
     respx_mock: respx.MockRouter,
 ) -> None:
     """When a commit has a reason, it appears in the new revision row."""
-    from mergify_cli.stack.note import NOTES_REF
-
     git_mock.commit(
         test_utils.Commit(
             sha="third_sha",
@@ -2356,18 +2357,16 @@ async def test_revision_comment_includes_reason_from_local_change(
             message="Message",
             change_id="I29617d37762fd69809c255d7e7073cb11f8fbf50",
             head_ref="current-branch/I29617d37762fd69809c255d7e7073cb11f8fbf50",
+            # The Rust walker emits the note alongside the commit
+            # body via `git log --notes=refs/notes/mergify/stack`,
+            # so the note arrives through `local["note"]` on the
+            # walker bridge output rather than via a separate
+            # `git notes show` mock.
+            note="fixed typo in sql",
         ),
     )
     git_mock.finalize(
         remote_shas={"I29617d37762fd69809c255d7e7073cb11f8fbf50": "second_sha"},
-    )
-    # Override the empty-note default with an actual note
-    git_mock.mock(
-        "notes",
-        f"--ref={NOTES_REF}",
-        "show",
-        "third_sha",
-        output="fixed typo in sql",
     )
     git_mock.mock("fetch", "origin", "refs/pull/123/head", output="")
 

--- a/mergify_cli/tests/utils.py
+++ b/mergify_cli/tests/utils.py
@@ -62,6 +62,7 @@ class _CommitRequired(typing.TypedDict):
 
 class Commit(_CommitRequired, total=False):
     head_ref: str  # existing PR branch ref; overrides slug-based refspec in finalize()
+    note: str  # amend-reason note from `refs/notes/mergify/stack`; empty by default
 
 
 @dataclasses.dataclass
@@ -128,13 +129,15 @@ class GitMock:
 
         Mirrors the per-commit shape emitted by
         `crates/mergify-stack/src/local_commits.rs::LocalCommit`:
-        `{commit_sha, title, message, change_id, slug}`. Called by the
-        `git_mock` fixture's bridge stub instead of running the
-        real subprocess against a real git repo. The `slug` is
-        computed via the test-only oracle in
+        `{commit_sha, title, message, change_id, slug, note}`.
+        Called by the `git_mock` fixture's bridge stub instead of
+        running the real subprocess against a real git repo. The
+        `slug` is computed via the test-only oracle in
         `mergify_cli/tests/_slug_oracle.py`, which mirrors the
         Rust `mergify-stack::slug::slugify_title` algorithm; the
-        Rust crate's unit tests pin the parity.
+        Rust crate's unit tests pin the parity. The `note`
+        defaults to empty string and individual tests can override
+        it via `Commit["note"]`.
         """
         from mergify_cli.tests._slug_oracle import slugify_title
 
@@ -148,6 +151,7 @@ class GitMock:
                     "message": body,
                     "change_id": c["change_id"],
                     "slug": slugify_title(c["title"], c["change_id"]),
+                    "note": c.get("note", ""),
                 },
             )
         return out


### PR DESCRIPTION
`mergify_cli/stack/push.py::read_reasons` ran one
`git notes --ref=refs/notes/mergify/stack show <sha>` subprocess
per `create`/`update` commit on every `mergify stack push`, just
to populate `LocalChange.reason` for the revision-history
comment. The walker was already doing one `git log` for the same
range; piggy-back the note read onto the same call via `%N` +
`--notes=refs/notes/mergify/stack` so the data arrives on the
existing bridge output instead of N extra round-trips.

- `mergify-stack::local_commits::LocalCommit` grows a `note`
  field (empty when the commit has no entry on the stack notes
  ref); the walker's format spec becomes
  `%H%x00%s%x00%b%x00%N%x1e` and the parser splits on 4 fields
- `mergify_cli/stack/changes.py::get_changes` passes
  `local["note"]` into `LocalChange(reason=…)` directly; the
  `read_reasons` orchestrator step in `stack_push` is gone, as
  is the function itself
- `GitMock` carries a `note` field on `Commit` (defaults to
  empty, matching git's `%N` output for commits with no entry)
  so existing stack tests don't need a per-commit
  `git notes show` mock anymore — they just override
  `Commit["note"]` when they care about the reason

Coverage:

- new Rust unit tests in `crates/mergify-stack/src/local_commits.rs`
  (`parse_extracts_note_when_present`,
  `parse_returns_empty_note_when_absent`); the existing
  `read_walks_a_real_repository` integration test grew a
  `git notes add` step and asserts both note-present and
  note-absent branches
- `mergify_cli/tests/stack/test_push.py::test_local_change_reason_populated_from_walker_note`
  replaces the deleted `test_read_reasons_*`: drives
  `changes.get_changes` end-to-end via the `git_mock` bridge,
  asserts the note flows through to `LocalChange.reason`
- the existing
  `test_revision_comment_includes_reason_from_local_change`
  stops registering a separate `git notes show` mock and sets
  the note on the `Commit` instead