### PR TITLE
feat(tests): add `tests quarantined` to list the CI Insights quarantine

### DIFF
--- a/crates/mergify-ci/src/tests_quarantine.rs
+++ b/crates/mergify-ci/src/tests_quarantine.rs
@@ -1,6 +1,6 @@
-//! `mergify tests quarantine` / `mergify tests unquarantine` — add a
-//! test to, or remove it from, the CI Insights quarantine through the
-//! public quarantine API.
+//! `mergify tests quarantine` / `mergify tests unquarantine` /
+//! `mergify tests quarantined` — add a test to, remove it from, or list
+//! the CI Insights quarantine through the public quarantine API.
 //!
 //! `quarantine` addresses a test by its fully qualified name.
 //! `unquarantine` accepts either the quarantine id (deleted directly,
@@ -9,9 +9,12 @@
 //! `(repository, test_name)`, so a name resolves to at most one
 //! quarantine per repository — `unquarantine` relies on this when it
 //! looks the name up in the list endpoint to recover the id.
+//! `quarantined` lists that same endpoint, rendering every record.
 
 use std::io::{self, Write};
 
+use chrono::DateTime;
+use chrono::Utc;
 use mergify_core::ApiFlavor;
 use mergify_core::CliError;
 use mergify_core::DeleteOutcome;
@@ -38,6 +41,12 @@ pub struct UnquarantineOptions<'a> {
     /// A test name or a quarantine id. A UUID-shaped value is taken as
     /// the quarantine id; anything else is treated as a test name.
     pub name_or_id: &'a str,
+    pub token: Option<&'a str>,
+    pub api_url: Option<&'a str>,
+}
+
+pub struct QuarantinedOptions<'a> {
+    pub repository: &'a str,
     pub token: Option<&'a str>,
     pub api_url: Option<&'a str>,
 }
@@ -104,6 +113,30 @@ pub async fn unquarantine(
     Ok(ExitCode::Success)
 }
 
+/// List every quarantine recorded for the repository, one block per
+/// record. Returns `Success` even when the quarantine is empty — an
+/// empty list is a normal state, not an error (mirrors `freeze list`).
+/// Auth, request, and decode failures still propagate as errors.
+pub async fn quarantined(
+    opts: QuarantinedOptions<'_>,
+    output: &mut dyn Output,
+) -> Result<ExitCode, CliError> {
+    let (owner, repo) = split_owner_repo(opts.repository)?;
+    let token = auth::resolve_token(opts.token)?;
+    let api_url = auth::resolve_api_url(opts.api_url)?;
+    let client = HttpClient::new(api_url, token, ApiFlavor::Mergify)?;
+
+    // Omitting `per_page` returns the full list in a single response.
+    let path = format!("/v1/ci/{owner}/repositories/{repo}/quarantines");
+    let list: QuarantineList<QuarantinedTest> = client.get(&path).await?;
+
+    let payload = QuarantinedPayload {
+        quarantined_tests: list.quarantined_tests,
+    };
+    output.emit(&payload, &mut |w| render_quarantined_list(w, &payload))?;
+    Ok(ExitCode::Success)
+}
+
 /// The quarantine targeted by `unquarantine`, with the test name
 /// included only when we learned it (i.e. resolved by name).
 struct UnquarantineTarget {
@@ -132,7 +165,7 @@ async fn resolve_target(
 
     // Omitting `per_page` returns the full list in a single response.
     let list_path = format!("/v1/ci/{owner}/repositories/{repo}/quarantines");
-    let list: QuarantineList = client.get(&list_path).await?;
+    let list: QuarantineList<QuarantineListItem> = client.get(&list_path).await?;
     list.quarantined_tests
         .into_iter()
         .find(|quarantine| quarantine.test_name == name_or_id)
@@ -181,15 +214,43 @@ struct AddQuarantineResponse {
     id: String,
 }
 
+/// The list endpoint's envelope. Generic over the row type so callers
+/// pull only the fields they need: `unquarantine` resolves a name to an
+/// id with the minimal [`QuarantineListItem`], while `quarantined`
+/// reads the full [`QuarantinedTest`] for display.
 #[derive(Deserialize)]
-struct QuarantineList {
-    quarantined_tests: Vec<QuarantineListItem>,
+struct QuarantineList<T> {
+    quarantined_tests: Vec<T>,
 }
 
 #[derive(Deserialize)]
 struct QuarantineListItem {
     id: String,
     test_name: String,
+}
+
+/// A full quarantine record as listed by `quarantined`. Every field is
+/// re-serialized in `--json` mode, so the fields the human block omits
+/// (e.g. `created_at`) still reach machine consumers.
+#[derive(Deserialize, Serialize)]
+struct QuarantinedTest {
+    id: String,
+    test_name: String,
+    reason: String,
+    // Null means the quarantine applies to every branch.
+    branch: Option<String>,
+    created_at: DateTime<Utc>,
+    // How the quarantine was created — `manual` by a user, `auto` by
+    // flaky detection. Kept as the raw string (the API models it as a
+    // free-form string with a `manual` default, not a closed enum) so
+    // `--json` stays faithful and an omitted value still deserializes.
+    #[serde(default = "default_source")]
+    source: String,
+    is_recovered: bool,
+}
+
+fn default_source() -> String {
+    "manual".to_string()
 }
 
 #[derive(Serialize)]
@@ -211,6 +272,14 @@ struct UnquarantineResult {
     test_name: Option<String>,
 }
 
+/// The `quarantined` payload. Wraps the rows under `quarantined_tests`
+/// so `--json` emits `{"quarantined_tests": [...]}`, mirroring the API
+/// envelope.
+#[derive(Serialize)]
+struct QuarantinedPayload {
+    quarantined_tests: Vec<QuarantinedTest>,
+}
+
 fn render_quarantined(w: &mut dyn Write, result: &QuarantineResult) -> io::Result<()> {
     write!(w, "✓ Quarantined '{}'", result.test_name)?;
     if let Some(branch) = &result.branch {
@@ -224,6 +293,49 @@ fn render_unquarantined(w: &mut dyn Write, result: &UnquarantineResult) -> io::R
         Some(test_name) => writeln!(w, "✓ Unquarantined '{test_name}' (id: {}).", result.id),
         None => writeln!(w, "✓ Unquarantined quarantine {}.", result.id),
     }
+}
+
+/// Render each quarantine as an indented block followed by a count, or
+/// a single line when nothing is quarantined. The test name gets its
+/// own line — never a table cell — so a long name is never wrapped
+/// mid-name. Mirrors `tests show`'s detail layout in this crate.
+fn render_quarantined_list(w: &mut dyn Write, payload: &QuarantinedPayload) -> io::Result<()> {
+    let tests = &payload.quarantined_tests;
+    if tests.is_empty() {
+        return writeln!(w, "No quarantined tests found.");
+    }
+
+    for (index, test) in tests.iter().enumerate() {
+        if index > 0 {
+            writeln!(w)?;
+        }
+        render_quarantined_one(w, test)?;
+    }
+
+    writeln!(w)?;
+    let n = tests.len();
+    writeln!(
+        w,
+        "{n} quarantined test{plural}",
+        plural = if n == 1 { "" } else { "s" },
+    )
+}
+
+/// One record: the test name as a header, then its id (the value
+/// `unquarantine` accepts) and metadata indented under it. A null
+/// branch shows as `*`, the "all branches" marker `quarantine`'s human
+/// output already uses.
+fn render_quarantined_one(w: &mut dyn Write, test: &QuarantinedTest) -> io::Result<()> {
+    writeln!(w, "{}", test.test_name)?;
+    writeln!(w, "  id:         {}", test.id)?;
+    writeln!(w, "  branch:     {}", test.branch.as_deref().unwrap_or("*"))?;
+    writeln!(w, "  source:     {}", test.source)?;
+    writeln!(
+        w,
+        "  recovered:  {}",
+        if test.is_recovered { "yes" } else { "no" },
+    )?;
+    writeln!(w, "  reason:     {}", test.reason)
 }
 
 #[cfg(test)]
@@ -613,5 +725,231 @@ mod tests {
         assert!(matches!(err, CliError::MergifyApi(_)), "got {err:?}");
         assert!(err.to_string().contains("is not quarantined"), "got {err}");
         assert_eq!(read(&cap.stdout), "");
+    }
+
+    fn quarantined_options(api_url: &str) -> QuarantinedOptions<'_> {
+        QuarantinedOptions {
+            repository: "owner/repo",
+            token: Some("test-token"),
+            api_url: Some(api_url),
+        }
+    }
+
+    async fn mount_quarantine_list(server: &MockServer, body: serde_json::Value) {
+        Mock::given(method("GET"))
+            .and(path_matcher(QUARANTINES_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn quarantined_renders_each_record_as_a_block() {
+        let server = MockServer::start().await;
+        mount_quarantine_list(
+            &server,
+            json!({
+                "quarantined_tests": [
+                    {
+                        "id": "id-1",
+                        "test_name": "test_login",
+                        "reason": "flaky — MRGFY-1234",
+                        "branch": null,
+                        "created_at": "2026-01-01T10:00:00Z",
+                        "source": "manual",
+                        "is_recovered": false,
+                    },
+                    {
+                        "id": "id-2",
+                        "test_name": "test_logout",
+                        "reason": "consistently failing",
+                        "branch": "release/*",
+                        "created_at": "2026-02-01T12:00:00Z",
+                        "source": "auto",
+                        "is_recovered": true,
+                    },
+                ],
+                "size": 2,
+                "per_page": null,
+            }),
+        )
+        .await;
+
+        let mut cap = captured(OutputMode::Human);
+        let api_url = server.uri();
+        let exit = quarantined(quarantined_options(&api_url), &mut cap.output)
+            .await
+            .unwrap();
+
+        assert_eq!(exit, ExitCode::Success);
+        let out = read(&cap.stdout);
+        // Each test name sits on its own line (a block header), with the
+        // quarantine id shown so the row is actionable for `unquarantine`.
+        assert!(out.contains("test_login\n"), "got {out:?}");
+        assert!(out.contains("id:         id-1"), "id missing, got {out:?}");
+        assert!(out.contains("id:         id-2"), "id missing, got {out:?}");
+        // A null branch renders as the all-branches marker.
+        assert!(
+            out.contains("branch:     *"),
+            "null branch should show '*', got {out:?}"
+        );
+        assert!(out.contains("source:     manual"), "got {out:?}");
+        assert!(out.contains("branch:     release/*"), "got {out:?}");
+        assert!(out.contains("source:     auto"), "got {out:?}");
+        assert!(out.contains("recovered:  yes"), "got {out:?}");
+        assert!(out.contains("recovered:  no"), "got {out:?}");
+        assert!(
+            out.contains("reason:     flaky — MRGFY-1234"),
+            "got {out:?}"
+        );
+        assert!(
+            out.contains("2 quarantined tests"),
+            "count missing, got {out:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn quarantined_empty_list_renders_message() {
+        let server = MockServer::start().await;
+        mount_quarantine_list(
+            &server,
+            json!({"quarantined_tests": [], "size": 0, "per_page": null}),
+        )
+        .await;
+
+        let mut cap = captured(OutputMode::Human);
+        let api_url = server.uri();
+        quarantined(quarantined_options(&api_url), &mut cap.output)
+            .await
+            .unwrap();
+
+        let out = read(&cap.stdout);
+        assert!(out.contains("No quarantined tests found"), "got {out:?}");
+    }
+
+    #[tokio::test]
+    async fn quarantined_json_emits_every_field() {
+        let server = MockServer::start().await;
+        mount_quarantine_list(
+            &server,
+            json!({
+                "quarantined_tests": [{
+                    "id": "id-1",
+                    "test_name": "test_login",
+                    "reason": "flaky",
+                    "branch": null,
+                    "created_at": "2026-01-01T10:00:00Z",
+                    "source": "auto",
+                    "is_recovered": true,
+                }],
+                "size": 1,
+                "per_page": null,
+            }),
+        )
+        .await;
+
+        let mut cap = captured(OutputMode::Json);
+        let api_url = server.uri();
+        quarantined(quarantined_options(&api_url), &mut cap.output)
+            .await
+            .unwrap();
+
+        let value: serde_json::Value = serde_json::from_str(&read(&cap.stdout)).unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "quarantined_tests": [{
+                    "id": "id-1",
+                    "test_name": "test_login",
+                    "reason": "flaky",
+                    "branch": null,
+                    "created_at": "2026-01-01T10:00:00Z",
+                    "source": "auto",
+                    "is_recovered": true,
+                }],
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn quarantined_preserves_unmodeled_source_verbatim() {
+        // The API models `source` as a free-form string; a value beyond
+        // manual/auto must reach `--json` unchanged, not normalized.
+        let server = MockServer::start().await;
+        mount_quarantine_list(
+            &server,
+            json!({
+                "quarantined_tests": [{
+                    "id": "id-1",
+                    "test_name": "test_login",
+                    "reason": "flaky",
+                    "branch": null,
+                    "created_at": "2026-01-01T10:00:00Z",
+                    "source": "some_future_source",
+                    "is_recovered": false,
+                }],
+                "size": 1,
+                "per_page": null,
+            }),
+        )
+        .await;
+
+        let mut cap = captured(OutputMode::Json);
+        let api_url = server.uri();
+        quarantined(quarantined_options(&api_url), &mut cap.output)
+            .await
+            .unwrap();
+
+        let value: serde_json::Value = serde_json::from_str(&read(&cap.stdout)).unwrap();
+        assert_eq!(
+            value["quarantined_tests"][0]["source"], "some_future_source",
+            "unmodeled source must round-trip verbatim, got {value}"
+        );
+    }
+
+    #[tokio::test]
+    async fn quarantined_omitted_source_defaults_to_manual() {
+        // The schema marks `source` optional with a `manual` default, so
+        // a record that omits it must still deserialize — not abort the
+        // whole list — and render as `manual`.
+        let server = MockServer::start().await;
+        mount_quarantine_list(
+            &server,
+            json!({
+                "quarantined_tests": [{
+                    "id": "id-1",
+                    "test_name": "test_login",
+                    "reason": "flaky",
+                    "branch": null,
+                    "created_at": "2026-01-01T10:00:00Z",
+                    "is_recovered": false,
+                }],
+                "size": 1,
+                "per_page": null,
+            }),
+        )
+        .await;
+
+        let mut cap = captured(OutputMode::Human);
+        let api_url = server.uri();
+        quarantined(quarantined_options(&api_url), &mut cap.output)
+            .await
+            .unwrap();
+
+        let out = read(&cap.stdout);
+        assert!(out.contains("source:     manual"), "got {out:?}");
+    }
+
+    #[tokio::test]
+    async fn quarantined_invalid_repository_format_is_a_configuration_error() {
+        let mut cap = captured(OutputMode::Human);
+        let opts = QuarantinedOptions {
+            repository: "not-a-slash-pair",
+            token: Some("t"),
+            api_url: Some("https://example.invalid"),
+        };
+        let err = quarantined(opts, &mut cap.output).await.unwrap_err();
+        assert!(matches!(err, CliError::Configuration(_)), "got {err:?}");
     }
 }

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -31,6 +31,7 @@ use mergify_ci::git_refs::GitRefsOptions;
 use mergify_ci::junit_process::JunitProcessOptions;
 use mergify_ci::scopes_send::ScopesSendOptions;
 use mergify_ci::tests_quarantine::QuarantineOptions;
+use mergify_ci::tests_quarantine::QuarantinedOptions;
 use mergify_ci::tests_quarantine::UnquarantineOptions;
 use mergify_ci::tests_show::TestsShowOptions;
 use mergify_config::simulate::PullRequestRef;
@@ -146,6 +147,7 @@ const NATIVE_COMMANDS: &[(&str, &str)] = &[
     ("tests", "show"),
     ("tests", "quarantine"),
     ("tests", "unquarantine"),
+    ("tests", "quarantined"),
     ("queue", "pause"),
     ("queue", "unpause"),
     ("queue", "status"),
@@ -183,6 +185,7 @@ enum NativeCommand {
     TestsShow(TestsShowOpts),
     TestsQuarantine(TestsQuarantineOpts),
     TestsUnquarantine(TestsUnquarantineOpts),
+    TestsQuarantined(TestsQuarantinedOpts),
     QueuePause(QueuePauseOpts),
     QueueUnpause(QueueUnpauseOpts),
     QueueStatus(QueueStatusOpts),
@@ -306,6 +309,13 @@ struct TestsQuarantineOpts {
 struct TestsUnquarantineOpts {
     repository: String,
     name_or_id: String,
+    token: Option<String>,
+    api_url: Option<String>,
+    json: bool,
+}
+
+struct TestsQuarantinedOpts {
+    repository: String,
     token: Option<String>,
     api_url: Option<String>,
     json: bool,
@@ -611,6 +621,20 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
             api_url,
             json,
         })),
+        Subcommands::Tests(TestsArgs {
+            command:
+                TestsSubcommand::Quarantined(TestsQuarantinedCliArgs {
+                    repository,
+                    token,
+                    api_url,
+                    json,
+                }),
+        }) => Dispatch::Native(NativeCommand::TestsQuarantined(TestsQuarantinedOpts {
+            repository,
+            token,
+            api_url,
+            json,
+        })),
         Subcommands::Queue(QueueArgs {
             repository,
             token,
@@ -781,6 +805,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
         NativeCommand::TestsShow(opts) if opts.json => OutputMode::Json,
         NativeCommand::TestsQuarantine(opts) if opts.json => OutputMode::Json,
         NativeCommand::TestsUnquarantine(opts) if opts.json => OutputMode::Json,
+        NativeCommand::TestsQuarantined(opts) if opts.json => OutputMode::Json,
         _ => OutputMode::Human,
     };
     let mut output = StdioOutput::new(mode);
@@ -911,6 +936,17 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                     UnquarantineOptions {
                         repository: &opts.repository,
                         name_or_id: &opts.name_or_id,
+                        token: opts.token.as_deref(),
+                        api_url: opts.api_url.as_deref(),
+                    },
+                    &mut output,
+                )
+                .await
+            }
+            NativeCommand::TestsQuarantined(opts) => {
+                mergify_ci::tests_quarantine::quarantined(
+                    QuarantinedOptions {
+                        repository: &opts.repository,
                         token: opts.token.as_deref(),
                         api_url: opts.api_url.as_deref(),
                     },
@@ -1380,6 +1416,8 @@ enum TestsSubcommand {
     Quarantine(TestsQuarantineCliArgs),
     /// Remove a test from the CI Insights quarantine.
     Unquarantine(TestsUnquarantineCliArgs),
+    /// List the tests currently in the CI Insights quarantine.
+    Quarantined(TestsQuarantinedCliArgs),
 }
 
 #[derive(clap::Args)]
@@ -1480,6 +1518,32 @@ struct TestsUnquarantineCliArgs {
     #[arg(value_name = "NAME_OR_ID")]
     name_or_id: String,
 
+    /// Repository full name (owner/repo).
+    #[arg(
+        long,
+        short = 'r',
+        required = true,
+        value_parser = mergify_ci::detector::parse_owner_repo,
+    )]
+    repository: String,
+
+    /// Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and
+    /// then ``GITHUB_TOKEN`` env vars.
+    #[arg(long, short = 't')]
+    token: Option<String>,
+
+    /// Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var,
+    /// then to the default.
+    #[arg(long = "api-url", short = 'u')]
+    api_url: Option<String>,
+
+    /// Emit a single JSON document to stdout instead of human prose.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(clap::Args)]
+struct TestsQuarantinedCliArgs {
     /// Repository full name (owner/repo).
     #[arg(
         long,

--- a/skills/mergify-ci/SKILL.md
+++ b/skills/mergify-ci/SKILL.md
@@ -21,6 +21,7 @@ mergify ci queue-info                     # Output merge queue batch metadata fr
 mergify tests show NAME...                # Look up tests by name and print health, ratios, last failure
 mergify tests quarantine NAME             # Add a test to the CI Insights quarantine
 mergify tests unquarantine NAME           # Remove a test from the CI Insights quarantine
+mergify tests quarantined                 # List the tests currently in the CI Insights quarantine
 ```
 
 ## JUnit Processing (`junit-process`)
@@ -233,6 +234,37 @@ mergify tests unquarantine -r owner/repo 12345678-1234-5678-1234-567812345678
 **Exit codes:**
 - `0` -- Test unquarantined.
 - `6` -- Mergify API error (e.g. the test is not quarantined).
+
+## Tests Quarantined (`tests quarantined`)
+
+Lists every test currently in the repository's CI Insights quarantine. Takes no
+test argument -- it prints the whole quarantine. Human output is one indented
+block per record -- the test name on its own line (never wrapped mid-name),
+then its id (the value `unquarantine` accepts), branch, source, recovered, and
+reason. `--json` emits the full records.
+
+```bash
+# Human output (one block per record).
+mergify tests quarantined -r owner/repo
+
+# JSON for jq -- e.g. names of quarantines an auto-recover run flagged.
+mergify tests quarantined -r owner/repo --json \
+  | jq -r '.quarantined_tests[] | select(.is_recovered) | .test_name'
+```
+
+A null `branch` renders as `*` (the quarantine applies to all branches).
+`source` is `manual` (added by a user) or `auto` (added by flaky detection).
+`is_recovered` flags quarantines whose recent runs suggest they can be removed.
+
+**Key options:**
+- `--repository` / `-r` -- Repository full name (`owner/repo`); required.
+- `--token` / `-t` (env: `MERGIFY_TOKEN`, then `GITHUB_TOKEN`) -- Auth token.
+- `--api-url` / `-u` (env: `MERGIFY_API_URL`) -- API base URL.
+- `--json` -- Emit `{"quarantined_tests": [...]}` to stdout, each record carrying
+  `id`, `test_name`, `reason`, `branch`, `created_at`, `source`, `is_recovered`.
+
+**Exit codes:**
+- `0` -- Always, including an empty quarantine ("No quarantined tests found.").
 
 ## Queue Info (`queue-info`)
 


### PR DESCRIPTION
List every test in a repository's CI Insights quarantine via
`GET /v1/ci/{owner}/repositories/{repo}/quarantines`. Each record renders
as an indented block — the test name on its own line (never wrapped
mid-name), then its quarantine id (the value `unquarantine` accepts),
branch, source, recovered flag, and reason. `--json` emits
`{"quarantined_tests": [...]}` carrying every field.

The list envelope `QuarantineList<T>` becomes generic so `unquarantine`'s
name→id lookup keeps its minimal row while the new command reads the full
record (id, test_name, reason, branch, created_at, source, is_recovered).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>