### PR TITLE
ci: drop cli-schema release-asset job (broken on immutable releases)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,29 +44,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
-
-  cli-schema:
-    # Generate the machine-readable CLI schema from the tagged source
-    # and attach it to the release. The docs site consumes this asset
-    # (via the ci-bot schemas sync) to build the command reference, so
-    # it tracks released versions and never lives in the repo tree.
-    name: attach CLI schema to release
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6.0.2
-
-      - name: Install Rust toolchain
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Generate CLI schema
-        run: cargo run --quiet --bin mergify -- _internal dump-cli-schema > cli-schema.json
-
-      - name: Attach to release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" cli-schema.json --clobber


### PR DESCRIPTION
The job uploaded cli-schema.json with `gh release upload` on
`release: published`, which fails HTTP 422 — assets can't be added to an
immutable release once it is published, so the job can never succeed.

The docs command reference gets the schema from the ci-bot schemas sync
generating it from the published package instead of a release asset, so
nothing needs to produce one here. The `_internal dump-cli-schema` command
is unchanged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>