### PR TITLE
feat(rust): generate a machine-readable CLI schema

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,29 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
+
+  cli-schema:
+    # Generate the machine-readable CLI schema from the tagged source
+    # and attach it to the release. The docs site consumes this asset
+    # (via the ci-bot schemas sync) to build the command reference, so
+    # it tracks released versions and never lives in the repo tree.
+    name: attach CLI schema to release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Generate CLI schema
+        run: cargo run --quiet --bin mergify -- _internal dump-cli-schema > cli-schema.json
+
+      - name: Attach to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" cli-schema.json --clobber

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,6 +1167,7 @@ dependencies = [
  "mergify-queue",
  "mergify-stack",
  "regex",
+ "serde",
  "serde_json",
  "serde_yaml_ng",
  "temp-env",

--- a/crates/mergify-cli/Cargo.toml
+++ b/crates/mergify-cli/Cargo.toml
@@ -23,10 +23,10 @@ mergify-freeze = { path = "../mergify-freeze" }
 mergify-py-shim = { path = "../mergify-py-shim" }
 mergify-queue = { path = "../mergify-queue" }
 mergify-stack = { path = "../mergify-stack" }
-# Used by Python-migration helpers (`_internal junit-parse`,
-# `_internal stack-local-commits`). When the last `_internal`
-# subcommand goes away — i.e. every stack subcommand is native —
-# this dep can be dropped too.
+# Backs the `_internal dump-cli-schema` generator (serializing the
+# clap command tree) and the Python-migration helpers (`_internal
+# stack-local-commits` et al.).
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", default-features = false, features = ["macros", "rt", "time"] }
 url = "2"

--- a/crates/mergify-cli/src/cli_schema.rs
+++ b/crates/mergify-cli/src/cli_schema.rs
@@ -1,0 +1,361 @@
+//! Machine-readable CLI schema — the CLI's equivalent of the API's
+//! `OpenAPI` spec. [`build`] walks the clap `Command` tree rooted at
+//! [`crate::CliRoot`] and emits every command, subcommand, and
+//! argument (descriptions, flags, defaults, value sets) as JSON. The
+//! docs site renders that JSON the same way it renders the `OpenAPI`
+//! spec, so the published reference can never drift from the binary:
+//! every field is sourced from a clap getter that the derive macro
+//! populates from the Rust doc comments and `#[arg]`/`#[command]`
+//! attributes — there is no hand-maintained docs metadata.
+
+use std::collections::BTreeSet;
+
+use clap::CommandFactory;
+use serde::Serialize;
+
+use crate::CliRoot;
+use crate::StackDropCli;
+use crate::StackEditCli;
+use crate::StackFixupCli;
+use crate::StackNewCli;
+use crate::StackNoteCli;
+
+/// Internal contract version. Bump when a field is renamed or removed
+/// so the docs renderer can move in lockstep.
+const SCHEMA_VERSION: u32 = 1;
+
+/// Stack subcommands still served by the Python shim during the
+/// Python→Rust migration. clap can't see them — the `stack` group is
+/// a `trailing_var_arg` forwarder, so a plain walk of `CliRoot` would
+/// silently drop them from the published reference. Names and help are
+/// the source of truth in `mergify_cli/stack/cli.py`'s `@stack.command`
+/// decorators; delete each entry as its command ports to a native clap
+/// parser, at which point [`stack_subcommands`] picks it up
+/// automatically.
+const PENDING_PYTHON_STACK: &[(&str, &str)] = &[
+    ("hooks", "Show git hooks status and manage installation"),
+    (
+        "setup",
+        "Configure git hooks (alias for 'stack hooks --setup')",
+    ),
+    ("reorder", "Reorder the stack's commits"),
+    ("move", "Move a commit within the stack"),
+    (
+        "push",
+        "Push/sync the pull requests stack. By default, `stack push` skips the rebase when any PR \
+         in the stack has approvals; use --force-rebase to rebase anyway.",
+    ),
+    ("checkout", "Checkout the pull requests stack"),
+    (
+        "sync",
+        "Sync the stack: fetch trunk, remove merged commits, rebase",
+    ),
+    ("list", "List the stack's commits and their associated PRs"),
+    ("open", "Open a PR from the stack in the browser"),
+    ("reword", "Change a commit's message"),
+    ("squash", "Squash commits into a target commit"),
+];
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliSchema {
+    schema_version: u32,
+    generator: &'static str,
+    cli: CliInfo,
+    command: CommandNode,
+}
+
+#[derive(Serialize)]
+struct CliInfo {
+    name: String,
+    version: &'static str,
+    about: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CommandNode {
+    /// Leaf name, e.g. `add`.
+    name: String,
+    /// Full invocation path, e.g. `["mergify", "tests", "quarantines", "add"]`.
+    /// Drives the docs slug and grouping.
+    path: Vec<String>,
+    about: Option<String>,
+    long_about: Option<String>,
+    usage: String,
+    aliases: Vec<String>,
+    subcommand_required: bool,
+    /// `native` (introspected from clap) or `python-shim` (still
+    /// forwarded to Python; name + help only).
+    source: &'static str,
+    args: Vec<ArgNode>,
+    commands: Vec<CommandNode>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ArgNode {
+    id: String,
+    /// `positional`, `flag` (takes no value), or `option`.
+    kind: &'static str,
+    short: Option<String>,
+    long: Option<String>,
+    value_names: Vec<String>,
+    help: Option<String>,
+    long_help: Option<String>,
+    required: bool,
+    global: bool,
+    default: Option<String>,
+    possible_values: Vec<PossibleValueNode>,
+    /// clap's `ValueRange` rendering, e.g. `1`, `0..=1`, `1..`.
+    num_args: Option<String>,
+    env: Option<String>,
+    value_hint: Option<&'static str>,
+}
+
+#[derive(Serialize)]
+struct PossibleValueNode {
+    name: String,
+    help: Option<String>,
+}
+
+/// Build the schema for the whole CLI.
+pub fn build() -> CliSchema {
+    let mut root = CliRoot::command();
+    // clap injects argument defaults (num_args, actions, value hints)
+    // and propagates global args only during `build()`; walking an
+    // unbuilt command yields null/wrong values for those fields.
+    root.build();
+
+    // Seed the path root from clap's configured name so `command.path[0]`
+    // can't drift from `cli.name`.
+    let command = command_node(&root, vec![root.get_name().to_string()], &BTreeSet::new());
+
+    CliSchema {
+        schema_version: SCHEMA_VERSION,
+        generator: "mergify _internal dump-cli-schema",
+        cli: CliInfo {
+            name: root.get_name().to_string(),
+            version: env!("CARGO_PKG_VERSION"),
+            about: root.get_about().map(ToString::to_string),
+        },
+        command,
+    }
+}
+
+/// Serialize the schema as pretty JSON with a trailing newline.
+pub fn dump() -> String {
+    let mut s = serde_json::to_string_pretty(&build()).expect("CLI schema serializes");
+    s.push('\n');
+    s
+}
+
+/// Print the schema to stdout. Entry point for `_internal dump-cli-schema`.
+pub fn run() -> std::process::ExitCode {
+    print!("{}", dump());
+    std::process::ExitCode::SUCCESS
+}
+
+fn command_node(
+    cmd: &clap::Command,
+    path: Vec<String>,
+    inherited_globals: &BTreeSet<String>,
+) -> CommandNode {
+    let about = cmd.get_about().map(ToString::to_string);
+    // clap returns None for `long_about` when only the short `///`
+    // line is set; mirror its own short→long fallback so the field is
+    // never spuriously empty.
+    let long_about = cmd
+        .get_long_about()
+        .map(ToString::to_string)
+        .or_else(|| about.clone());
+
+    // Each global arg is emitted once, at the command where it's
+    // declared; descendants inherit it (clap propagates it into their
+    // `get_arguments()` after `build()`) so we skip it there.
+    let mut globals_seen = inherited_globals.clone();
+    let mut args = Vec::new();
+    for arg in cmd.get_arguments() {
+        let id = arg.get_id().as_str();
+        // clap's synthetic `--help`/`--version` and any `hide`-d arg
+        // (e.g. the `stack` shim's trailing var-arg) are not part of
+        // the user-facing reference.
+        if id == "help" || id == "version" || arg.is_hide_set() {
+            continue;
+        }
+        if arg.is_global_set() {
+            if inherited_globals.contains(id) {
+                continue;
+            }
+            globals_seen.insert(id.to_string());
+        }
+        args.push(arg_node(arg));
+    }
+
+    // `stack` is the last Python-shimmed group: its native subcommands
+    // live in standalone parser structs outside the walkable tree, and
+    // the rest are still in Python. Graft both in.
+    let commands = if path.last().map(String::as_str) == Some("stack") {
+        stack_subcommands(&path)
+    } else {
+        cmd.get_subcommands()
+            .filter(|sub| !sub.is_hide_set())
+            .map(|sub| {
+                let mut child = path.clone();
+                child.push(sub.get_name().to_string());
+                command_node(sub, child, &globals_seen)
+            })
+            .collect()
+    };
+
+    let usage = render_usage(cmd, &path);
+
+    CommandNode {
+        name: cmd.get_name().to_string(),
+        path,
+        about,
+        long_about,
+        usage,
+        aliases: cmd.get_visible_aliases().map(ToString::to_string).collect(),
+        subcommand_required: cmd.is_subcommand_required_set(),
+        source: "native",
+        args,
+        commands,
+    }
+}
+
+fn arg_node(arg: &clap::Arg) -> ArgNode {
+    let help = arg.get_help().map(ToString::to_string);
+    let long_help = arg
+        .get_long_help()
+        .map(ToString::to_string)
+        .or_else(|| help.clone());
+
+    let defaults: Vec<String> = arg
+        .get_default_values()
+        .iter()
+        .map(|v| v.to_string_lossy().into_owned())
+        .collect();
+    let default = (!defaults.is_empty()).then(|| defaults.join(","));
+
+    let possible_values = arg
+        .get_possible_values()
+        .into_iter()
+        .filter(|pv| !pv.is_hide_set())
+        .map(|pv| PossibleValueNode {
+            name: pv.get_name().to_string(),
+            help: pv.get_help().map(ToString::to_string),
+        })
+        .collect();
+
+    let kind = arg_kind(arg);
+    // Flags take no value, but clap still derives a placeholder value
+    // name from the id (e.g. `DEBUG` for `--debug`) — drop it so the
+    // reference doesn't imply `--debug <DEBUG>`.
+    let value_names = if kind == "flag" {
+        Vec::new()
+    } else {
+        arg.get_value_names()
+            .map(|names| names.iter().map(ToString::to_string).collect())
+            .unwrap_or_default()
+    };
+
+    ArgNode {
+        id: arg.get_id().as_str().to_string(),
+        kind,
+        short: arg.get_short().map(|c| c.to_string()),
+        long: arg.get_long().map(ToString::to_string),
+        value_names,
+        help,
+        long_help,
+        required: arg.is_required_set(),
+        global: arg.is_global_set(),
+        default,
+        possible_values,
+        num_args: arg.get_num_args().map(|r| r.to_string()),
+        env: arg.get_env().map(|e| e.to_string_lossy().into_owned()),
+        value_hint: value_hint(arg),
+    }
+}
+
+fn arg_kind(arg: &clap::Arg) -> &'static str {
+    use clap::ArgAction;
+    if arg.is_positional() {
+        "positional"
+    } else if matches!(
+        arg.get_action(),
+        ArgAction::SetTrue | ArgAction::SetFalse | ArgAction::Count
+    ) {
+        "flag"
+    } else {
+        "option"
+    }
+}
+
+fn value_hint(arg: &clap::Arg) -> Option<&'static str> {
+    use clap::ValueHint;
+    Some(match arg.get_value_hint() {
+        ValueHint::Unknown => return None,
+        ValueHint::AnyPath => "anyPath",
+        ValueHint::FilePath => "filePath",
+        ValueHint::DirPath => "dirPath",
+        ValueHint::ExecutablePath => "executablePath",
+        ValueHint::CommandName => "commandName",
+        ValueHint::CommandString => "commandString",
+        ValueHint::CommandWithArguments => "commandWithArguments",
+        ValueHint::Username => "username",
+        ValueHint::Hostname => "hostname",
+        ValueHint::Url => "url",
+        ValueHint::EmailAddress => "emailAddress",
+        _ => "other",
+    })
+}
+
+/// Render the usage line, overriding the bin name so it shows the full
+/// invocation path (`mergify tests quarantines add …`). `render_usage`
+/// needs `&mut`, so clone — the walk stays immutable.
+fn render_usage(cmd: &clap::Command, path: &[String]) -> String {
+    let mut cmd = cmd.clone().bin_name(path.join(" "));
+    let usage = cmd.render_usage().to_string();
+    // `render_usage` prefixes "Usage: "; the schema carries the bare line.
+    usage.strip_prefix("Usage: ").unwrap_or(&usage).to_string()
+}
+
+/// Subcommands of `stack`: the five natively-ported parsers grafted in
+/// (they're side-parsed outside `CliRoot`, so the walk can't reach
+/// them), followed by the still-Python ones from [`PENDING_PYTHON_STACK`].
+fn stack_subcommands(stack_path: &[String]) -> Vec<CommandNode> {
+    let mut out = Vec::new();
+
+    for mut native in [
+        StackNewCli::command(),
+        StackNoteCli::command(),
+        StackEditCli::command(),
+        StackDropCli::command(),
+        StackFixupCli::command(),
+    ] {
+        native.build();
+        let mut child = stack_path.to_vec();
+        child.push(native.get_name().to_string());
+        out.push(command_node(&native, child, &BTreeSet::new()));
+    }
+
+    for (name, help) in PENDING_PYTHON_STACK {
+        let mut child = stack_path.to_vec();
+        child.push((*name).to_string());
+        out.push(CommandNode {
+            name: (*name).to_string(),
+            usage: format!("{} {name} [OPTIONS]", stack_path.join(" ")),
+            path: child,
+            about: Some((*help).to_string()),
+            long_about: Some((*help).to_string()),
+            aliases: Vec::new(),
+            subcommand_required: false,
+            source: "python-shim",
+            args: Vec::new(),
+            commands: Vec::new(),
+        });
+    }
+
+    out
+}

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -49,6 +49,8 @@ use mergify_queue::show::ShowOptions;
 use mergify_queue::status::StatusOptions;
 use mergify_queue::unpause::UnpauseOptions;
 
+mod cli_schema;
+
 fn main() -> ExitCode {
     let argv: Vec<String> = env::args().skip(1).collect();
 
@@ -172,6 +174,9 @@ const NATIVE_COMMANDS: &[(&str, &str)] = &[
     // rewrite the todo file in-process. Not a user-facing
     // command; not stable.
     ("_internal", "rebase-todo-rewrite"),
+    // Emits the machine-readable CLI schema the docs site renders
+    // into the command reference. Hidden; not a stable surface.
+    ("_internal", "dump-cli-schema"),
 ];
 
 /// Native commands the Rust binary handles without delegating to
@@ -249,6 +254,10 @@ enum NativeCommand {
     /// applies the named transformation, writes it back in place.
     /// Wire format is not stable.
     InternalRebaseTodoRewrite(InternalRebaseTodoRewriteOpts),
+    /// `_internal dump-cli-schema` — serialize the clap command tree
+    /// to JSON for the docs site. Pure introspection; no async, no I/O
+    /// beyond stdout.
+    InternalDumpCliSchema,
 }
 
 struct StackEditOpts {
@@ -737,6 +746,9 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
                 todo_path,
             },
         )),
+        Subcommands::Internal(InternalArgs {
+            command: InternalSubcommand::DumpCliSchema,
+        }) => Dispatch::Native(NativeCommand::InternalDumpCliSchema),
         Subcommands::Ci(CiArgs {
             command:
                 CiSubcommand::Scopes(ScopesCliArgs {
@@ -1035,6 +1047,12 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
 
 #[allow(clippy::too_many_lines)] // mostly mechanical match arms
 fn run_native(cmd: NativeCommand) -> ExitCode {
+    // Pure introspection — no async runtime, network, or shared output
+    // machinery. Handle it before spinning up tokio.
+    if matches!(cmd, NativeCommand::InternalDumpCliSchema) {
+        return cli_schema::run();
+    }
+
     let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -1061,6 +1079,10 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
 
     let result: Result<mergify_core::ExitCode, mergify_core::CliError> = rt.block_on(async {
         match cmd {
+            // Handled above, before the runtime was built.
+            NativeCommand::InternalDumpCliSchema => {
+                unreachable!("dump-cli-schema is handled before the runtime starts")
+            }
             NativeCommand::ConfigValidate { config_file } => {
                 mergify_config::validate::run(config_file.as_deref(), &mut output)
                     .await
@@ -1763,6 +1785,12 @@ enum InternalSubcommand {
     /// user-facing surface.
     #[command(name = "rebase-todo-rewrite")]
     RebaseTodoRewrite(InternalRebaseTodoRewriteArgs),
+    /// Emit the machine-readable CLI schema (the JSON the docs site
+    /// renders into the command reference) to stdout. Walks the clap
+    /// command tree so every description and flag is sourced from the
+    /// code, never hand-maintained. Not a stable user-facing surface.
+    #[command(name = "dump-cli-schema")]
+    DumpCliSchema,
 }
 
 #[derive(clap::Args)]
@@ -2669,6 +2697,50 @@ mod tests {
             std::iter::once("mergify".to_string()).chain(argv.iter().map(|s| (*s).to_string())),
         )
         .expect("argv parses")
+    }
+
+    /// The schema is published as a release asset (not committed), so
+    /// guard the generator structurally rather than against a golden
+    /// file: it must serialize to valid JSON, expose every top-level
+    /// group, surface both stack sources, and never leak the hidden
+    /// `_internal` machinery into the public reference.
+    #[test]
+    fn cli_schema_is_well_formed() {
+        let v: serde_json::Value =
+            serde_json::from_str(&cli_schema::dump()).expect("schema is valid JSON");
+
+        let groups: Vec<&str> = v["command"]["commands"]
+            .as_array()
+            .expect("commands array")
+            .iter()
+            .map(|c| c["name"].as_str().expect("group name"))
+            .collect();
+        assert_eq!(
+            groups,
+            ["config", "ci", "tests", "queue", "freeze", "stack"]
+        );
+        assert!(!groups.contains(&"_internal"), "hidden group leaked");
+
+        let stack = v["command"]["commands"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["name"] == "stack")
+            .expect("stack group");
+        let sources: std::collections::BTreeSet<&str> = stack["commands"]
+            .as_array()
+            .expect("stack subcommands")
+            .iter()
+            .map(|c| c["source"].as_str().expect("source"))
+            .collect();
+        assert!(
+            sources.contains("native"),
+            "native stack subcommands missing"
+        );
+        assert!(
+            sources.contains("python-shim"),
+            "pending-python stack subcommands missing"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add a hidden `_internal dump-cli-schema` subcommand that walks the clap
command tree and serializes every command, argument, default, and value
set to JSON — the CLI's analog of the API's OpenAPI spec, for the docs
site to render. Every field comes from existing doc comments and
`#[arg]`/`#[command]` attributes, so the reference cannot drift from the
binary.

The `stack` group's five native subcommands are grafted in (they are
side-parsed outside `CliRoot`); the still-Python ones are carried in a
temporary table until they port. The release workflow generates the
schema from the tagged source and attaches it as a GitHub release asset
for the docs sync to consume — it is generated, never committed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>