### PR TITLE
feat(tests): Auto-detect the repository on `mergify tests *` commands

### DIFF
--- a/crates/mergify-ci/src/detector.rs
+++ b/crates/mergify-ci/src/detector.rs
@@ -9,6 +9,7 @@
 use std::env;
 
 use mergify_core::CliError;
+use mergify_core::auth;
 use url::Url;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -155,6 +156,43 @@ pub fn get_github_repository() -> Option<String> {
         CIProvider::Jenkins => get_github_repository_from_env("GIT_URL"),
         CIProvider::Buildkite => get_github_repository_from_env("BUILDKITE_REPO"),
     }
+}
+
+/// Resolve the target repository for a CI Insights command, in
+/// precedence order: an explicit `--repository` value, then the CI
+/// environment (via [`get_github_repository`]), then the local git
+/// remote (via [`auth::repository_from_git_remote`]). CI detection
+/// wins over the git remote so a checkout with a different `origin`
+/// can't override the repository the job is actually running for.
+///
+/// The result is validated to a clean `owner/repo` regardless of its
+/// source, so callers can interpolate it into a request path without
+/// re-checking or percent-encoding.
+///
+/// # Errors
+///
+/// Returns `Configuration` when no source yields a repository, or
+/// when the resolved value isn't a valid `owner/repo`.
+pub fn resolve_repository(explicit: Option<&str>) -> Result<String, CliError> {
+    let repository = explicit
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(get_github_repository)
+        .or_else(auth::repository_from_git_remote)
+        .ok_or_else(|| {
+            CliError::Configuration(
+                "--repository not provided and could not be detected from the CI \
+                 environment or the local git remote"
+                    .to_string(),
+            )
+        })?;
+    // The git-remote fallback (`parse_slug`) doesn't enforce the
+    // owner/repo character set that CI detection and the `--repository`
+    // value parser do; validate every source here so a stray
+    // `remote.origin.url` can't slip extra path segments or reserved
+    // characters into a request URL downstream.
+    split_owner_repo(&repository)?;
+    Ok(repository)
 }
 
 pub fn get_github_pull_request_number() -> Result<Option<u64>, CliError> {
@@ -493,6 +531,56 @@ mod tests {
             assert_eq!(get_github_repository(), None);
         });
     }
+
+    #[test]
+    fn resolve_repository_prefers_flag_over_env() {
+        with_ci_env(
+            &[
+                ("GITHUB_ACTIONS", Some("true")),
+                ("GITHUB_REPOSITORY", Some("env/env")),
+            ],
+            || {
+                assert_eq!(resolve_repository(Some("cli/cli")).unwrap(), "cli/cli");
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_repository_prefers_ci_env_over_git_remote() {
+        // With no flag but a CI provider present, the CI repository is
+        // used — even though this test runs inside a git checkout whose
+        // `origin` would otherwise resolve to a different slug. Asserts
+        // both the CI fallback and its precedence over the git remote.
+        with_ci_env(
+            &[
+                ("GITHUB_ACTIONS", Some("true")),
+                ("GITHUB_REPOSITORY", Some("owner/repo")),
+            ],
+            || {
+                assert_eq!(resolve_repository(None).unwrap(), "owner/repo");
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_repository_rejects_invalid_slug() {
+        // The resolved value is validated regardless of source. The
+        // git-remote fallback (`parse_slug`) accepts multi-segment
+        // paths that would inject extra request-path segments; an
+        // explicit value exercises the same guard deterministically.
+        with_ci_env(&[], || {
+            assert!(matches!(
+                resolve_repository(Some("owner/repo/extra")),
+                Err(CliError::Configuration(_))
+            ));
+        });
+    }
+
+    // The no-flag/no-CI path falls through to the local git remote
+    // (`auth::repository_from_git_remote`); its parsing and the
+    // not-a-repo `None` case are covered in `mergify_core::auth`. The
+    // `Configuration` error only fires with neither a CI env nor a git
+    // remote, which can't be reproduced from inside this checkout.
 
     #[test]
     fn pull_request_buildkite_reads_env() {

--- a/crates/mergify-ci/src/junit_process/command.rs
+++ b/crates/mergify-ci/src/junit_process/command.rs
@@ -69,7 +69,7 @@ pub async fn run(
     let api_url = Url::parse(&api_url_raw)
         .map_err(|e| CliError::Configuration(format!("--api-url is not a valid URL: {e}")))?;
     let token = resolve_token(opts.token)?;
-    let repository = resolve_repository(opts.repository)?;
+    let repository = detector::resolve_repository(opts.repository)?;
     let tests_target_branch = resolve_tests_target_branch(opts.tests_target_branch)?;
     let test_exit_code = resolve_test_exit_code(opts.test_exit_code)?;
     let files = expand_files(opts.files)?;
@@ -244,18 +244,6 @@ fn resolve_token(explicit: Option<&str>) -> Result<String, CliError> {
                 "--token not provided and MERGIFY_TOKEN env var is empty".to_string(),
             )
         })
-}
-
-fn resolve_repository(explicit: Option<&str>) -> Result<String, CliError> {
-    if let Some(v) = explicit.filter(|s| !s.is_empty()) {
-        return Ok(v.to_string());
-    }
-    detector::get_github_repository().ok_or_else(|| {
-        CliError::Configuration(
-            "--repository not provided and could not be detected from the CI environment"
-                .to_string(),
-        )
-    })
 }
 
 fn resolve_tests_target_branch(explicit: Option<&str>) -> Result<String, CliError> {

--- a/crates/mergify-ci/src/scopes_send.rs
+++ b/crates/mergify-ci/src/scopes_send.rs
@@ -54,7 +54,7 @@ pub async fn run(opts: ScopesSendOptions<'_>, output: &mut dyn Output) -> Result
         return Ok(());
     };
 
-    let repository = resolve_repository(opts.repository)?;
+    let repository = detector::resolve_repository(opts.repository)?;
     let token = auth::resolve_token(opts.token)?;
     let api_url = auth::resolve_api_url(opts.api_url)?;
 
@@ -89,18 +89,6 @@ pub async fn run(opts: ScopesSendOptions<'_>, output: &mut dyn Output) -> Result
         .await?;
 
     Ok(())
-}
-
-fn resolve_repository(explicit: Option<&str>) -> Result<String, CliError> {
-    if let Some(value) = explicit.filter(|s| !s.is_empty()) {
-        return Ok(value.to_string());
-    }
-    detector::get_github_repository().ok_or_else(|| {
-        CliError::Configuration(
-            "--repository not provided and could not be detected from the CI environment"
-                .to_string(),
-        )
-    })
 }
 
 fn resolve_pull_request(explicit: Option<u64>) -> Result<Option<u64>, CliError> {
@@ -158,26 +146,6 @@ mod tests {
     use super::*;
     use crate::testing::with_ci_env;
     use crate::testing::with_ci_env_async;
-
-    #[test]
-    fn resolve_repository_prefers_flag_over_env() {
-        with_ci_env(
-            &[
-                ("GITHUB_ACTIONS", Some("true")),
-                ("GITHUB_REPOSITORY", Some("env/env")),
-            ],
-            || {
-                assert_eq!(resolve_repository(Some("cli/cli")).unwrap(), "cli/cli");
-            },
-        );
-    }
-
-    #[test]
-    fn resolve_repository_errors_when_no_provider_and_no_flag() {
-        with_ci_env(&[], || {
-            assert!(resolve_repository(None).is_err());
-        });
-    }
 
     #[test]
     fn resolve_pull_request_prefers_explicit() {

--- a/crates/mergify-ci/src/testing.rs
+++ b/crates/mergify-ci/src/testing.rs
@@ -1,11 +1,12 @@
-//! Test-only helpers shared between `detector` and `scopes_send`.
+//! Test-only helpers shared across the CI-aware command modules
+//! (`detector`, `scopes_send`, `tests_show`, `tests_quarantine`).
 //!
-//! Both modules test CI-provider-aware code paths and need to scrub
+//! These modules test CI-provider-aware code paths and need to scrub
 //! the host's CI env vars before running each case — otherwise a
 //! test running on a real Buildkite/Actions/Circle/Jenkins host
 //! inherits provider state and the detector picks the wrong branch.
 //! Two flavors: a sync `with_ci_env` and an async `with_ci_env_async`
-//! (used by the `#[tokio::test]` cases in `scopes_send`).
+//! (used by the `#[tokio::test]` cases).
 
 use std::future::Future;
 

--- a/crates/mergify-ci/src/tests_quarantine.rs
+++ b/crates/mergify-ci/src/tests_quarantine.rs
@@ -25,10 +25,13 @@ use mergify_core::auth;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::detector::resolve_repository;
 use crate::detector::split_owner_repo;
 
 pub struct QuarantineOptions<'a> {
-    pub repository: &'a str,
+    /// Explicit `--repository owner/repo`, or `None` to detect it
+    /// from the CI environment.
+    pub repository: Option<&'a str>,
     pub test_name: &'a str,
     pub reason: &'a str,
     pub branch: Option<&'a str>,
@@ -37,7 +40,9 @@ pub struct QuarantineOptions<'a> {
 }
 
 pub struct UnquarantineOptions<'a> {
-    pub repository: &'a str,
+    /// Explicit `--repository owner/repo`, or `None` to detect it
+    /// from the CI environment.
+    pub repository: Option<&'a str>,
     /// A test name or a quarantine id. A UUID-shaped value is taken as
     /// the quarantine id; anything else is treated as a test name.
     pub name_or_id: &'a str,
@@ -46,7 +51,9 @@ pub struct UnquarantineOptions<'a> {
 }
 
 pub struct QuarantinedOptions<'a> {
-    pub repository: &'a str,
+    /// Explicit `--repository owner/repo`, or `None` to detect it
+    /// from the CI environment.
+    pub repository: Option<&'a str>,
     pub token: Option<&'a str>,
     pub api_url: Option<&'a str>,
 }
@@ -57,7 +64,8 @@ pub async fn quarantine(
     opts: QuarantineOptions<'_>,
     output: &mut dyn Output,
 ) -> Result<ExitCode, CliError> {
-    let (owner, repo) = split_owner_repo(opts.repository)?;
+    let repository = resolve_repository(opts.repository)?;
+    let (owner, repo) = split_owner_repo(&repository)?;
     let token = auth::resolve_token(opts.token)?;
     let api_url = auth::resolve_api_url(opts.api_url)?;
     let client = HttpClient::new(api_url, token, ApiFlavor::Mergify)?;
@@ -87,7 +95,8 @@ pub async fn unquarantine(
     opts: UnquarantineOptions<'_>,
     output: &mut dyn Output,
 ) -> Result<ExitCode, CliError> {
-    let (owner, repo) = split_owner_repo(opts.repository)?;
+    let repository = resolve_repository(opts.repository)?;
+    let (owner, repo) = split_owner_repo(&repository)?;
     let token = auth::resolve_token(opts.token)?;
     let api_url = auth::resolve_api_url(opts.api_url)?;
     let client = HttpClient::new(api_url, token, ApiFlavor::Mergify)?;
@@ -121,7 +130,8 @@ pub async fn quarantined(
     opts: QuarantinedOptions<'_>,
     output: &mut dyn Output,
 ) -> Result<ExitCode, CliError> {
-    let (owner, repo) = split_owner_repo(opts.repository)?;
+    let repository = resolve_repository(opts.repository)?;
+    let (owner, repo) = split_owner_repo(&repository)?;
     let token = auth::resolve_token(opts.token)?;
     let api_url = auth::resolve_api_url(opts.api_url)?;
     let client = HttpClient::new(api_url, token, ApiFlavor::Mergify)?;
@@ -355,6 +365,7 @@ mod tests {
     use wiremock::matchers::path as path_matcher;
 
     use super::*;
+    use crate::testing::with_ci_env_async;
 
     type SharedBytes = Arc<Mutex<Vec<u8>>>;
 
@@ -396,7 +407,7 @@ mod tests {
         branch: Option<&'a str>,
     ) -> QuarantineOptions<'a> {
         QuarantineOptions {
-            repository: "owner/repo",
+            repository: Some("owner/repo"),
             test_name,
             reason,
             branch,
@@ -407,7 +418,7 @@ mod tests {
 
     fn unquarantine_options<'a>(api_url: &'a str, name_or_id: &'a str) -> UnquarantineOptions<'a> {
         UnquarantineOptions {
-            repository: "owner/repo",
+            repository: Some("owner/repo"),
             name_or_id,
             token: Some("test-token"),
             api_url: Some(api_url),
@@ -617,7 +628,7 @@ mod tests {
     async fn quarantine_invalid_repository_format_is_a_configuration_error() {
         let mut cap = captured(OutputMode::Human);
         let opts = QuarantineOptions {
-            repository: "not-a-slash-pair",
+            repository: Some("not-a-slash-pair"),
             test_name: "test_login",
             reason: "flaky",
             branch: None,
@@ -632,7 +643,7 @@ mod tests {
     async fn unquarantine_invalid_repository_format_is_a_configuration_error() {
         let mut cap = captured(OutputMode::Human);
         let opts = UnquarantineOptions {
-            repository: "not-a-slash-pair",
+            repository: Some("not-a-slash-pair"),
             name_or_id: "test_login",
             token: Some("t"),
             api_url: Some("https://example.invalid"),
@@ -729,7 +740,7 @@ mod tests {
 
     fn quarantined_options(api_url: &str) -> QuarantinedOptions<'_> {
         QuarantinedOptions {
-            repository: "owner/repo",
+            repository: Some("owner/repo"),
             token: Some("test-token"),
             api_url: Some(api_url),
         }
@@ -742,6 +753,38 @@ mod tests {
             .expect(1)
             .mount(server)
             .await;
+    }
+
+    #[tokio::test]
+    async fn quarantined_detects_repository_from_ci_env() {
+        // With no `--repository`, the command resolves the repository
+        // from the CI environment — here GitHub Actions'
+        // `GITHUB_REPOSITORY` — and queries that repository's endpoint.
+        with_ci_env_async(
+            &[
+                ("GITHUB_ACTIONS", Some("true")),
+                ("GITHUB_REPOSITORY", Some("owner/repo")),
+            ],
+            async {
+                let server = MockServer::start().await;
+                mount_quarantine_list(
+                    &server,
+                    json!({"quarantined_tests": [], "size": 0, "per_page": null}),
+                )
+                .await;
+
+                let mut cap = captured(OutputMode::Human);
+                let api_url = server.uri();
+                let opts = QuarantinedOptions {
+                    repository: None,
+                    token: Some("test-token"),
+                    api_url: Some(&api_url),
+                };
+                let exit = quarantined(opts, &mut cap.output).await.unwrap();
+                assert_eq!(exit, ExitCode::Success);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -945,7 +988,7 @@ mod tests {
     async fn quarantined_invalid_repository_format_is_a_configuration_error() {
         let mut cap = captured(OutputMode::Human);
         let opts = QuarantinedOptions {
-            repository: "not-a-slash-pair",
+            repository: Some("not-a-slash-pair"),
             token: Some("t"),
             api_url: Some("https://example.invalid"),
         };

--- a/crates/mergify-ci/src/tests_show.rs
+++ b/crates/mergify-ci/src/tests_show.rs
@@ -18,12 +18,15 @@ use mergify_core::auth;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::detector::resolve_repository;
 use crate::detector::split_owner_repo;
 
 const DETAILS_FANOUT: usize = 5;
 
 pub struct TestsShowOptions<'a> {
-    pub repository: &'a str,
+    /// Explicit `--repository owner/repo`, or `None` to detect it
+    /// from the CI environment.
+    pub repository: Option<&'a str>,
     pub test_names: &'a [String],
     pub token: Option<&'a str>,
     pub api_url: Option<&'a str>,
@@ -40,7 +43,8 @@ pub async fn run(
     opts: TestsShowOptions<'_>,
     output: &mut dyn Output,
 ) -> Result<ExitCode, CliError> {
-    let (owner, repo) = split_owner_repo(opts.repository)?;
+    let repository = resolve_repository(opts.repository)?;
+    let (owner, repo) = split_owner_repo(&repository)?;
     let token = auth::resolve_token(opts.token)?;
     let api_url = auth::resolve_api_url(opts.api_url)?;
     let client = Arc::new(HttpClient::new(api_url, token, ApiFlavor::Mergify)?);
@@ -386,6 +390,7 @@ mod tests {
     use wiremock::matchers::path as path_matcher;
 
     use super::*;
+    use crate::testing::with_ci_env_async;
 
     type SharedBytes = Arc<Mutex<Vec<u8>>>;
 
@@ -487,7 +492,7 @@ mod tests {
 
     fn options<'a>(api_url: &'a str, names: &'a [String]) -> TestsShowOptions<'a> {
         TestsShowOptions {
-            repository: "owner/repo",
+            repository: Some("owner/repo"),
             test_names: names,
             token: Some("test-token"),
             api_url: Some(api_url),
@@ -522,6 +527,41 @@ mod tests {
             serde_json::from_str::<serde_json::Value>(&stdout).unwrap(),
             json!({"tests": []})
         );
+    }
+
+    #[tokio::test]
+    async fn detects_repository_from_ci_env() {
+        // With no `--repository`, the command resolves the repository
+        // from the CI environment — here GitHub Actions'
+        // `GITHUB_REPOSITORY` — and queries that repository's endpoint.
+        with_ci_env_async(
+            &[
+                ("GITHUB_ACTIONS", Some("true")),
+                ("GITHUB_REPOSITORY", Some("owner/repo")),
+            ],
+            async {
+                let server = MockServer::start().await;
+                mount_search(&server, json!({"tests": []})).await;
+
+                let mut cap = captured(OutputMode::Json);
+                let api_url = server.uri();
+                let names = vec!["ghost".to_string()];
+                let opts = TestsShowOptions {
+                    repository: None,
+                    test_names: &names,
+                    token: Some("test-token"),
+                    api_url: Some(&api_url),
+                    pipeline_name: &[],
+                    pipeline_name_exclude: &[],
+                    job_name: &[],
+                    job_name_exclude: &[],
+                    per_page: None,
+                };
+                let exit = run(opts, &mut cap.output).await.unwrap();
+                assert_eq!(exit, ExitCode::Success);
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -855,7 +895,7 @@ mod tests {
         let job_excludes = vec!["lint".to_string()];
 
         let opts = TestsShowOptions {
-            repository: "owner/repo",
+            repository: Some("owner/repo"),
             test_names: &names,
             token: Some("t"),
             api_url: Some(&api_url),
@@ -928,7 +968,7 @@ mod tests {
         let mut cap = captured(OutputMode::Human);
         let names = vec!["a".to_string()];
         let opts = TestsShowOptions {
-            repository: "not-a-slash-pair",
+            repository: Some("not-a-slash-pair"),
             test_names: &names,
             token: Some("t"),
             api_url: Some("https://example.invalid"),

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -335,7 +335,7 @@ struct FreezeListOpts {
 }
 
 struct TestsShowOpts {
-    repository: String,
+    repository: Option<String>,
     test_names: Vec<String>,
     token: Option<String>,
     api_url: Option<String>,
@@ -348,7 +348,7 @@ struct TestsShowOpts {
 }
 
 struct TestsQuarantineOpts {
-    repository: String,
+    repository: Option<String>,
     test_name: String,
     reason: String,
     branch: Option<String>,
@@ -358,7 +358,7 @@ struct TestsQuarantineOpts {
 }
 
 struct TestsUnquarantineOpts {
-    repository: String,
+    repository: Option<String>,
     name_or_id: String,
     token: Option<String>,
     api_url: Option<String>,
@@ -366,7 +366,7 @@ struct TestsUnquarantineOpts {
 }
 
 struct TestsQuarantinedOpts {
-    repository: String,
+    repository: Option<String>,
     token: Option<String>,
     api_url: Option<String>,
     json: bool,
@@ -1010,7 +1010,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
             NativeCommand::TestsShow(opts) => {
                 mergify_ci::tests_show::run(
                     TestsShowOptions {
-                        repository: &opts.repository,
+                        repository: opts.repository.as_deref(),
                         test_names: &opts.test_names,
                         token: opts.token.as_deref(),
                         api_url: opts.api_url.as_deref(),
@@ -1027,7 +1027,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
             NativeCommand::TestsQuarantine(opts) => {
                 mergify_ci::tests_quarantine::quarantine(
                     QuarantineOptions {
-                        repository: &opts.repository,
+                        repository: opts.repository.as_deref(),
                         test_name: &opts.test_name,
                         reason: &opts.reason,
                         branch: opts.branch.as_deref(),
@@ -1041,7 +1041,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
             NativeCommand::TestsUnquarantine(opts) => {
                 mergify_ci::tests_quarantine::unquarantine(
                     UnquarantineOptions {
-                        repository: &opts.repository,
+                        repository: opts.repository.as_deref(),
                         name_or_id: &opts.name_or_id,
                         token: opts.token.as_deref(),
                         api_url: opts.api_url.as_deref(),
@@ -1053,7 +1053,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
             NativeCommand::TestsQuarantined(opts) => {
                 mergify_ci::tests_quarantine::quarantined(
                     QuarantinedOptions {
-                        repository: &opts.repository,
+                        repository: opts.repository.as_deref(),
                         token: opts.token.as_deref(),
                         api_url: opts.api_url.as_deref(),
                     },
@@ -1660,8 +1660,8 @@ struct ScopesCliArgs {
 
 #[derive(clap::Args)]
 struct ScopesSendCliArgs {
-    /// Repository full name (owner/repo). Falls back to
-    /// ``GITHUB_REPOSITORY`` env var.
+    /// Repository full name (owner/repo). Detected from the CI
+    /// environment or the local git remote when omitted.
     #[arg(long, short = 'r')]
     repository: Option<String>,
 
@@ -1715,8 +1715,8 @@ struct JunitProcessCliArgs {
     #[arg(long, short = 't')]
     token: Option<String>,
 
-    /// Repository full name (owner/repo). Auto-detected from the
-    /// CI environment when omitted.
+    /// Repository full name (owner/repo). Detected from the CI
+    /// environment or the local git remote when omitted.
     #[arg(long, short = 'r')]
     repository: Option<String>,
 
@@ -1783,14 +1783,14 @@ struct TestsShowCliArgs {
     #[arg(value_name = "NAME", required = true, num_args = 1..)]
     test_names: Vec<String>,
 
-    /// Repository full name (owner/repo).
+    /// Repository full name (owner/repo). Detected from the CI
+    /// environment or the local git remote when omitted.
     #[arg(
         long,
         short = 'r',
-        required = true,
         value_parser = mergify_ci::detector::parse_owner_repo,
     )]
-    repository: String,
+    repository: Option<String>,
 
     /// Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and
     /// then ``GITHUB_TOKEN`` env vars.
@@ -1834,14 +1834,14 @@ struct TestsQuarantineCliArgs {
     #[arg(value_name = "NAME")]
     test_name: String,
 
-    /// Repository full name (owner/repo).
+    /// Repository full name (owner/repo). Detected from the CI
+    /// environment or the local git remote when omitted.
     #[arg(
         long,
         short = 'r',
-        required = true,
         value_parser = mergify_ci::detector::parse_owner_repo,
     )]
-    repository: String,
+    repository: Option<String>,
 
     /// Reason recorded for quarantining the test.
     #[arg(long)]
@@ -1874,14 +1874,14 @@ struct TestsUnquarantineCliArgs {
     #[arg(value_name = "NAME_OR_ID")]
     name_or_id: String,
 
-    /// Repository full name (owner/repo).
+    /// Repository full name (owner/repo). Detected from the CI
+    /// environment or the local git remote when omitted.
     #[arg(
         long,
         short = 'r',
-        required = true,
         value_parser = mergify_ci::detector::parse_owner_repo,
     )]
-    repository: String,
+    repository: Option<String>,
 
     /// Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and
     /// then ``GITHUB_TOKEN`` env vars.
@@ -1900,14 +1900,14 @@ struct TestsUnquarantineCliArgs {
 
 #[derive(clap::Args)]
 struct TestsQuarantinedCliArgs {
-    /// Repository full name (owner/repo).
+    /// Repository full name (owner/repo). Detected from the CI
+    /// environment or the local git remote when omitted.
     #[arg(
         long,
         short = 'r',
-        required = true,
         value_parser = mergify_ci::detector::parse_owner_repo,
     )]
-    repository: String,
+    repository: Option<String>,
 
     /// Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and
     /// then ``GITHUB_TOKEN`` env vars.

--- a/crates/mergify-core/src/auth.rs
+++ b/crates/mergify-core/src/auth.rs
@@ -77,16 +77,25 @@ pub fn resolve_repository(explicit: Option<&str>) -> Result<String, CliError> {
     if let Some(value) = var_non_empty("GITHUB_REPOSITORY") {
         return Ok(value);
     }
-    if let Some(remote) = git_remote_origin_url() {
-        if let Some(slug) = parse_slug(&remote) {
-            return Ok(slug);
-        }
+    if let Some(slug) = repository_from_git_remote() {
+        return Ok(slug);
     }
     Err(CliError::Configuration(
         "--repository not provided, GITHUB_REPOSITORY env var is unset, and \
          the local git config has no usable `remote.origin.url`"
             .to_string(),
     ))
+}
+
+/// Repository slug (`<owner>/<repo>`) parsed from the local
+/// `git config --get remote.origin.url`, or `None` when the working
+/// tree isn't a git repo or has no usable `remote.origin.url`.
+///
+/// Exposed so `mergify-ci`'s CI-aware resolver can share the same
+/// git-remote fallback instead of reimplementing it.
+#[must_use]
+pub fn repository_from_git_remote() -> Option<String> {
+    parse_slug(&git_remote_origin_url()?)
 }
 
 /// Run `gh auth token` and return stdout (trimmed). Returns an

--- a/skills/mergify-ci/SKILL.md
+++ b/skills/mergify-ci/SKILL.md
@@ -166,7 +166,7 @@ mergify tests show -r owner/repo \
 ```
 
 **Key options:**
-- `--repository` / `-r` -- Repository full name (`owner/repo`); required.
+- `--repository` / `-r` -- Repository full name (`owner/repo`); auto-detected from the CI environment or the local git remote when omitted.
 - `--token` / `-t` (env: `MERGIFY_TOKEN`, then `GITHUB_TOKEN`) -- Auth token.
 - `--api-url` / `-u` (env: `MERGIFY_API_URL`) -- API base URL.
 - `--pipeline-name`, `--pipeline-name-exclude` -- Restrict / exclude by pipeline.
@@ -198,7 +198,7 @@ mergify tests quarantine -r owner/repo \
 ```
 
 **Key options:**
-- `--repository` / `-r` -- Repository full name (`owner/repo`); required.
+- `--repository` / `-r` -- Repository full name (`owner/repo`); auto-detected from the CI environment or the local git remote when omitted.
 - `--reason` -- Reason recorded for the quarantine; required.
 - `--branch` / `-b` -- Branch name or pattern to scope to. Omit for all branches.
 - `--token` / `-t` (env: `MERGIFY_TOKEN`, then `GITHUB_TOKEN`) -- Auth token.
@@ -225,7 +225,7 @@ mergify tests unquarantine -r owner/repo 12345678-1234-5678-1234-567812345678
 ```
 
 **Key options:**
-- `--repository` / `-r` -- Repository full name (`owner/repo`); required.
+- `--repository` / `-r` -- Repository full name (`owner/repo`); auto-detected from the CI environment or the local git remote when omitted.
 - `--token` / `-t` (env: `MERGIFY_TOKEN`, then `GITHUB_TOKEN`) -- Auth token.
 - `--api-url` / `-u` (env: `MERGIFY_API_URL`) -- API base URL.
 - `--json` -- Emit `{"id", "test_name"}` to stdout (`test_name` is null when
@@ -257,7 +257,7 @@ A null `branch` renders as `*` (the quarantine applies to all branches).
 `is_recovered` flags quarantines whose recent runs suggest they can be removed.
 
 **Key options:**
-- `--repository` / `-r` -- Repository full name (`owner/repo`); required.
+- `--repository` / `-r` -- Repository full name (`owner/repo`); auto-detected from the CI environment or the local git remote when omitted.
 - `--token` / `-t` (env: `MERGIFY_TOKEN`, then `GITHUB_TOKEN`) -- Auth token.
 - `--api-url` / `-u` (env: `MERGIFY_API_URL`) -- API base URL.
 - `--json` -- Emit `{"quarantined_tests": [...]}` to stdout, each record carrying


### PR DESCRIPTION
The four `mergify tests` commands required an explicit `--repository`,
which is redundant outside an interactive shell: in CI the repository
is in the environment, and in a local checkout it is the git remote.
Make `--repository` optional and resolve it automatically so the
commands work with zero extra configuration both in a pipeline and on
a developer's machine.

Consolidate the CI Insights repository resolution behind a single
`detector::resolve_repository` (explicit flag → CI environment → git
remote), removing the duplicate copy in `junit_process` and the
CI-only helper that `scopes-send` carried. The git-remote step reuses
`auth::repository_from_git_remote`, extracted from the queue/freeze
resolver so the logic isn't reimplemented. CI detection wins over the
git remote so a checkout pointing at a different `origin` can't
override the repository the job is running for.

Validate the resolved repository to a clean `owner/repo` regardless of
source: the git-remote fallback's URL parser doesn't enforce the
owner/repo character set, and `scopes-send` / `junit-process`
interpolate the repository into a request path without re-checking, so
an unusual `remote.origin.url` could otherwise inject extra path
segments instead of failing with a clear error.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Fixes: MRGFY-7499