### PR TITLE
feat(tests): Add `tests quarantines add/remove/get/list` subgroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ and global options (`--token`, `--repository`, `--api-url`).
   [Docs](https://docs.mergify.com/ci-insights/)
 - **`mergify tests`** — Inspect test health and manage quarantine for tests
   tracked by Mergify CI Insights (`mergify tests show NAME...`,
-  `mergify tests quarantine NAME`, `mergify tests unquarantine NAME`).
+  `mergify tests quarantines add NAME`, `mergify tests quarantines remove NAME`).
   [Docs](https://docs.mergify.com/ci-insights/)
 - **`mergify queue`** — Monitor and manage the Mergify merge queue.
   [Docs](https://docs.mergify.com/merge-queue/)

--- a/crates/mergify-ci/src/tests_quarantine.rs
+++ b/crates/mergify-ci/src/tests_quarantine.rs
@@ -1,15 +1,15 @@
-//! `mergify tests quarantine` / `mergify tests unquarantine` /
-//! `mergify tests quarantined` — add a test to, remove it from, or list
-//! the CI Insights quarantine through the public quarantine API.
+//! `mergify tests quarantines add` / `remove` / `get` / `list` — add a
+//! test to, remove it from, fetch one from, or list the CI Insights
+//! quarantine through the public quarantine API.
 //!
-//! `quarantine` addresses a test by its fully qualified name.
-//! `unquarantine` accepts either the quarantine id (deleted directly,
-//! as the DELETE endpoint is keyed by it) or a test name. The
-//! quarantine resource has the composite primary key
-//! `(repository, test_name)`, so a name resolves to at most one
-//! quarantine per repository — `unquarantine` relies on this when it
-//! looks the name up in the list endpoint to recover the id.
-//! `quarantined` lists that same endpoint, rendering every record.
+//! `add` addresses a test by its fully qualified name. `remove`
+//! accepts either the quarantine id (deleted directly, as the DELETE
+//! endpoint is keyed by it) or a test name. The quarantine resource
+//! has the composite primary key `(repository, test_name)`, so a name
+//! resolves to at most one quarantine per repository — `remove` and
+//! `get` rely on this when they look the name up in the list endpoint.
+//! `list` renders every record; `get` filters that same list to the
+//! single match (the API exposes no single-quarantine GET).
 
 use std::io::{self, Write};
 
@@ -54,6 +54,17 @@ pub struct QuarantinedOptions<'a> {
     /// Explicit `--repository owner/repo`, or `None` to detect it
     /// from the CI environment.
     pub repository: Option<&'a str>,
+    pub token: Option<&'a str>,
+    pub api_url: Option<&'a str>,
+}
+
+pub struct GetOptions<'a> {
+    /// Explicit `--repository owner/repo`, or `None` to detect it
+    /// from the CI environment.
+    pub repository: Option<&'a str>,
+    /// A test name or a quarantine id. A UUID-shaped value is matched
+    /// against the quarantine id; anything else against the test name.
+    pub name_or_id: &'a str,
     pub token: Option<&'a str>,
     pub api_url: Option<&'a str>,
 }
@@ -130,21 +141,55 @@ pub async fn quarantined(
     opts: QuarantinedOptions<'_>,
     output: &mut dyn Output,
 ) -> Result<ExitCode, CliError> {
-    let repository = resolve_repository(opts.repository)?;
-    let (owner, repo) = split_owner_repo(&repository)?;
-    let token = auth::resolve_token(opts.token)?;
-    let api_url = auth::resolve_api_url(opts.api_url)?;
-    let client = HttpClient::new(api_url, token, ApiFlavor::Mergify)?;
-
-    // Omitting `per_page` returns the full list in a single response.
-    let path = format!("/v1/ci/{owner}/repositories/{repo}/quarantines");
-    let list: QuarantineList<QuarantinedTest> = client.get(&path).await?;
-
-    let payload = QuarantinedPayload {
-        quarantined_tests: list.quarantined_tests,
-    };
+    let quarantined_tests = fetch_quarantines(opts.repository, opts.token, opts.api_url).await?;
+    let payload = QuarantinedPayload { quarantined_tests };
     output.emit(&payload, &mut |w| render_quarantined_list(w, &payload))?;
     Ok(ExitCode::Success)
+}
+
+/// Fetch a single quarantine, addressed either by quarantine id (a
+/// UUID-shaped value) or by test name, and render the full record.
+/// Both keys are resolved client-side against the list endpoint, the
+/// same source `quarantined` and `unquarantine` read — the API has no
+/// single-quarantine GET. Errors when no quarantine matches.
+pub async fn get(opts: GetOptions<'_>, output: &mut dyn Output) -> Result<ExitCode, CliError> {
+    let quarantines = fetch_quarantines(opts.repository, opts.token, opts.api_url).await?;
+
+    // Match by id when the argument is UUID-shaped, else by name —
+    // decided once rather than per row.
+    let by_id = looks_like_uuid(opts.name_or_id);
+    let test = quarantines
+        .into_iter()
+        .find(|quarantine| {
+            if by_id {
+                quarantine.id.eq_ignore_ascii_case(opts.name_or_id)
+            } else {
+                quarantine.test_name == opts.name_or_id
+            }
+        })
+        .ok_or_else(|| not_found(opts.name_or_id))?;
+
+    output.emit(&test, &mut |w| render_quarantined_one(w, &test))?;
+    Ok(ExitCode::Success)
+}
+
+/// Fetch every quarantine recorded for the repository. Shared by
+/// `quarantined` (renders all) and `get` (filters to one); omitting
+/// `per_page` returns the full list in a single response.
+async fn fetch_quarantines(
+    repository: Option<&str>,
+    token: Option<&str>,
+    api_url: Option<&str>,
+) -> Result<Vec<QuarantinedTest>, CliError> {
+    let repository = resolve_repository(repository)?;
+    let (owner, repo) = split_owner_repo(&repository)?;
+    let token = auth::resolve_token(token)?;
+    let api_url = auth::resolve_api_url(api_url)?;
+    let client = HttpClient::new(api_url, token, ApiFlavor::Mergify)?;
+
+    let path = format!("/v1/ci/{owner}/repositories/{repo}/quarantines");
+    let list: QuarantineList<QuarantinedTest> = client.get(&path).await?;
+    Ok(list.quarantined_tests)
 }
 
 /// The quarantine targeted by `unquarantine`, with the test name
@@ -332,8 +377,8 @@ fn render_quarantined_list(w: &mut dyn Write, payload: &QuarantinedPayload) -> i
 }
 
 /// One record: the test name as a header, then its id (the value
-/// `unquarantine` accepts) and metadata indented under it. A null
-/// branch shows as `*`, the "all branches" marker `quarantine`'s human
+/// `quarantines remove` accepts) and metadata indented under it. A
+/// null branch shows as `*`, the "all branches" marker `add`'s human
 /// output already uses.
 fn render_quarantined_one(w: &mut dyn Write, test: &QuarantinedTest) -> io::Result<()> {
     writeln!(w, "{}", test.test_name)?;
@@ -994,5 +1039,84 @@ mod tests {
         };
         let err = quarantined(opts, &mut cap.output).await.unwrap_err();
         assert!(matches!(err, CliError::Configuration(_)), "got {err:?}");
+    }
+
+    fn get_options<'a>(api_url: &'a str, name_or_id: &'a str) -> GetOptions<'a> {
+        GetOptions {
+            repository: Some("owner/repo"),
+            name_or_id,
+            token: Some("test-token"),
+            api_url: Some(api_url),
+        }
+    }
+
+    fn one_quarantine_list(id: &str, test_name: &str) -> serde_json::Value {
+        json!({
+            "quarantined_tests": [{
+                "id": id,
+                "test_name": test_name,
+                "reason": "flaky — MRGFY-1234",
+                "branch": null,
+                "created_at": "2026-01-01T10:00:00Z",
+                "source": "manual",
+                "is_recovered": false,
+            }],
+            "size": 1,
+            "per_page": null,
+        })
+    }
+
+    #[tokio::test]
+    async fn get_by_name_renders_the_matching_record() {
+        let server = MockServer::start().await;
+        mount_quarantine_list(&server, one_quarantine_list("id-1", "test_login")).await;
+
+        let mut cap = captured(OutputMode::Human);
+        let api_url = server.uri();
+        let exit = get(get_options(&api_url, "test_login"), &mut cap.output)
+            .await
+            .unwrap();
+
+        assert_eq!(exit, ExitCode::Success);
+        let out = read(&cap.stdout);
+        assert!(out.contains("test_login\n"), "got {out:?}");
+        assert!(out.contains("id:         id-1"), "got {out:?}");
+        assert!(
+            out.contains("reason:     flaky — MRGFY-1234"),
+            "got {out:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_by_id_emits_the_record_in_json() {
+        let id = "12345678-1234-5678-1234-567812345678";
+        let server = MockServer::start().await;
+        mount_quarantine_list(&server, one_quarantine_list(id, "test_logout")).await;
+
+        let mut cap = captured(OutputMode::Json);
+        let api_url = server.uri();
+        // An uppercase id still matches the canonical lowercase record.
+        let upper_id = id.to_uppercase();
+        let exit = get(get_options(&api_url, &upper_id), &mut cap.output)
+            .await
+            .unwrap();
+
+        assert_eq!(exit, ExitCode::Success);
+        let value: serde_json::Value = serde_json::from_str(&read(&cap.stdout)).unwrap();
+        assert_eq!(value["id"], id);
+        assert_eq!(value["test_name"], "test_logout");
+    }
+
+    #[tokio::test]
+    async fn get_unknown_test_is_a_mergify_error() {
+        let server = MockServer::start().await;
+        mount_quarantine_list(&server, one_quarantine_list("id-1", "test_login")).await;
+
+        let mut cap = captured(OutputMode::Human);
+        let api_url = server.uri();
+        let err = get(get_options(&api_url, "ghost"), &mut cap.output)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CliError::MergifyApi(_)), "got {err:?}");
     }
 }

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -30,6 +30,7 @@ use mergify_ci::git_refs::Format as GitRefsFormat;
 use mergify_ci::git_refs::GitRefsOptions;
 use mergify_ci::junit_process::JunitProcessOptions;
 use mergify_ci::scopes_send::ScopesSendOptions;
+use mergify_ci::tests_quarantine::GetOptions;
 use mergify_ci::tests_quarantine::QuarantineOptions;
 use mergify_ci::tests_quarantine::QuarantinedOptions;
 use mergify_ci::tests_quarantine::UnquarantineOptions;
@@ -145,9 +146,7 @@ const NATIVE_COMMANDS: &[(&str, &str)] = &[
     ("ci", "junit-process"),
     ("ci", "junit-upload"),
     ("tests", "show"),
-    ("tests", "quarantine"),
-    ("tests", "unquarantine"),
-    ("tests", "quarantined"),
+    ("tests", "quarantines"),
     ("queue", "pause"),
     ("queue", "unpause"),
     ("queue", "status"),
@@ -194,6 +193,7 @@ enum NativeCommand {
     TestsShow(TestsShowOpts),
     TestsQuarantine(TestsQuarantineOpts),
     TestsUnquarantine(TestsUnquarantineOpts),
+    TestsQuarantineGet(TestsQuarantineGetOpts),
     TestsQuarantined(TestsQuarantinedOpts),
     QueuePause(QueuePauseOpts),
     QueueUnpause(QueueUnpauseOpts),
@@ -402,6 +402,14 @@ struct TestsUnquarantineOpts {
     json: bool,
 }
 
+struct TestsQuarantineGetOpts {
+    repository: Option<String>,
+    name_or_id: String,
+    token: Option<String>,
+    api_url: Option<String>,
+    json: bool,
+}
+
 struct TestsQuarantinedOpts {
     repository: Option<String>,
     token: Option<String>,
@@ -564,6 +572,51 @@ fn dispatch_stack(debug: bool, args: Vec<String>) -> Dispatch {
             Dispatch::Native(NativeCommand::StackEdit(StackEditOpts::from(parsed)))
         }
         _ => Dispatch::Shim(inject_global_flags(debug, prepend_one("stack", args))),
+    }
+}
+
+/// Build the run options for `quarantines add`.
+fn quarantine_opts(args: TestsQuarantineCliArgs) -> TestsQuarantineOpts {
+    TestsQuarantineOpts {
+        repository: args.repository,
+        test_name: args.test_name,
+        reason: args.reason,
+        branch: args.branch,
+        token: args.token,
+        api_url: args.api_url,
+        json: args.json,
+    }
+}
+
+/// Build the run options for `quarantines remove`.
+fn unquarantine_opts(args: TestsUnquarantineCliArgs) -> TestsUnquarantineOpts {
+    TestsUnquarantineOpts {
+        repository: args.repository,
+        name_or_id: args.name_or_id,
+        token: args.token,
+        api_url: args.api_url,
+        json: args.json,
+    }
+}
+
+/// Build the run options for `quarantines list`.
+fn quarantined_opts(args: TestsQuarantinedCliArgs) -> TestsQuarantinedOpts {
+    TestsQuarantinedOpts {
+        repository: args.repository,
+        token: args.token,
+        api_url: args.api_url,
+        json: args.json,
+    }
+}
+
+/// Build the run options for `quarantines get`.
+fn quarantine_get_opts(args: TestsQuarantineGetCliArgs) -> TestsQuarantineGetOpts {
+    TestsQuarantineGetOpts {
+        repository: args.repository,
+        name_or_id: args.name_or_id,
+        token: args.token,
+        api_url: args.api_url,
+        json: args.json,
     }
 }
 
@@ -751,55 +804,21 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
             json,
         })),
         Subcommands::Tests(TestsArgs {
-            command:
-                TestsSubcommand::Quarantine(TestsQuarantineCliArgs {
-                    test_name,
-                    repository,
-                    reason,
-                    branch,
-                    token,
-                    api_url,
-                    json,
-                }),
-        }) => Dispatch::Native(NativeCommand::TestsQuarantine(TestsQuarantineOpts {
-            repository,
-            test_name,
-            reason,
-            branch,
-            token,
-            api_url,
-            json,
-        })),
-        Subcommands::Tests(TestsArgs {
-            command:
-                TestsSubcommand::Unquarantine(TestsUnquarantineCliArgs {
-                    name_or_id,
-                    repository,
-                    token,
-                    api_url,
-                    json,
-                }),
-        }) => Dispatch::Native(NativeCommand::TestsUnquarantine(TestsUnquarantineOpts {
-            repository,
-            name_or_id,
-            token,
-            api_url,
-            json,
-        })),
-        Subcommands::Tests(TestsArgs {
-            command:
-                TestsSubcommand::Quarantined(TestsQuarantinedCliArgs {
-                    repository,
-                    token,
-                    api_url,
-                    json,
-                }),
-        }) => Dispatch::Native(NativeCommand::TestsQuarantined(TestsQuarantinedOpts {
-            repository,
-            token,
-            api_url,
-            json,
-        })),
+            command: TestsSubcommand::Quarantines(TestsQuarantinesArgs { command }),
+        }) => Dispatch::Native(match command {
+            QuarantinesSubcommand::Add(args) => {
+                NativeCommand::TestsQuarantine(quarantine_opts(args))
+            }
+            QuarantinesSubcommand::Remove(args) => {
+                NativeCommand::TestsUnquarantine(unquarantine_opts(args))
+            }
+            QuarantinesSubcommand::Get(args) => {
+                NativeCommand::TestsQuarantineGet(quarantine_get_opts(args))
+            }
+            QuarantinesSubcommand::List(args) => {
+                NativeCommand::TestsQuarantined(quarantined_opts(args))
+            }
+        }),
         Subcommands::Queue(QueueArgs {
             repository,
             token,
@@ -970,6 +989,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
         NativeCommand::TestsShow(opts) if opts.json => OutputMode::Json,
         NativeCommand::TestsQuarantine(opts) if opts.json => OutputMode::Json,
         NativeCommand::TestsUnquarantine(opts) if opts.json => OutputMode::Json,
+        NativeCommand::TestsQuarantineGet(opts) if opts.json => OutputMode::Json,
         NativeCommand::TestsQuarantined(opts) if opts.json => OutputMode::Json,
         _ => OutputMode::Human,
     };
@@ -1099,6 +1119,18 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
             NativeCommand::TestsUnquarantine(opts) => {
                 mergify_ci::tests_quarantine::unquarantine(
                     UnquarantineOptions {
+                        repository: opts.repository.as_deref(),
+                        name_or_id: &opts.name_or_id,
+                        token: opts.token.as_deref(),
+                        api_url: opts.api_url.as_deref(),
+                    },
+                    &mut output,
+                )
+                .await
+            }
+            NativeCommand::TestsQuarantineGet(opts) => {
+                mergify_ci::tests_quarantine::get(
+                    GetOptions {
                         repository: opts.repository.as_deref(),
                         name_or_id: &opts.name_or_id,
                         token: opts.token.as_deref(),
@@ -1914,12 +1946,26 @@ struct TestsArgs {
 enum TestsSubcommand {
     /// Look up tests by name and print their health and metrics.
     Show(TestsShowCliArgs),
+    /// Manage the CI Insights quarantine.
+    Quarantines(TestsQuarantinesArgs),
+}
+
+#[derive(clap::Args)]
+struct TestsQuarantinesArgs {
+    #[command(subcommand)]
+    command: QuarantinesSubcommand,
+}
+
+#[derive(Subcommand)]
+enum QuarantinesSubcommand {
     /// Add a test to the CI Insights quarantine.
-    Quarantine(TestsQuarantineCliArgs),
+    Add(TestsQuarantineCliArgs),
     /// Remove a test from the CI Insights quarantine.
-    Unquarantine(TestsUnquarantineCliArgs),
+    Remove(TestsUnquarantineCliArgs),
+    /// Print a single quarantine by test name or id.
+    Get(TestsQuarantineGetCliArgs),
     /// List the tests currently in the CI Insights quarantine.
-    Quarantined(TestsQuarantinedCliArgs),
+    List(TestsQuarantinedCliArgs),
 }
 
 #[derive(clap::Args)]
@@ -2016,7 +2062,38 @@ struct TestsQuarantineCliArgs {
 #[derive(clap::Args)]
 struct TestsUnquarantineCliArgs {
     /// Test to remove from quarantine: either its fully qualified name
-    /// or the quarantine id (as printed by `tests quarantine`).
+    /// or the quarantine id (as printed by `tests quarantines add`).
+    #[arg(value_name = "NAME_OR_ID")]
+    name_or_id: String,
+
+    /// Repository full name (owner/repo). Detected from the CI
+    /// environment or the local git remote when omitted.
+    #[arg(
+        long,
+        short = 'r',
+        value_parser = mergify_ci::detector::parse_owner_repo,
+    )]
+    repository: Option<String>,
+
+    /// Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and
+    /// then ``GITHUB_TOKEN`` env vars.
+    #[arg(long, short = 't')]
+    token: Option<String>,
+
+    /// Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var,
+    /// then to the default.
+    #[arg(long = "api-url", short = 'u')]
+    api_url: Option<String>,
+
+    /// Emit a single JSON document to stdout instead of human prose.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(clap::Args)]
+struct TestsQuarantineGetCliArgs {
+    /// Quarantine to print: either the test's fully qualified name or
+    /// the quarantine id (as printed by `tests quarantines add`).
     #[arg(value_name = "NAME_OR_ID")]
     name_or_id: String,
 
@@ -2418,5 +2495,58 @@ mod tests {
         assert_eq!(opts.token.as_deref(), Some("tok"));
         assert_eq!(opts.tests_target_branch.as_deref(), Some("main"));
         assert_eq!(opts.files, vec!["report.xml"]);
+    }
+
+    #[test]
+    fn tests_quarantines_add_dispatches_natively() {
+        let parsed = parse(&[
+            "tests",
+            "quarantines",
+            "add",
+            "test_login",
+            "--reason",
+            "flaky",
+            "-r",
+            "owner/repo",
+        ]);
+        let Dispatch::Native(NativeCommand::TestsQuarantine(opts)) = dispatch_from_parsed(parsed)
+        else {
+            panic!("tests quarantines add must dispatch to TestsQuarantine");
+        };
+        assert_eq!(opts.test_name, "test_login");
+        assert_eq!(opts.reason, "flaky");
+        assert_eq!(opts.repository.as_deref(), Some("owner/repo"));
+    }
+
+    #[test]
+    fn tests_quarantines_get_dispatches_natively() {
+        let parsed = parse(&[
+            "tests",
+            "quarantines",
+            "get",
+            "test_login",
+            "-r",
+            "owner/repo",
+        ]);
+        let Dispatch::Native(NativeCommand::TestsQuarantineGet(opts)) =
+            dispatch_from_parsed(parsed)
+        else {
+            panic!("tests quarantines get must dispatch to TestsQuarantineGet");
+        };
+        assert_eq!(opts.name_or_id, "test_login");
+        assert_eq!(opts.repository.as_deref(), Some("owner/repo"));
+    }
+
+    #[test]
+    fn removed_flat_quarantine_commands_are_not_native() {
+        // The deprecated flat commands were removed; only the
+        // `quarantines` subgroup routes natively now.
+        let native = |argv: &[&str]| {
+            looks_native(&argv.iter().map(|s| (*s).to_string()).collect::<Vec<_>>())
+        };
+        assert!(!native(&["mergify", "tests", "quarantine"]));
+        assert!(!native(&["mergify", "tests", "unquarantine"]));
+        assert!(!native(&["mergify", "tests", "quarantined"]));
+        assert!(native(&["mergify", "tests", "quarantines", "add"]));
     }
 }

--- a/skills/mergify-ci/SKILL.md
+++ b/skills/mergify-ci/SKILL.md
@@ -19,9 +19,10 @@ mergify ci scopes --config PATH           # Detect scopes impacted by changed fi
 mergify ci scopes-send -s SCOPE           # Send scopes tied to a pull request to Mergify
 mergify ci queue-info                     # Output merge queue batch metadata from the current PR event
 mergify tests show NAME...                # Look up tests by name and print health, ratios, last failure
-mergify tests quarantine NAME             # Add a test to the CI Insights quarantine
-mergify tests unquarantine NAME           # Remove a test from the CI Insights quarantine
-mergify tests quarantined                 # List the tests currently in the CI Insights quarantine
+mergify tests quarantines add NAME        # Add a test to the CI Insights quarantine
+mergify tests quarantines remove NAME     # Remove a test from the CI Insights quarantine
+mergify tests quarantines get NAME        # Print a single quarantine by test name or id
+mergify tests quarantines list            # List the tests currently in the CI Insights quarantine
 ```
 
 ## JUnit Processing (`junit-process`)
@@ -179,7 +180,7 @@ mergify tests show -r owner/repo \
 - `1` -- At least one test is `flaky`.
 - `6` -- At least one test is `broken` (consistently failing).
 
-## Tests Quarantine (`tests quarantine`)
+## Tests Quarantines Add (`tests quarantines add`)
 
 Adds a test to the repository's CI Insights quarantine, so its failures stop
 blocking the CI verdict. Takes a single fully qualified test name; a `--reason`
@@ -187,12 +188,12 @@ is required.
 
 ```bash
 # Quarantine on all branches.
-mergify tests quarantine -r owner/repo \
+mergify tests quarantines add -r owner/repo \
   --reason 'flaky — tracked in MRGFY-1234' \
   'test_login'
 
 # Scope the quarantine to one branch (or branch pattern), JSON output.
-mergify tests quarantine -r owner/repo \
+mergify tests quarantines add -r owner/repo \
   --reason 'broken on release branch' --branch 'release/*' --json \
   'test_logout'
 ```
@@ -209,19 +210,19 @@ mergify tests quarantine -r owner/repo \
 - `0` -- Test quarantined.
 - `6` -- Mergify API error (e.g. the test is already quarantined).
 
-## Tests Unquarantine (`tests unquarantine`)
+## Tests Quarantines Remove (`tests quarantines remove`)
 
 Removes a test from the quarantine. Accepts either the fully qualified test
 name (resolved to its quarantine id via the list endpoint) or the quarantine
-id directly (as printed by `tests quarantine`). A UUID-shaped argument is
-treated as the id and deleted without a lookup.
+id directly (as printed by `tests quarantines add`). A UUID-shaped argument
+is treated as the id and deleted without a lookup.
 
 ```bash
 # By test name.
-mergify tests unquarantine -r owner/repo 'test_login'
+mergify tests quarantines remove -r owner/repo 'test_login'
 
-# By quarantine id (the value `tests quarantine` printed).
-mergify tests unquarantine -r owner/repo 12345678-1234-5678-1234-567812345678
+# By quarantine id (the value `tests quarantines add` printed).
+mergify tests quarantines remove -r owner/repo 12345678-1234-5678-1234-567812345678
 ```
 
 **Key options:**
@@ -235,20 +236,46 @@ mergify tests unquarantine -r owner/repo 12345678-1234-5678-1234-567812345678
 - `0` -- Test unquarantined.
 - `6` -- Mergify API error (e.g. the test is not quarantined).
 
-## Tests Quarantined (`tests quarantined`)
+## Tests Quarantines Get (`tests quarantines get`)
+
+Prints a single quarantine, addressed by the fully qualified test name or the
+quarantine id (a UUID-shaped argument is matched against the id). The output
+mirrors one record of `tests quarantines list`.
+
+```bash
+# By test name.
+mergify tests quarantines get -r owner/repo 'test_login'
+
+# By quarantine id, JSON output.
+mergify tests quarantines get -r owner/repo --json \
+  12345678-1234-5678-1234-567812345678
+```
+
+**Key options:**
+- `--repository` / `-r` -- Repository full name (`owner/repo`); auto-detected from the CI environment or the local git remote when omitted.
+- `--token` / `-t` (env: `MERGIFY_TOKEN`, then `GITHUB_TOKEN`) -- Auth token.
+- `--api-url` / `-u` (env: `MERGIFY_API_URL`) -- API base URL.
+- `--json` -- Emit the record (`id`, `test_name`, `reason`, `branch`, `created_at`,
+  `source`, `is_recovered`) to stdout.
+
+**Exit codes:**
+- `0` -- Quarantine found and printed.
+- `6` -- Mergify API error (e.g. no matching quarantine).
+
+## Tests Quarantines List (`tests quarantines list`)
 
 Lists every test currently in the repository's CI Insights quarantine. Takes no
 test argument -- it prints the whole quarantine. Human output is one indented
 block per record -- the test name on its own line (never wrapped mid-name),
-then its id (the value `unquarantine` accepts), branch, source, recovered, and
+then its id (the value `delete` accepts), branch, source, recovered, and
 reason. `--json` emits the full records.
 
 ```bash
 # Human output (one block per record).
-mergify tests quarantined -r owner/repo
+mergify tests quarantines list -r owner/repo
 
 # JSON for jq -- e.g. names of quarantines an auto-recover run flagged.
-mergify tests quarantined -r owner/repo --json \
+mergify tests quarantines list -r owner/repo --json \
   | jq -r '.quarantined_tests[] | select(.is_recovered) | .test_name'
 ```
 


### PR DESCRIPTION
The quarantine commands were three inconsistent top-level verbs
(`quarantine`, `unquarantine`, `quarantined`). Replace them with a
`tests quarantines` resource exposing `add`, `remove`, `get`, and
`list`, so the surface reads as one coherent resource.

`add` and `remove` reuse the existing quarantine/unquarantine
implementation; `get` is new — it prints a single quarantine resolved
by test name or quarantine id, filtering the list endpoint
client-side since the API exposes no single-quarantine GET.

Remove the flat `quarantine` / `unquarantine` / `quarantined` commands
outright rather than keeping them as aliases — the `quarantines`
subgroup fully replaces them.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Fixes: MRGFY-7500