### PR TITLE
fix(stack): detect duplicate open PRs sharing a Change-Id

### DIFF
--- a/mergify_cli/stack/changes.py
+++ b/mergify_cli/stack/changes.py
@@ -167,8 +167,18 @@ async def get_remote_changes(
                 pass
             elif other_pull["state"] == "closed" and pull["state"] == "open":
                 remote_changes[changeid] = pull
-            elif other_pull["state"] == "opened":
-                msg = f"More than 1 pull found with this head: {pull['head']['ref']}"
+            elif other_pull["state"] == "open" and pull["state"] == "open":
+                # Two open PRs on the same Change-Id is a user-state
+                # bug the rest of the orchestration can't reconcile
+                # (push would race, lease check would clobber).
+                # Surface loudly with both PR URLs + the Change-Id so
+                # the user can close one without a second round trip.
+                msg = (
+                    f"More than 1 pull found for Change-Id {changeid}: "
+                    f"#{other_pull['number']} ({other_pull['html_url']}) and "
+                    f"#{pull['number']} ({pull['html_url']}) "
+                    f"— close one of them and rerun."
+                )
                 raise RuntimeError(msg)
 
         else:

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -2036,6 +2036,79 @@ async def test_get_remote_changes_old_format_branch(
     assert cid in result
 
 
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_get_remote_changes_errors_on_duplicate_open_prs(
+    respx_mock: respx.MockRouter,
+) -> None:
+    """Two open PRs with the same Change-Id is a user-state bug the
+    rest of the orchestration can't reconcile (push would race,
+    lease check would clobber) — surface it loudly.
+
+    Regression: the previous check compared against `state ==
+    "opened"`, which is never GitHub's actual PR state (it's
+    `"open"` / `"closed"`). The error branch was therefore dead
+    and duplicate open PRs were silently kept.
+    """
+    import httpx
+
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/1",
+                    },
+                },
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/2",
+                    },
+                },
+            ],
+        },
+    )
+    same_change_id_ref = "my-stack/feat-a--deadbeef"
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/1",
+            "number": 1,
+            "title": "First",
+            "head": {"sha": "sha1", "ref": same_change_id_ref},
+            "body": "",
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/2").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/2",
+            "number": 2,
+            "title": "Second",
+            "head": {"sha": "sha2", "ref": same_change_id_ref},
+            "body": "",
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        with pytest.raises(RuntimeError, match="More than 1 pull found"):
+            await changes.get_remote_changes(
+                client,
+                user="user",
+                repo="repo",
+                stack_prefix="my-stack",
+                author="author",
+            )
+
+
 def test_revision_entry_timestamp_iso_normalises_to_utc() -> None:
     tz_ist = datetime.timezone(datetime.timedelta(hours=5, minutes=30))
     dt = datetime.datetime(2026, 4, 14, 20, 0, 0, tzinfo=tz_ist)  # 14:30:00 UTC


### PR DESCRIPTION
`changes.get_remote_changes` had a dead duplicate-detection
branch: when two PRs shared the same Change-Id, the second
`elif other_pull["state"] == "opened"` check compared against a
value GitHub's PR API never returns. The real state values are
`"open"` / `"closed"`, so the `RuntimeError("More than 1 pull
found …")` path was unreachable and duplicate open PRs were
silently kept.

Two open PRs on the same Change-Id is a user-state bug the rest
of the orchestration can't reconcile — `stack push` would race
on the head ref and the force-with-lease check would clobber
whichever PR wasn't first. Surface it loudly so the user closes
one manually instead of pushing into an undefined state.

The fix is a single-character correction (`"opened"` →
`"open"`) plus a respx-mocked regression test that drives two
search results with the same Change-Id-bearing head ref and
asserts the now-reachable error fires.

Spotted while reviewing the Rust port in #1503 — the port
faithfully reproduced the bug; this PR corrects the Python
first so the port lands on top of corrected behaviour rather
than carrying a "preserves intended behaviour" caveat in its
comments.