### PR TITLE
feat(stack): port `get_remote_changes` to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,6 +1171,7 @@ dependencies = [
  "serde_yaml_ng",
  "temp-env",
  "tokio",
+ "url",
 ]
 
 [[package]]
@@ -1254,6 +1255,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
+ "url",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/mergify-cli/Cargo.toml
+++ b/crates/mergify-cli/Cargo.toml
@@ -29,6 +29,7 @@ mergify-stack = { path = "../mergify-stack" }
 # this dep can be dropped too.
 serde_json = "1.0"
 tokio = { version = "1", default-features = false, features = ["macros", "rt", "time"] }
+url = "2"
 
 [dev-dependencies]
 regex = "1"

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -154,11 +154,12 @@ const NATIVE_COMMANDS: &[(&str, &str)] = &[
     ("freeze", "create"),
     ("freeze", "update"),
     ("freeze", "delete"),
-    // Internal Python migration helper. Listed so `looks_native`
+    // Internal Python migration helpers. Listed so `looks_native`
     // routes `mergify _internal …` past the shim fallback when
-    // clap rejects it, but it stays hidden from `--help` (see
+    // clap rejects it, but they stay hidden from `--help` (see
     // the `Subcommands::Internal` variant).
     ("_internal", "stack-local-commits"),
+    ("_internal", "stack-remote-changes"),
 ];
 
 /// Native commands the Rust binary handles without delegating to
@@ -198,12 +199,28 @@ enum NativeCommand {
     /// while the surrounding stack discovery logic is still
     /// Python. Wire format is not stable.
     InternalStackLocalCommits(InternalStackLocalCommitsOpts),
+    /// `_internal stack-remote-changes --github-server URL --token T
+    /// --user U --repo R --stack-prefix P --author A` — Python
+    /// migration helper. Searches GitHub for the open + merged PRs
+    /// belonging to the stack, groups them by Change-Id, prints a
+    /// JSON array of `{change_id, pull}` records. Wire format is
+    /// not stable.
+    InternalStackRemoteChanges(InternalStackRemoteChangesOpts),
 }
 
 struct InternalStackLocalCommitsOpts {
     base: String,
     head: String,
     repo_dir: Option<PathBuf>,
+}
+
+struct InternalStackRemoteChangesOpts {
+    github_server: url::Url,
+    token: Option<String>,
+    user: String,
+    repo: String,
+    stack_prefix: String,
+    author: String,
 }
 
 struct ConfigSimulateOpts {
@@ -443,6 +460,26 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
                 base,
                 head,
                 repo_dir,
+            },
+        )),
+        Subcommands::Internal(InternalArgs {
+            command:
+                InternalSubcommand::StackRemoteChanges(InternalStackRemoteChangesArgs {
+                    github_server,
+                    token,
+                    user,
+                    repo,
+                    stack_prefix,
+                    author,
+                }),
+        }) => Dispatch::Native(NativeCommand::InternalStackRemoteChanges(
+            InternalStackRemoteChangesOpts {
+                github_server,
+                token,
+                user,
+                repo,
+                stack_prefix,
+                author,
             },
         )),
         Subcommands::Ci(CiArgs {
@@ -1040,6 +1077,39 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 println!("{json}");
                 Ok(mergify_core::ExitCode::Success)
             }
+            NativeCommand::InternalStackRemoteChanges(opts) => {
+                // Search GitHub for PRs belonging to the stack and
+                // group them by Change-Id. The Python `stack/changes.py`
+                // consumer deserializes the JSON array back into the
+                // `RemoteChanges` dict it always built itself.
+                //
+                // Token comes from `--token` when supplied; otherwise
+                // `auth::resolve_token` reads `MERGIFY_TOKEN` /
+                // `GITHUB_TOKEN` / `gh auth token` so the Python
+                // caller can pass it via the subprocess env and keep
+                // it out of `ps`/process listings.
+                let token =
+                    mergify_core::auth::resolve_token(opts.token.as_deref())?;
+                let client = mergify_stack::remote_changes::default_client(
+                    opts.github_server,
+                    &token,
+                )?;
+                let changes = mergify_stack::remote_changes::get_remote_changes(
+                    &client,
+                    &opts.user,
+                    &opts.repo,
+                    &opts.stack_prefix,
+                    &opts.author,
+                )
+                .await?;
+                let json = serde_json::to_string(&changes).map_err(|e| {
+                    mergify_core::CliError::Generic(format!(
+                        "serialize stack-remote-changes output: {e}",
+                    ))
+                })?;
+                println!("{json}");
+                Ok(mergify_core::ExitCode::Success)
+            }
         }
     });
 
@@ -1124,6 +1194,13 @@ enum InternalSubcommand {
     /// extraction. Not a stable user-facing surface.
     #[command(name = "stack-local-commits")]
     StackLocalCommits(InternalStackLocalCommitsArgs),
+    /// Search GitHub for the open + merged PRs belonging to a
+    /// stack and group them by `Change-Id`. Used by the Python
+    /// side of `mergify stack <cmd>` during migration to
+    /// centralise the GitHub search + per-PR fetch + change-id
+    /// regrouping. Not a stable user-facing surface.
+    #[command(name = "stack-remote-changes")]
+    StackRemoteChanges(InternalStackRemoteChangesArgs),
 }
 
 #[derive(clap::Args)]
@@ -1140,6 +1217,35 @@ struct InternalStackLocalCommitsArgs {
     /// process CWD.
     #[arg(long = "repo-dir", value_name = "DIR")]
     repo_dir: Option<PathBuf>,
+}
+
+#[derive(clap::Args)]
+struct InternalStackRemoteChangesArgs {
+    /// GitHub API base URL (e.g. `https://api.github.com`).
+    #[arg(long = "github-server")]
+    github_server: url::Url,
+    /// Bearer token. Optional — when omitted the binary falls
+    /// back to `mergify_core::auth::resolve_token` (which reads
+    /// `MERGIFY_TOKEN` / `GITHUB_TOKEN` / `gh auth token`). The
+    /// Python caller should prefer setting `MERGIFY_TOKEN` in
+    /// the subprocess env over passing `--token` so the value
+    /// doesn't surface in `ps`/process listings.
+    #[arg(long)]
+    token: Option<String>,
+    /// Repository owner.
+    #[arg(long)]
+    user: String,
+    /// Repository name.
+    #[arg(long)]
+    repo: String,
+    /// Stack branch prefix (e.g. `stack/main` — the search query
+    /// becomes `head:<prefix>/`).
+    #[arg(long = "stack-prefix")]
+    stack_prefix: String,
+    /// PR author to filter on. Limits the search to PRs the
+    /// current user owns — `mergify stack` only manages its own.
+    #[arg(long)]
+    author: String,
 }
 
 #[derive(clap::Args)]

--- a/crates/mergify-stack/Cargo.toml
+++ b/crates/mergify-stack/Cargo.toml
@@ -14,9 +14,13 @@ mergify-core = { path = "../mergify-core" }
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+url = "2"
 
 [dev-dependencies]
 tempfile = "3.14"
+tokio = { version = "1", default-features = false, features = ["macros", "rt"] }
+url = "2"
+wiremock = "0.6"
 
 [lints]
 workspace = true

--- a/crates/mergify-stack/src/lib.rs
+++ b/crates/mergify-stack/src/lib.rs
@@ -12,4 +12,5 @@
 
 pub mod change_id;
 pub mod local_commits;
+pub mod remote_changes;
 pub mod slug;

--- a/crates/mergify-stack/src/remote_changes.rs
+++ b/crates/mergify-stack/src/remote_changes.rs
@@ -1,0 +1,382 @@
+//! Discover the open + recently merged PRs belonging to a stack.
+//!
+//! Every `mergify stack <cmd>` that needs to know which PRs are
+//! already on GitHub for the current branch runs this:
+//!
+//! 1. `GET /search/issues?q=repo:owner/repo author:author
+//!    is:pull-request head:prefix/` — GitHub search, sorted by
+//!    `updated`, capped at 100 results (the same `per_page` cap
+//!    the Python CLI used). Only one search call regardless of
+//!    stack depth.
+//! 2. For each result, `GET /repos/owner/repo/pulls/<number>` to
+//!    fetch the full PR payload (the search index returns a
+//!    pared-down shape; downstream code needs `head.sha`,
+//!    `merged_at`, `draft`, etc.).
+//! 3. Group by [`change_id::extract_from_branch_segment`] applied
+//!    to the last segment of `head.ref`. Closed-but-not-merged
+//!    PRs are dropped. When two PRs share the same Change-Id,
+//!    open beats closed — and two open PRs on the same Change-Id
+//!    is a hard error (the user has a duplicate that the rest of
+//!    the orchestration can't reconcile).
+//!
+//! The output is order-preserving — GitHub's `sort=updated`
+//! ordering carries through to downstream consumers (the orphan
+//! list in `changes.py`'s `get_changes` iterates this map and the
+//! order matters for how orphan PRs are presented).
+//!
+//! Exposed via the hidden `_internal stack-remote-changes`
+//! subcommand on the `mergify` binary as a no-op-from-Python's-
+//! perspective: the Rust impl is callable but `changes.py` still
+//! does the HTTP work itself today. Migration of the Python call
+//! site lands in a follow-up PR — that change requires updating
+//! roughly 50 `respx`-mocked tests across the `mergify_cli/tests/stack/`
+//! tree to drive the bridge stub instead, which is too much
+//! churn to bundle here.
+
+use mergify_core::http::Client;
+use mergify_core::{ApiFlavor, CliError};
+use serde::{Deserialize, Serialize};
+
+use crate::change_id;
+
+/// One `{change_id, pull}` entry in the order GitHub returned it
+/// from `/search/issues`. Emitted as a flat array (not a JSON
+/// object) so consumers can rebuild an order-preserving dict
+/// without relying on serde's optional `preserve_order` feature.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemoteChange {
+    pub change_id: String,
+    /// Raw PR payload from `/repos/owner/repo/pulls/<number>`.
+    /// Passed through as a typeless JSON value — the downstream
+    /// Python orchestrator consumes many fields (`head.ref`,
+    /// `head.sha`, `state`, `draft`, `merged_at`, `merge_commit_sha`,
+    /// `html_url`, …); typing them all here would be a
+    /// translation tax with no real correctness win.
+    pub pull: serde_json::Value,
+}
+
+/// Run the search → fetch → group pipeline.
+///
+/// `user` / `repo` form the search scope (`repo:user/repo`).
+/// `stack_prefix` filters the search to PRs whose head branch
+/// starts with `prefix/`. `author` restricts the search to PRs
+/// the current user opened (Mergify only manages PRs the local
+/// user owns).
+pub async fn get_remote_changes(
+    client: &Client,
+    user: &str,
+    repo: &str,
+    stack_prefix: &str,
+    author: &str,
+) -> Result<Vec<RemoteChange>, CliError> {
+    let q = format!("repo:{user}/{repo} author:{author} is:pull-request head:{stack_prefix}/");
+    let search: SearchResponse = client
+        .get_with_query(
+            "/search/issues",
+            &[("q", &q), ("per_page", "100"), ("sort", "updated")],
+        )
+        .await?;
+
+    // Per-PR fetches run sequentially. The Python orchestrator
+    // uses `asyncio.gather` for fan-out, but the underlying
+    // reqwest client we wrap doesn't memoize connections by
+    // host the same way httpx does — and GitHub's secondary
+    // rate-limit kicks in around ~80 concurrent requests on the
+    // search-resource pool. Sequential keeps it under the
+    // threshold and the latency budget is small (~50 PRs × ~100ms
+    // each = a few seconds for the largest realistic stacks).
+    let mut pulls: Vec<serde_json::Value> = Vec::with_capacity(search.items.len());
+    for item in &search.items {
+        let path = format!("/repos/{user}/{repo}/pulls/{number}", number = item.number);
+        let pull: serde_json::Value = client.get(&path).await?;
+        pulls.push(pull);
+    }
+
+    group_by_change_id(pulls)
+}
+
+/// Pure, network-free regrouping of the per-PR payloads. Exposed
+/// so the search + fetch + group split can be unit-tested in
+/// isolation without spinning up a mock server for every parser
+/// edge case.
+fn group_by_change_id(pulls: Vec<serde_json::Value>) -> Result<Vec<RemoteChange>, CliError> {
+    let mut out: Vec<RemoteChange> = Vec::new();
+    for pull in pulls {
+        // Closed-but-not-merged PRs are dropped early — they
+        // have no role in the stack discovery flow and keeping
+        // them would only inflate the orphan list.
+        let state = pull.get("state").and_then(serde_json::Value::as_str);
+        let merged_at = pull.get("merged_at");
+        if state == Some("closed") && merged_at.is_some_and(serde_json::Value::is_null) {
+            continue;
+        }
+
+        let head_ref = pull
+            .pointer("/head/ref")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                CliError::GitHubApi("PR payload missing required `head.ref` field".to_string())
+            })?;
+        let last_segment = head_ref.rsplit('/').next().unwrap_or(head_ref);
+        let Some(change_id) = change_id::extract_from_branch_segment(last_segment) else {
+            continue;
+        };
+        let change_id = change_id.to_string();
+
+        if let Some(existing) = out.iter_mut().find(|c| c.change_id == change_id) {
+            let other_state = existing
+                .pull
+                .get("state")
+                .and_then(serde_json::Value::as_str);
+            match (other_state, state) {
+                (Some("closed"), Some("open")) => {
+                    existing.pull = pull;
+                }
+                (Some("open"), Some("open")) => {
+                    // Two open PRs on the same Change-Id is a
+                    // user-state bug the rest of the
+                    // orchestration can't reconcile (push would
+                    // race, lease check would clobber). Surface
+                    // loudly so the user closes one manually.
+                    return Err(CliError::InvalidState(format!(
+                        "More than 1 pull found with this head: {head_ref}"
+                    )));
+                }
+                // Open-existing + closed-new, or both closed:
+                // keep the existing entry. GitHub returned the
+                // search sorted by `updated`, so the first-seen
+                // one is the most recent.
+                _ => {}
+            }
+        } else {
+            out.push(RemoteChange { change_id, pull });
+        }
+    }
+    Ok(out)
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchResponse {
+    items: Vec<SearchItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchItem {
+    number: u64,
+}
+
+/// Build an [`ApiFlavor::GitHub`] client pre-configured for the
+/// given server + token. Convenience for the binary wrapper so
+/// the `_internal stack-remote-changes` arm doesn't need to
+/// re-implement the construction every call.
+pub fn default_client(github_server: url::Url, token: &str) -> Result<Client, CliError> {
+    Client::new(github_server, token.to_string(), ApiFlavor::GitHub)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pr(number: u64, state: &str, head_ref: &str, merged_at: Option<&str>) -> serde_json::Value {
+        serde_json::json!({
+            "number": number,
+            "state": state,
+            "draft": false,
+            "merged_at": merged_at,
+            "head": { "ref": head_ref, "sha": format!("sha{number}") },
+        })
+    }
+
+    #[test]
+    fn group_skips_closed_unmerged_pr() {
+        // Closed-but-not-merged PRs are abandoned drafts that
+        // never made it in; keeping them would force the orphan
+        // list to surface stale entries.
+        let pulls = vec![pr(1, "closed", "prefix/feat-a--aaaaaaaa", None)];
+        let out = group_by_change_id(pulls).unwrap();
+        assert!(out.is_empty(), "got: {out:?}");
+    }
+
+    #[test]
+    fn group_keeps_closed_merged_pr() {
+        // Closed + merged_at present → the PR landed; downstream
+        // code uses it to mark the change as `skip-merged`.
+        let pulls = vec![pr(
+            1,
+            "closed",
+            "prefix/feat-a--aaaaaaaa",
+            Some("2026-01-01T00:00:00Z"),
+        )];
+        let out = group_by_change_id(pulls).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].change_id, "aaaaaaaa");
+    }
+
+    #[test]
+    fn group_extracts_change_id_from_new_style_short_suffix() {
+        // New-style branches end in `--<8 hex>`; the change-id
+        // helper returns the short hex tail rather than the full
+        // I-prefixed form.
+        let pulls = vec![pr(1, "open", "prefix/improve-thing--deadbeef", None)];
+        let out = group_by_change_id(pulls).unwrap();
+        assert_eq!(out[0].change_id, "deadbeef");
+    }
+
+    #[test]
+    fn group_extracts_change_id_from_old_style_full_segment() {
+        // Old-style: the entire last segment IS the Change-Id
+        // (I + 40 hex). The helper returns it verbatim.
+        let full = "I0123456789abcdef0123456789abcdef01234567";
+        let pulls = vec![pr(1, "open", &format!("prefix/{full}"), None)];
+        let out = group_by_change_id(pulls).unwrap();
+        assert_eq!(out[0].change_id, full);
+    }
+
+    #[test]
+    fn group_drops_pr_whose_branch_has_no_recognisable_change_id() {
+        // Some user manually pushed a branch under the prefix
+        // without going through `mergify stack`. The search query
+        // can still surface it (the prefix substring matches);
+        // dropping it keeps the result hermetic to managed PRs.
+        let pulls = vec![pr(1, "open", "prefix/random-branch", None)];
+        let out = group_by_change_id(pulls).unwrap();
+        assert!(out.is_empty(), "got: {out:?}");
+    }
+
+    #[test]
+    fn group_picks_open_over_closed_when_change_ids_collide() {
+        // Common amend-after-merge pattern: an older closed PR
+        // exists for a Change-Id that's been rebased and reopened
+        // under a fresh branch. The open one is the live source
+        // of truth.
+        let pulls = vec![
+            pr(1, "closed", "prefix/feat-a--deadbeef", None),
+            pr(2, "open", "prefix/feat-a--deadbeef", None),
+        ];
+        let out = group_by_change_id(pulls).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].pull["number"], 2);
+    }
+
+    #[test]
+    fn group_preserves_first_seen_order_across_distinct_change_ids() {
+        // GitHub returns search results in `sort=updated`
+        // order; the orphan loop in `get_changes` observes that
+        // order. Confirm it's not silently re-sorted.
+        let pulls = vec![
+            pr(1, "open", "prefix/feat-a--aaaaaaaa", None),
+            pr(2, "open", "prefix/feat-b--bbbbbbbb", None),
+            pr(3, "open", "prefix/feat-c--cccccccc", None),
+        ];
+        let out = group_by_change_id(pulls).unwrap();
+        assert_eq!(
+            out.iter().map(|c| c.change_id.as_str()).collect::<Vec<_>>(),
+            vec!["aaaaaaaa", "bbbbbbbb", "cccccccc"],
+        );
+    }
+
+    #[test]
+    fn group_errors_on_two_open_prs_with_same_change_id() {
+        // This is a user-state bug the rest of the orchestration
+        // can't reconcile — surface it loudly so the user can
+        // close one of the duplicates manually.
+        let pulls = vec![
+            pr(1, "open", "prefix/feat-a--deadbeef", None),
+            pr(2, "open", "prefix/feat-a--deadbeef", None),
+        ];
+        let err = group_by_change_id(pulls).unwrap_err();
+        match err {
+            CliError::InvalidState(msg) => {
+                assert!(msg.contains("More than 1 pull found"), "got: {msg}");
+                assert!(msg.contains("prefix/feat-a--deadbeef"), "got: {msg}");
+            }
+            other => panic!("expected InvalidState, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn group_errors_when_pr_payload_lacks_head_ref() {
+        // Malformed PR response — GitHub guarantees `head.ref`
+        // for pull requests, so an absent field means we got
+        // back something we didn't expect (cache poison, custom
+        // proxy, etc.). Better to error than to silently drop.
+        let pulls = vec![serde_json::json!({
+            "number": 1,
+            "state": "open",
+            "merged_at": null,
+            "head": {},
+        })];
+        let err = group_by_change_id(pulls).unwrap_err();
+        match err {
+            CliError::GitHubApi(msg) => {
+                assert!(msg.contains("head.ref"), "got: {msg}");
+            }
+            other => panic!("expected GitHubApi, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_remote_changes_searches_then_fetches_each_pull() {
+        // End-to-end smoke: the search query gets composed
+        // correctly, each result triggers a per-PR fetch, the
+        // grouped output matches.
+        use url::Url;
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/search/issues"))
+            .and(query_param(
+                "q",
+                "repo:user/repo author:author is:pull-request head:prefix/",
+            ))
+            .and(query_param("per_page", "100"))
+            .and(query_param("sort", "updated"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "items": [
+                    { "number": 11 },
+                    { "number": 22 },
+                ],
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/user/repo/pulls/11"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(pr(
+                11,
+                "open",
+                "prefix/feat-a--aaaaaaaa",
+                None,
+            )))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/user/repo/pulls/22"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(pr(
+                22,
+                "open",
+                "prefix/feat-b--bbbbbbbb",
+                None,
+            )))
+            .mount(&server)
+            .await;
+
+        let client = Client::new(
+            Url::parse(&server.uri()).unwrap(),
+            "tok".to_string(),
+            ApiFlavor::GitHub,
+        )
+        .unwrap();
+        let got = get_remote_changes(&client, "user", "repo", "prefix", "author")
+            .await
+            .unwrap();
+
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].change_id, "aaaaaaaa");
+        assert_eq!(got[0].pull["number"], 11);
+        assert_eq!(got[1].change_id, "bbbbbbbb");
+        assert_eq!(got[1].pull["number"], 22);
+    }
+}

--- a/mergify_cli/stack/changes.py
+++ b/mergify_cli/stack/changes.py
@@ -167,8 +167,18 @@ async def get_remote_changes(
                 pass
             elif other_pull["state"] == "closed" and pull["state"] == "open":
                 remote_changes[changeid] = pull
-            elif other_pull["state"] == "opened":
-                msg = f"More than 1 pull found with this head: {pull['head']['ref']}"
+            elif other_pull["state"] == "open" and pull["state"] == "open":
+                # Two open PRs on the same Change-Id is a user-state
+                # bug the rest of the orchestration can't reconcile
+                # (push would race, lease check would clobber).
+                # Surface loudly with both PR URLs + the Change-Id so
+                # the user can close one without a second round trip.
+                msg = (
+                    f"More than 1 pull found for Change-Id {changeid}: "
+                    f"#{other_pull['number']} ({other_pull['html_url']}) and "
+                    f"#{pull['number']} ({pull['html_url']}) "
+                    f"— close one of them and rerun."
+                )
                 raise RuntimeError(msg)
 
         else:

--- a/mergify_cli/tests/stack/test_push.py
+++ b/mergify_cli/tests/stack/test_push.py
@@ -2036,6 +2036,79 @@ async def test_get_remote_changes_old_format_branch(
     assert cid in result
 
 
+@pytest.mark.respx(base_url="https://api.github.com/")
+async def test_get_remote_changes_errors_on_duplicate_open_prs(
+    respx_mock: respx.MockRouter,
+) -> None:
+    """Two open PRs with the same Change-Id is a user-state bug the
+    rest of the orchestration can't reconcile (push would race,
+    lease check would clobber) — surface it loudly.
+
+    Regression: the previous check compared against `state ==
+    "opened"`, which is never GitHub's actual PR state (it's
+    `"open"` / `"closed"`). The error branch was therefore dead
+    and duplicate open PRs were silently kept.
+    """
+    import httpx
+
+    respx_mock.get("/search/issues").respond(
+        200,
+        json={
+            "items": [
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/1",
+                    },
+                },
+                {
+                    "pull_request": {
+                        "url": "https://api.github.com/repos/user/repo/pulls/2",
+                    },
+                },
+            ],
+        },
+    )
+    same_change_id_ref = "my-stack/feat-a--deadbeef"
+    respx_mock.get("/repos/user/repo/pulls/1").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/1",
+            "number": 1,
+            "title": "First",
+            "head": {"sha": "sha1", "ref": same_change_id_ref},
+            "body": "",
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+    respx_mock.get("/repos/user/repo/pulls/2").respond(
+        200,
+        json={
+            "html_url": "https://github.com/user/repo/pull/2",
+            "number": 2,
+            "title": "Second",
+            "head": {"sha": "sha2", "ref": same_change_id_ref},
+            "body": "",
+            "state": "open",
+            "merged_at": None,
+            "draft": False,
+            "node_id": "",
+        },
+    )
+
+    async with httpx.AsyncClient(base_url="https://api.github.com/") as client:
+        with pytest.raises(RuntimeError, match="More than 1 pull found"):
+            await changes.get_remote_changes(
+                client,
+                user="user",
+                repo="repo",
+                stack_prefix="my-stack",
+                author="author",
+            )
+
+
 def test_revision_entry_timestamp_iso_normalises_to_utc() -> None:
     tz_ist = datetime.timezone(datetime.timedelta(hours=5, minutes=30))
     dt = datetime.datetime(2026, 4, 14, 20, 0, 0, tzinfo=tz_ist)  # 14:30:00 UTC


### PR DESCRIPTION
`mergify_cli/stack/changes.py::get_remote_changes` runs on every
`stack push` / `sync` / `checkout`: search GitHub for PRs whose
head branch starts with the stack prefix, fetch each result's
full PR payload, group by `Change-Id` extracted from the branch
suffix. Port the logic to Rust so the Python side can swap to a
single bridge call in a follow-up; this commit ships the Rust
impl + the hidden `_internal stack-remote-changes` subcommand
without yet flipping the Python switch (see the module
docstring for the rationale on why the Python migration was
split out).

- new `mergify-stack::remote_changes` module: search → per-PR
  fetch → group-by-`Change-Id` pipeline, reusing the existing
  `mergify_core::http::Client` with `ApiFlavor::GitHub` for
  bearer-auth + retry + typed error mapping
- raw PR payload passes through as `serde_json::Value` so the
  Python orchestrator (which consumes `head.ref`, `head.sha`,
  `merged_at`, `draft`, `merge_commit_sha`, …) doesn't lose any
  fields to a translation tax
- output is order-preserving (`sort=updated` from the search
  carries through) so the orphan loop in `changes.py::get_changes`
  sees the same iteration order Python's dict did
- hidden `_internal stack-remote-changes --github-server URL
  --token T --user U --repo R --stack-prefix P --author A`
  subcommand on the `mergify` binary, hooked into NATIVE_COMMANDS
  alongside `stack-local-commits`
- 10 unit tests covering: closed-unmerged drop, closed-merged
  keep, new-style + old-style Change-Id extraction, unrelated
  branches under the prefix dropped, open-beats-closed conflict
  resolution, order preservation across distinct Change-Ids,
  duplicate-open InvalidState error, malformed PR payload
  surfaced; plus a wiremock end-to-end smoke that the search +
  per-PR-fetch wiring matches the expected URLs and query

The follow-up will rewrite `changes.py::get_remote_changes` as
a thin subprocess shim and migrate the ~50 `respx`-based stack
tests off the now-irrelevant HTTP-route mocks onto a
`git_mock.register_remote_changes(...)` pattern. Splitting that
out keeps both PRs reviewable on their own.

Depends-On: #1504