### PR TITLE
feat(release): ship platform binaries via GH Release + curl|sh installer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,12 +102,134 @@ jobs:
             exit 1
           }
 
+  # End-to-end exercise of the `install.sh` one-liner: build the
+  # release binary, pretend to be a GitHub Release by serving the
+  # repackaged `mergify-<target>.tar.gz` + `SHA256SUMS` through a
+  # local HTTP fixture, then run `install.sh` against it and assert
+  # the installed binary works. This catches the install path that
+  # the unit-style shellcheck pass can't — detect_target mapping,
+  # sha256 verification, the `install -m 0755` step, and the final
+  # `--version` exec.
+  #
+  # Linux + macOS only (Windows users go through a separate
+  # PowerShell installer, TBD).
+  install-script-smoke:
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-15]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: install-${{ matrix.os }}
+
+      - name: Install shellcheck (Linux only)
+        if: matrix.os == 'ubuntu-24.04'
+        run: sudo apt-get install -y --no-install-recommends shellcheck
+      - name: Lint install.sh
+        if: matrix.os == 'ubuntu-24.04'
+        run: shellcheck install.sh
+
+      # Build the binary the same way the release path does, then
+      # repackage it under the exact name/structure `install.sh`
+      # expects so the fixture is bit-identical to a real release
+      # asset.
+      - name: Build release binary
+        run: cargo build --release -p mergify-cli
+
+      - name: Pack release fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          target=$(rustc -vV | awk '/^host:/ {print $2}')
+          echo "Building fixture for target: ${target}"
+          mkdir -p fixture/release
+          tar -C target/release -czf "fixture/release/mergify-${target}.tar.gz" mergify
+          (cd fixture/release && shasum -a 256 "mergify-${target}.tar.gz" > SHA256SUMS)
+          ls -la fixture/release
+
+      - name: Serve fixture
+        shell: bash
+        run: |
+          cd fixture/release
+          # `python3 -m http.server` is preinstalled on both runners.
+          # Bind to localhost only; the runner is ephemeral but
+          # there's no point exposing the fixture.
+          python3 -m http.server 8765 --bind 127.0.0.1 > /tmp/server.log 2>&1 &
+          echo $! > /tmp/server.pid
+          # Wait for the server to actually accept connections.
+          for _ in $(seq 1 50); do
+              curl -fsS http://127.0.0.1:8765/SHA256SUMS > /dev/null && break
+              sleep 0.1
+          done
+
+      - name: Run install.sh against the fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          export MERGIFY_BASE_URL=http://127.0.0.1:8765
+          export MERGIFY_INSTALL_DIR=/tmp/mergify-install
+          ./install.sh
+          # `install.sh` runs `--version` itself, but pin it here
+          # too so a future refactor that drops the post-install
+          # smoke from the script still trips this job.
+          /tmp/mergify-install/mergify --version
+
+      # Negative paths: corrupted SHA256SUMS must fail closed, not
+      # silently install a tampered binary. Tests both the
+      # `sha256sum -c` mismatch path (right shape, wrong hash) and
+      # the malformed-line path (`sha256sum -c` only warns on
+      # malformed lines, so install.sh validates the line shape
+      # separately).
+      - name: install.sh rejects a tampered SHA256SUMS
+        shell: bash
+        run: |
+          set -euo pipefail
+          target=$(rustc -vV | awk '/^host:/ {print $2}')
+          asset="mergify-${target}.tar.gz"
+          # Keep a clean copy so the malformed test below can write
+          # its own bad version without losing the original.
+          cp fixture/release/SHA256SUMS fixture/release/SHA256SUMS.orig
+
+          echo "Case 1: wrong-but-well-formed hash"
+          printf '%064d  %s\n' 0 "${asset}" > fixture/release/SHA256SUMS
+          ! MERGIFY_BASE_URL=http://127.0.0.1:8765 \
+            MERGIFY_INSTALL_DIR=/tmp/mergify-bad1 \
+            ./install.sh > /tmp/case1.log 2>&1
+          grep -q 'checksum verification failed' /tmp/case1.log
+
+          echo "Case 2: malformed line"
+          echo "bogus  ${asset}" > fixture/release/SHA256SUMS
+          ! MERGIFY_BASE_URL=http://127.0.0.1:8765 \
+            MERGIFY_INSTALL_DIR=/tmp/mergify-bad2 \
+            ./install.sh > /tmp/case2.log 2>&1
+          grep -q 'malformed checksum entry' /tmp/case2.log
+
+          # Restore — the next steps may depend on a working fixture.
+          mv fixture/release/SHA256SUMS.orig fixture/release/SHA256SUMS
+
+      - name: Stop fixture server
+        if: always()
+        shell: bash
+        run: |
+          if [ -f /tmp/server.pid ]; then
+              kill "$(cat /tmp/server.pid)" || true
+          fi
+
   ci-gate:
     if: ${{ !cancelled() }}
     needs:
       - rust
       - wheels
       - smoke-test-binary
+      - install-script-smoke
     runs-on: ubuntu-latest
     steps:
       - name: Verify all jobs succeeded

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,31 +1,167 @@
-name: upload release to PyPI
+name: release
 
-# Builds the platform-tagged wheel matrix (delegated to
-# `build-wheels.yml`) plus an sdist with the wheel version stamped
-# from the git tag, then publishes everything to PyPI in a single
-# Trusted-Publisher upload.
+# Two-stage release flow, forced by GitHub's immutable-releases
+# policy (assets can't be added after publish — PR #1569 dropped a
+# prior `gh release upload` job for the same reason):
 #
-# `build-wheels.yml` is shared with `ci.yaml`; the only release-
-# specific behaviour lives here (version stamping, the publish
-# step itself). Adding a new platform target in `build-wheels.yml`
-# automatically extends the release matrix.
+# 1. `release: created` with `draft == true` — maintainer clicks
+#    "Save draft" in the UI. We build wheels, extract the binary
+#    from each, and attach `mergify-<target>.{tar.gz,zip}` +
+#    `SHA256SUMS` to the still-mutable draft. The assets appear in
+#    the draft's asset list within a few minutes.
+#
+# 2. `release: published` — maintainer reviews the now-asset-laden
+#    draft and clicks "Publish release". We assert the expected
+#    asset names are attached (blocks the PyPI step with a clear
+#    error if the maintainer bypassed the draft flow and published
+#    directly — the release is then immutable and binaries can't be
+#    backfilled), then build wheels again and publish to PyPI.
+#
+# Yes, wheels are built twice (once per stage). The alternative —
+# stash wheels somewhere between runs — adds storage plumbing for
+# ~5 min of CI savings; not worth it. `build-wheels.yml` is shared
+# with `ci.yaml` so adding a new platform target there extends both
+# stages automatically.
 
 on:
   release:
-    types:
-      - published
+    types: [created, published]
 
 jobs:
-  build:
+  # ---------------- Draft stage: attach binaries ----------------
+
+  build-wheels-for-draft:
+    name: build wheels (draft stage)
+    if: github.event.action == 'created' && github.event.release.draft
+    uses: ./.github/workflows/build-wheels.yml
+    with:
+      stamp-version: true
+
+  upload-binaries:
+    name: attach binaries to the draft release
+    if: github.event.action == 'created' && github.event.release.draft
+    needs: build-wheels-for-draft
+    runs-on: ubuntu-24.04
+    permissions:
+      # `gh release upload` writes to the release.
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          # Skip `wheel-sdist` (single dash); each wheel artifact is
+          # `wheel-<target>` with multiple dashes in the target.
+          pattern: wheel-*-*
+          path: artifacts
+
+      # Each `wheel-<target>` artifact is a maturin-built wheel with
+      # the `mergify` binary at `<dist>.data/scripts/mergify[.exe]`.
+      # Extract it, normalise into `mergify-<target>.{tar.gz,zip}`,
+      # then hash the lot with sha256 so the installer can verify
+      # what it pulled. Stable names (no embedded version) so the
+      # `releases/latest/download/...` redirect keeps working for
+      # the `install.sh` consumers — the version is still observable
+      # via `mergify --version` after install.
+      - name: Extract binaries and repack
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          for dir in artifacts/wheel-*; do
+            target="${dir#artifacts/wheel-}"
+            whl=$(ls "${dir}"/*.whl | head -1)
+            workdir=$(mktemp -d)
+            # `-j` flattens, `-o` overwrites — the wheel layout is
+            # `<dist>.data/scripts/<bin>`; we only want `<bin>`.
+            unzip -joq "${whl}" '*/scripts/mergify' '*/scripts/mergify.exe' -d "${workdir}"
+            if [[ "${target}" == *windows* ]]; then
+              (cd "${workdir}" && zip -q "${OLDPWD}/dist/mergify-${target}.zip" mergify.exe)
+            else
+              chmod +x "${workdir}/mergify"
+              tar -C "${workdir}" -czf "dist/mergify-${target}.tar.gz" mergify
+            fi
+            rm -rf "${workdir}"
+          done
+          (cd dist && sha256sum mergify-* > SHA256SUMS)
+          echo "Built release assets:"
+          ls -la dist
+
+      - name: Upload assets to the draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          # `--clobber` so re-saving the draft (which can re-fire
+          # `release: created`) replaces stale assets instead of
+          # erroring out.
+          gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber
+
+  # ---------------- Publish stage: assert + PyPI ----------------
+
+  assert-binaries-present:
+    name: assert binary assets attached
+    if: github.event.action == 'published'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Check expected assets are on the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ github.event.release.tag_name }}"
+          mapfile -t attached < <(gh release view "$tag" --json assets --jq '.assets[].name')
+          echo "Assets on $tag:"
+          printf '  %s\n' "${attached[@]}"
+
+          expected=(
+            mergify-x86_64-unknown-linux-gnu.tar.gz
+            mergify-aarch64-unknown-linux-gnu.tar.gz
+            mergify-x86_64-apple-darwin.tar.gz
+            mergify-aarch64-apple-darwin.tar.gz
+            mergify-x86_64-pc-windows-msvc.zip
+            SHA256SUMS
+          )
+          missing=()
+          for asset in "${expected[@]}"; do
+            printf '%s\n' "${attached[@]}" | grep -qx "$asset" || missing+=("$asset")
+          done
+          if (( ${#missing[@]} > 0 )); then
+            cat <<EOF >&2
+          ::error::Release $tag is missing assets: ${missing[*]}
+
+          Binaries are attached by the 'upload-binaries' job, which only runs when
+          a release is saved as a *draft* (release: created event). It looks like
+          this release was published directly without first being saved as a
+          draft. Because release metadata is now immutable, the assets can't be
+          backfilled — the PyPI publish is being blocked so the package and the
+          binary distributions don't diverge.
+
+          Recovery: delete this release, then re-create it via the UI making sure
+          to click "Save draft" first. Wait for the binaries to appear in the
+          draft's asset list before clicking "Publish".
+          EOF
+            exit 1
+          fi
+          echo "All expected assets present — proceeding."
+
+  build-wheels-for-publish:
+    name: build wheels (publish stage)
+    if: github.event.action == 'published'
+    needs: assert-binaries-present
     uses: ./.github/workflows/build-wheels.yml
     with:
       stamp-version: true
 
   publish:
     name: publish to PyPI
+    if: github.event.action == 'published'
     runs-on: ubuntu-24.04
     needs:
-      - build
+      - assert-binaries-present
+      - build-wheels-for-publish
     environment: release
     permissions:
       id-token: write
@@ -33,6 +169,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v8
         with:
+          # `wheel-*` covers both `wheel-<target>` artifacts and
+          # `wheel-sdist` — PyPI gets both.
           pattern: wheel-*
           merge-multiple: true
           path: dist

--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@ CI insights, merge queue, scheduled freezes, and configuration management.
 
 ## Installation
 
+Standalone binary (Linux + macOS, x86_64 and aarch64):
+
+```shell
+curl -fsSL https://raw.githubusercontent.com/Mergifyio/mergify-cli/main/install.sh | sh
+```
+
+Installs to `~/.local/bin/mergify`. Override with `MERGIFY_INSTALL_DIR=/usr/local/bin`
+or pin a version with `MERGIFY_VERSION=2026.4.23.1`.
+
+Or via Python packaging (any OS):
+
 ```shell
 uv tool install mergify-cli
 # or

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+# Install the `mergify` CLI from a GitHub Release.
+#
+# Default usage:
+#
+#   curl -fsSL https://raw.githubusercontent.com/Mergifyio/mergify-cli/main/install.sh | sh
+#
+# Environment overrides:
+#
+#   MERGIFY_INSTALL_DIR   Install directory (default: $HOME/.local/bin).
+#   MERGIFY_VERSION       Release tag to install (default: latest).
+#   MERGIFY_BASE_URL      Base URL for asset downloads (default: the
+#                         GitHub Releases endpoint for Mergifyio/mergify-cli).
+#                         Overriding this is how the install-script
+#                         smoke test points at a local fixture server.
+#
+# POSIX sh — no bash-only constructs. The script is intentionally
+# straightforward so a security-conscious user can `curl ... | less`
+# before piping to `sh`.
+
+set -eu
+
+REPO="Mergifyio/mergify-cli"
+INSTALL_DIR="${MERGIFY_INSTALL_DIR:-${HOME}/.local/bin}"
+VERSION="${MERGIFY_VERSION:-latest}"
+if [ "${VERSION}" = "latest" ]; then
+    BASE_URL="${MERGIFY_BASE_URL:-https://github.com/${REPO}/releases/latest/download}"
+else
+    BASE_URL="${MERGIFY_BASE_URL:-https://github.com/${REPO}/releases/download/${VERSION}}"
+fi
+
+die() {
+    printf 'error: %s\n' "$1" >&2
+    exit 1
+}
+
+# Map `uname -s` / `uname -m` to the Rust target triple the release
+# workflow tags its assets with. Anything we don't ship a binary for
+# bails — no auto-build fallback because that would imply a working
+# Rust toolchain on the user's machine, which defeats the point of a
+# prebuilt binary installer.
+detect_target() {
+    os=$(uname -s)
+    arch=$(uname -m)
+    case "${os}" in
+        Linux)  os_part="unknown-linux-gnu" ;;
+        Darwin) os_part="apple-darwin"      ;;
+        *) die "unsupported OS '${os}' — see https://github.com/${REPO}/releases for available assets" ;;
+    esac
+    case "${arch}" in
+        x86_64|amd64)  arch_part="x86_64"  ;;
+        arm64|aarch64) arch_part="aarch64" ;;
+        *) die "unsupported architecture '${arch}'" ;;
+    esac
+    printf '%s-%s' "${arch_part}" "${os_part}"
+}
+
+# `sha256sum` (GNU coreutils) on Linux, `shasum -a 256` on macOS.
+# Tests for both at use-site instead of caching because we already
+# have at most one fetch round-trip; cost is negligible.
+sha256_check() {
+    if command -v sha256sum > /dev/null 2>&1; then
+        sha256sum -c "$1"
+    elif command -v shasum > /dev/null 2>&1; then
+        shasum -a 256 -c "$1"
+    else
+        die "neither sha256sum nor shasum found — install one and retry"
+    fi
+}
+
+main() {
+    command -v curl > /dev/null 2>&1 || die "curl is required"
+    command -v tar  > /dev/null 2>&1 || die "tar is required"
+
+    target=$(detect_target)
+    asset="mergify-${target}.tar.gz"
+    url="${BASE_URL}/${asset}"
+    sums_url="${BASE_URL}/SHA256SUMS"
+
+    tmp=$(mktemp -d)
+    # POSIX-compatible cleanup. `trap` runs on EXIT regardless of
+    # how the script exits (success, die, signal).
+    trap 'rm -rf "${tmp}"' EXIT INT HUP TERM
+
+    printf 'Downloading %s\n' "${url}"
+    curl -fsSL "${url}" -o "${tmp}/${asset}"
+
+    printf 'Downloading checksums\n'
+    curl -fsSL "${sums_url}" -o "${tmp}/SHA256SUMS"
+
+    # `SHA256SUMS` is one line per asset; grep for ours so a
+    # mismatch on a sibling asset doesn't fail us (and so the
+    # `sha256sum -c` output is scoped to the file we actually
+    # downloaded). Validate the line shape (64 hex chars + two
+    # spaces + filename) before handing it to sha256sum: GNU
+    # `sha256sum -c` only *warns* on a malformed entry and still
+    # exits 0 if no real mismatch was found, which would let a
+    # corrupted SHA256SUMS slip past the check.
+    printf 'Verifying checksum\n'
+    cd "${tmp}"
+    grep " ${asset}\$" SHA256SUMS > scoped.sums \
+        || die "no checksum entry for ${asset} in SHA256SUMS"
+    grep -qE '^[0-9a-fA-F]{64}  ' scoped.sums \
+        || die "malformed checksum entry for ${asset} in SHA256SUMS"
+    sha256_check scoped.sums > /dev/null \
+        || die "checksum verification failed for ${asset}"
+    cd - > /dev/null
+
+    tar -xzf "${tmp}/${asset}" -C "${tmp}"
+
+    mkdir -p "${INSTALL_DIR}"
+    # `install -m 0755` is in coreutils on Linux and BSD install on
+    # macOS; both honour `-m`. Avoids a separate chmod step.
+    install -m 0755 "${tmp}/mergify" "${INSTALL_DIR}/mergify"
+
+    printf '\nmergify installed to %s/mergify\n' "${INSTALL_DIR}"
+    "${INSTALL_DIR}/mergify" --version
+
+    case ":${PATH}:" in
+        *":${INSTALL_DIR}:"*) ;;
+        *) printf '\nWarning: %s is not on your PATH.\n' "${INSTALL_DIR}"
+           # The `$PATH` reference here is meant to land verbatim in
+           # the user's shell config — they expand it, not us.
+           # shellcheck disable=SC2016
+           printf 'Add it to your shell config:  export PATH="%s:$PATH"\n' "${INSTALL_DIR}" ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
PyPI stays the compat channel, but pulling a Rust binary through
`pip install` is a weird install path for users who don't already
have Python — and discoverability on PyPI for a git tool is poor.
Add a parallel distribution channel.

Release workflow split into two stages, keyed off the release
event's `action` field. The draft stage is forced by GitHub's
immutable-releases policy (assets can't be added after publish —
see #1569 which dropped a prior post-publish upload job for the
same reason):

  1. `release: created` with `draft == true` — fires when the
     maintainer clicks "Save draft" in the UI. We build wheels,
     extract the bundled binary from each, repackage as
     `mergify-<target>.tar.gz` (`.zip` for Windows), generate a
     single `SHA256SUMS`, and `gh release upload --clobber` the
     lot to the still-mutable draft. Assets appear in the draft's
     asset list within ~10 min.

  2. `release: published` — fires when the maintainer clicks
     "Publish release". We assert the six expected asset names are
     attached; if anything's missing we hard-fail with an
     explanation of the draft-first flow and block the downstream
     PyPI publish so the two channels don't diverge. Wheels build
     again and the PyPI publish runs unchanged.

Yes, wheels are built twice (once per stage). Stashing them across
two separately-triggered runs adds cross-run artifact plumbing for
~5 min of CI savings; not worth it.

Maintainer-facing change: the UI flow now requires "Save draft"
before "Publish release". A direct publish (no draft phase) lands
red on the assert job and blocks PyPI — the release stays live but
asset-less, requiring a delete-and-recreate to recover.

`install.sh` at repo root is a POSIX-sh one-liner installer. Maps
`uname` to the Rust target triple, fetches the matching asset from
`releases/latest/download/`, validates against `SHA256SUMS` (with
explicit line-shape validation so a malformed SHA256SUMS can't
slip past `sha256sum -c`'s warn-but-pass behaviour), drops the
binary in `$HOME/.local/bin/mergify`, and runs `--version` to
confirm. Knobs are env vars: `MERGIFY_INSTALL_DIR`,
`MERGIFY_VERSION`, `MERGIFY_BASE_URL` (the last is how the CI
smoke test points the script at a localhost fixture instead of
the real GitHub Releases endpoint).

New `install-script-smoke` CI job (Linux + macOS) builds the
release binary, packages it identically to a real release, serves
it from `python3 -m http.server`, and runs `install.sh`
end-to-end. Two negative cases: a wrong-but-well-formed hash and
a malformed checksum line — both must fail closed with a clear
error.

README's `## Installation` section leads with the curl|sh
one-liner; the existing `uv tool install` / `pipx install` forms
move below as the Python-packaging alternative.

Homebrew tap is a follow-up.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>