### PR TITLE
ci(workflows): align smoke-test-binary on python 3.14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-python@v6.2.0
         with:
-          python-version: "3.13"
+          python-version: 3.14
       - name: Install Rust toolchain
         run: |
           rustup toolchain install stable --profile minimal


### PR DESCRIPTION
`smoke-test-binary` was the lone holdout on 3.13 — all the other
workflows (`build-wheels.yml`, `func-tests-live.yaml`) target
3.14. Match them so there's a single supported runtime version
across the CI surface.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>