### PR TITLE
feat(cli): mergify self-update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -223,6 +223,103 @@ jobs:
               kill "$(cat /tmp/server.pid)" || true
           fi
 
+  # Same fixture pattern as `install-script-smoke`, but exercises
+  # `mergify self-update`. Builds the release binary, packages it
+  # like a real release would, points the binary at a localhost
+  # fixture via `MERGIFY_BASE_URL`, and runs the full download +
+  # verify + atomic-swap path. Plus a negative case proving a
+  # tampered `SHA256SUMS` reject (binary must stay untouched).
+  self-update-smoke:
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-15]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: self-update-${{ matrix.os }}
+
+      - name: Build release binary
+        run: cargo build --release -p mergify-cli
+
+      # Same fixture shape `self_update::endpoints` expects in
+      # `MERGIFY_BASE_URL` mode: a flat dir holding
+      # `latest-release.json` (the API stub), the asset tarball,
+      # and `SHA256SUMS`.
+      - name: Pack self-update fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          target=$(rustc -vV | awk '/^host:/ {print $2}')
+          echo "Building fixture for target: ${target}"
+          mkdir -p fixture/su
+          # Pretend a far-future release is available so the
+          # `current == latest` short-circuit doesn't fire.
+          echo '{"tag_name":"2099.1.1.1"}' > fixture/su/latest-release.json
+          tar -C target/release -czf "fixture/su/mergify-${target}.tar.gz" mergify
+          (cd fixture/su && shasum -a 256 "mergify-${target}.tar.gz" > SHA256SUMS)
+          ls -la fixture/su
+
+      - name: Serve fixture
+        shell: bash
+        run: |
+          cd fixture/su
+          python3 -m http.server 8766 --bind 127.0.0.1 > /tmp/su-server.log 2>&1 &
+          echo $! > /tmp/su-server.pid
+          for _ in $(seq 1 50); do
+              curl -fsS http://127.0.0.1:8766/SHA256SUMS > /dev/null && break
+              sleep 0.1
+          done
+
+      - name: self-update --check reports both versions
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(MERGIFY_BASE_URL=http://127.0.0.1:8766 target/release/mergify self-update --check)
+          echo "$out"
+          echo "$out" | grep -q 'Current: 0.0.0'
+          echo "$out" | grep -q 'Latest:  2099.1.1.1'
+
+      - name: self-update happy path swaps the binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp target/release/mergify /tmp/mergify-su
+          MERGIFY_BASE_URL=http://127.0.0.1:8766 /tmp/mergify-su self-update
+          # Sanity: the swapped binary still runs.
+          /tmp/mergify-su --version
+
+      - name: self-update rejects tampered SHA256SUMS
+        shell: bash
+        run: |
+          set -euo pipefail
+          target=$(rustc -vV | awk '/^host:/ {print $2}')
+          cp target/release/mergify /tmp/mergify-su-tamper
+          before=$(shasum -a 256 /tmp/mergify-su-tamper | awk '{print $1}')
+          # Replace SHA256SUMS with a wrong-but-well-formed hash.
+          printf '%064d  mergify-%s.tar.gz\n' 0 "${target}" > fixture/su/SHA256SUMS
+          ! MERGIFY_BASE_URL=http://127.0.0.1:8766 /tmp/mergify-su-tamper self-update \
+              > /tmp/su-tamper.log 2>&1
+          grep -q 'checksum mismatch' /tmp/su-tamper.log
+          # The binary must NOT have been swapped.
+          after=$(shasum -a 256 /tmp/mergify-su-tamper | awk '{print $1}')
+          [ "$before" = "$after" ] || { echo "binary was tampered!"; exit 1; }
+
+      - name: Stop fixture server
+        if: always()
+        shell: bash
+        run: |
+          if [ -f /tmp/su-server.pid ]; then
+              kill "$(cat /tmp/su-server.pid)" || true
+          fi
+
   ci-gate:
     if: ${{ !cancelled() }}
     needs:
@@ -230,6 +327,7 @@ jobs:
       - wheels
       - smoke-test-binary
       - install-script-smoke
+      - self-update-smoke
     runs-on: ubuntu-latest
     steps:
       - name: Verify all jobs succeeded

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,12 +334,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -356,6 +384,16 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -578,6 +616,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1166,9 +1214,12 @@ dependencies = [
  "mergify-queue",
  "mergify-stack",
  "regex",
+ "reqwest",
+ "self-replace",
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "sha2",
  "temp-env",
  "tempfile",
  "tokio",
@@ -1955,6 +2006,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,6 +2076,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2301,6 +2374,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-general-category"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ curl -fsSL https://raw.githubusercontent.com/Mergifyio/mergify-cli/main/install.
 ```
 
 Installs to `~/.local/bin/mergify`. Override with `MERGIFY_INSTALL_DIR=/usr/local/bin`
-or pin a version with `MERGIFY_VERSION=2026.4.23.1`.
+or pin a version with `MERGIFY_VERSION=2026.4.23.1`. Once installed, upgrade with
+`mergify self-update`.
 
 Or via Python packaging (any OS):
 

--- a/crates/mergify-cli/Cargo.toml
+++ b/crates/mergify-cli/Cargo.toml
@@ -22,6 +22,19 @@ mergify-core = { path = "../mergify-core" }
 mergify-freeze = { path = "../mergify-freeze" }
 mergify-queue = { path = "../mergify-queue" }
 mergify-stack = { path = "../mergify-stack" }
+# `mergify self-update`: hits the GitHub Releases API for the
+# latest tag, downloads the asset matching the current target,
+# verifies it against `SHA256SUMS` (same format the curl|sh
+# installer trusts), and atomically swaps the running binary. We
+# go through `reqwest` directly here instead of
+# `mergify-core::HttpClient` because the latter wraps GitHub-API
+# auth + retry, neither of which apply to unauthenticated public
+# release downloads. `self_replace` handles the Windows
+# can't-rename-over-a-running-exe dance cross-platform.
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
+self-replace = "1"
+sha2 = "0.10"
+tempfile = "3"
 # Backs the `_internal dump-cli-schema` generator (serializing the
 # clap command tree) and the Python-migration helpers (`_internal
 # stack-local-commits` et al.).

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -39,6 +39,7 @@ use mergify_queue::status::StatusOptions;
 use mergify_queue::unpause::UnpauseOptions;
 
 mod cli_schema;
+mod self_update;
 
 /// User-visible CLI version. `build.rs` normalises the
 /// `MERGIFY_RELEASE_VERSION` env var the release workflow sets
@@ -263,6 +264,9 @@ enum NativeCommand {
     /// to JSON for the docs site. Pure introspection; no async, no I/O
     /// beyond stdout.
     InternalDumpCliSchema,
+    /// `mergify self-update [--force] [--check]` — replace the
+    /// running binary with the latest release.
+    SelfUpdate(self_update::Options),
 }
 
 struct StackEditOpts {
@@ -888,6 +892,7 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
     let _ = parsed.debug; // global flag — consulted by command impls, not here
     match parsed.command {
         Subcommands::Stack(ShimmedArgs { args }) => dispatch_stack(args),
+        Subcommands::SelfUpdate(cli) => Dispatch::Native(NativeCommand::SelfUpdate(cli.into())),
         Subcommands::Internal(InternalArgs {
             command:
                 InternalSubcommand::StackLocalCommits(InternalStackLocalCommitsArgs {
@@ -2440,6 +2445,10 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 }
                 Ok(mergify_core::ExitCode::Success)
             }
+            NativeCommand::SelfUpdate(opts) => {
+                self_update::run(&opts).await?;
+                Ok(mergify_core::ExitCode::Success)
+            }
             NativeCommand::InternalRebaseTodoRewrite(opts) => {
                 let action = match opts.action {
                     InternalRebaseAction::Edit => {
@@ -2663,6 +2672,11 @@ enum Subcommands {
     Freeze(FreezeArgs),
     /// Manage stacked pull requests.
     Stack(ShimmedArgs),
+    /// Replace the running binary with the latest release. Verifies
+    /// the download against `SHA256SUMS` before swap, matching the
+    /// curl|sh installer's contract.
+    #[command(name = "self-update")]
+    SelfUpdate(SelfUpdateCli),
     /// Internal helpers the Python side of the wheel calls during
     /// the Python→Rust migration. Hidden from `--help` because it
     /// is not part of the user-facing CLI; the wire format is not
@@ -3302,6 +3316,34 @@ impl From<StackSetupCli> for StackSetupOpts {
         Self {
             force: cli.force,
             check: cli.check,
+        }
+    }
+}
+
+/// `mergify self-update [--force] [--check]`.
+#[derive(Parser)]
+#[command(
+    name = "self-update",
+    about = "Replace the running binary with the latest release"
+)]
+struct SelfUpdateCli {
+    /// Re-download and re-install even when the running binary
+    /// already matches the latest release tag. Useful for
+    /// repairing a corrupted install without bumping the version.
+    #[arg(long, action = clap::ArgAction::SetTrue)]
+    force: bool,
+
+    /// Print the current and latest release tags and exit without
+    /// touching the binary.
+    #[arg(long, action = clap::ArgAction::SetTrue)]
+    check: bool,
+}
+
+impl From<SelfUpdateCli> for self_update::Options {
+    fn from(cli: SelfUpdateCli) -> Self {
+        Self {
+            force: cli.force,
+            check_only: cli.check,
         }
     }
 }
@@ -4115,7 +4157,15 @@ mod tests {
             .collect();
         assert_eq!(
             groups,
-            ["config", "ci", "tests", "queue", "freeze", "stack"]
+            [
+                "config",
+                "ci",
+                "tests",
+                "queue",
+                "freeze",
+                "stack",
+                "self-update"
+            ]
         );
         assert!(!groups.contains(&"_internal"), "hidden group leaked");
 

--- a/crates/mergify-cli/src/self_update.rs
+++ b/crates/mergify-cli/src/self_update.rs
@@ -1,0 +1,446 @@
+//! `mergify self-update` — upgrade the running binary in place.
+//!
+//! Targets the `curl | sh` install channel: same release assets,
+//! same `SHA256SUMS` verification, same Rust target triple
+//! mapping. Users on `PyPI` / `Homebrew` should keep using their
+//! package manager — we run a best-effort sanity check on the
+//! binary's install path and warn (not error) when it looks
+//! package-manager-owned.
+//!
+//! Flow:
+//!
+//! 1. GET `/repos/Mergifyio/mergify-cli/releases/latest` for the
+//!    tag.
+//! 2. If `tag == crate::VERSION` and `--force` wasn't passed,
+//!    print "already up to date" and return.
+//! 3. Download `mergify-<target>.tar.gz` + `SHA256SUMS` from the
+//!    matching release.
+//! 4. Verify the asset SHA256 against `SHA256SUMS`. Mirrors
+//!    `install.sh`'s line-shape validation so a malformed
+//!    `SHA256SUMS` can't slip past.
+//! 5. Shell out to `tar -xzf` for extraction (identical to
+//!    `install.sh`; saves a `tar` + `flate2` crate dep).
+//! 6. [`self_replace`] atomically swaps the running binary with
+//!    the freshly extracted one — handles the Windows
+//!    rename-over-a-running-exe case.
+
+use std::path::Path;
+use std::time::Duration;
+
+use mergify_core::CliError;
+use serde::Deserialize;
+use sha2::Digest;
+use sha2::Sha256;
+
+const REPO: &str = "Mergifyio/mergify-cli";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+const DEFAULT_API_BASE: &str = "https://api.github.com";
+const DEFAULT_DOWNLOAD_BASE: &str = "https://github.com";
+
+/// Env-var override that points all HTTP traffic at a single base
+/// URL. Same lever `install.sh` exposes as `MERGIFY_BASE_URL` —
+/// the CI smoke test sets it to a `python3 -m http.server` fixture
+/// so the full download + verify + swap path runs without hitting
+/// real GitHub. Unset in real use.
+const BASE_URL_ENV: &str = "MERGIFY_BASE_URL";
+
+struct Endpoints {
+    /// `<api>/repos/<REPO>/releases/latest`
+    latest_release: String,
+    /// `<download>/<REPO>/releases/download/<tag>/<asset>`
+    asset_base: String,
+}
+
+fn endpoints(tag: &str) -> Endpoints {
+    if let Ok(base) = std::env::var(BASE_URL_ENV) {
+        // Fixture mode: a single flat directory serves both
+        // `latest-release.json` (the stub for the API call) and
+        // every asset/checksum file by name. No path-routing logic
+        // on the fixture side.
+        return Endpoints {
+            latest_release: format!("{base}/latest-release.json"),
+            asset_base: base,
+        };
+    }
+    Endpoints {
+        latest_release: format!("{DEFAULT_API_BASE}/repos/{REPO}/releases/latest"),
+        asset_base: format!("{DEFAULT_DOWNLOAD_BASE}/{REPO}/releases/download/{tag}"),
+    }
+}
+
+/// Inputs to [`run`]. Construction is owned by the CLI binding in
+/// `main.rs` so this module stays UI-agnostic.
+#[derive(Debug)]
+pub struct Options {
+    /// Re-install even when the running binary already matches the
+    /// latest release. Useful for repairing a corrupted install.
+    pub force: bool,
+    /// Resolve and print the latest release tag, then exit without
+    /// touching the binary.
+    pub check_only: bool,
+}
+
+#[derive(Deserialize)]
+struct LatestRelease {
+    tag_name: String,
+}
+
+pub async fn run(opts: &Options) -> Result<(), CliError> {
+    let current = crate::VERSION;
+    let target = current_target()?;
+    let client = http_client()?;
+    // Fetch the latest tag with placeholder endpoints — the
+    // `asset_base` slot is only consulted after we know the tag.
+    let probe = endpoints("");
+    let latest = fetch_latest_tag(&client, &probe.latest_release).await?;
+
+    if opts.check_only {
+        println!("Current: {current}");
+        println!("Latest:  {latest}");
+        return Ok(());
+    }
+    if current == latest && !opts.force {
+        println!("mergify is up to date ({current})");
+        return Ok(());
+    }
+    println!("Updating mergify: {current} -> {latest}");
+
+    // Windows ships `.zip`, every other target `.tar.gz`. The
+    // release workflow packages assets the same way, so the
+    // extension is determined by `cfg!(windows)` here, not by
+    // target string-sniffing.
+    let ext = if cfg!(windows) { "zip" } else { "tar.gz" };
+    let asset = format!("mergify-{target}.{ext}");
+    let ep = endpoints(&latest);
+    let archive = download(&client, &format!("{}/{asset}", ep.asset_base)).await?;
+    let sums = download_text(&client, &format!("{}/SHA256SUMS", ep.asset_base)).await?;
+    verify_checksum(&archive, &asset, &sums)?;
+
+    // Stage the extracted binary in a sibling temp dir next to the
+    // current binary. Same filesystem keeps the final `rename` in
+    // [`self_replace`] atomic — on Linux/macOS a cross-fs rename
+    // would silently copy + delete and lose the "no half-written
+    // binary on disk" guarantee.
+    let current_exe = std::env::current_exe()
+        .map_err(|e| CliError::Generic(format!("locate current binary: {e}")))?;
+    let install_dir = current_exe
+        .parent()
+        .ok_or_else(|| CliError::Generic("current binary has no parent dir".to_string()))?;
+    warn_if_package_manager_owned(install_dir);
+
+    let workdir = tempfile::tempdir_in(install_dir)
+        .map_err(|e| CliError::Generic(format!("create temp dir near binary: {e}")))?;
+    let archive_path = workdir.path().join(&asset);
+    std::fs::write(&archive_path, &archive)
+        .map_err(|e| CliError::Generic(format!("write archive: {e}")))?;
+
+    extract(&archive_path, workdir.path())?;
+    let bin_name = if cfg!(windows) {
+        "mergify.exe"
+    } else {
+        "mergify"
+    };
+    let new_bin = workdir.path().join(bin_name);
+    if !new_bin.exists() {
+        return Err(CliError::Generic(format!(
+            "archive {asset} did not contain the expected binary {bin_name}"
+        )));
+    }
+
+    // `self_replace::self_replace` does the atomic swap. On Unix
+    // this is a `rename(new, current)` over the running binary
+    // (kernel keeps the in-use inode alive). On Windows it renames
+    // the current binary aside, then renames the new one into
+    // place — there's no truly atomic `rename`-over-a-running-exe
+    // on Windows, but the orphaned `.old` file is cleaned up on
+    // the next process exit.
+    self_replace::self_replace(&new_bin)
+        .map_err(|e| CliError::Generic(format!("replace running binary: {e}")))?;
+
+    println!("Installed mergify {latest} to {}", current_exe.display());
+    Ok(())
+}
+
+fn http_client() -> Result<reqwest::Client, CliError> {
+    reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .user_agent(concat!("mergify-cli/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| CliError::Generic(format!("build HTTP client: {e}")))
+}
+
+async fn fetch_latest_tag(client: &reqwest::Client, url: &str) -> Result<String, CliError> {
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| CliError::Generic(format!("GET {url}: {e}")))?
+        .error_for_status()
+        .map_err(|e| CliError::Generic(format!("GitHub API: {e}")))?
+        .json::<LatestRelease>()
+        .await
+        .map_err(|e| CliError::Generic(format!("parse latest-release: {e}")))?;
+    Ok(resp.tag_name)
+}
+
+async fn download(client: &reqwest::Client, url: &str) -> Result<Vec<u8>, CliError> {
+    Ok(client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| CliError::Generic(format!("GET {url}: {e}")))?
+        .error_for_status()
+        .map_err(|e| CliError::Generic(format!("GET {url}: {e}")))?
+        .bytes()
+        .await
+        .map_err(|e| CliError::Generic(format!("read body {url}: {e}")))?
+        .to_vec())
+}
+
+async fn download_text(client: &reqwest::Client, url: &str) -> Result<String, CliError> {
+    let bytes = download(client, url).await?;
+    String::from_utf8(bytes)
+        .map_err(|e| CliError::Generic(format!("non-UTF8 body from {url}: {e}")))
+}
+
+/// Verify the downloaded archive's SHA256 against the entry for
+/// `asset_name` in `SHA256SUMS`. Mirrors `install.sh` exactly: the
+/// line must split as `<hash> <name>` on whitespace where the
+/// second field equals `asset_name` *literally* (not `ends_with`,
+/// so `mergify-fooX-target.tar.gz` can't accidentally pass the
+/// check for `target.tar.gz`), and the hash field must be 64 hex
+/// chars. Both layers fail closed.
+fn verify_checksum(archive: &[u8], asset_name: &str, sums: &str) -> Result<(), CliError> {
+    let mut expected: Option<&str> = None;
+    for line in sums.lines() {
+        let mut fields = line.split_whitespace();
+        let Some(hash) = fields.next() else { continue };
+        let Some(name) = fields.next() else { continue };
+        // Canonical `sha256sum` output is exactly two fields; bail
+        // on anything else even if `name == asset_name`, so a
+        // doctored entry with smuggled extras can't sneak past.
+        if fields.next().is_some() {
+            continue;
+        }
+        if name == asset_name {
+            expected = Some(hash);
+            break;
+        }
+    }
+    let expected = expected.ok_or_else(|| {
+        CliError::Generic(format!("no checksum entry for {asset_name} in SHA256SUMS"))
+    })?;
+    if expected.len() != 64 || !expected.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(CliError::Generic(format!(
+            "malformed checksum entry for {asset_name}"
+        )));
+    }
+    let mut hasher = Sha256::new();
+    hasher.update(archive);
+    let actual = format!("{:x}", hasher.finalize());
+    if actual.eq_ignore_ascii_case(expected) {
+        Ok(())
+    } else {
+        Err(CliError::Generic(format!(
+            "checksum mismatch for {asset_name}: expected {expected}, got {actual}"
+        )))
+    }
+}
+
+/// Extract `archive` (a `.tar.gz` or `.zip`) into `dest` by
+/// shelling out to the system `tar` / PowerShell `Expand-Archive`.
+/// `install.sh` shells out to `tar` too — keeping the same
+/// extractor for both code paths keeps "did the archive parse OK"
+/// surface area tiny.
+fn extract(archive: &Path, dest: &Path) -> Result<(), CliError> {
+    let archive_str = archive.to_string_lossy();
+    let dest_str = dest.to_string_lossy();
+    let status = if archive_str.ends_with(".zip") {
+        // PowerShell single-quoted strings escape an embedded `'`
+        // by doubling it. Without this, a Windows username like
+        // `C:\Users\O'Connor\...` would terminate the literal
+        // early and PowerShell would refuse the command.
+        let archive_quoted = archive_str.replace('\'', "''");
+        let dest_quoted = dest_str.replace('\'', "''");
+        std::process::Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-Command",
+                &format!(
+                    "Expand-Archive -LiteralPath '{archive_quoted}' \
+                     -DestinationPath '{dest_quoted}' -Force"
+                ),
+            ])
+            .status()
+    } else {
+        std::process::Command::new("tar")
+            .args(["-xzf", &archive_str, "-C", &dest_str])
+            .status()
+    };
+    let status = status.map_err(|e| CliError::Generic(format!("spawn extractor: {e}")))?;
+    if !status.success() {
+        return Err(CliError::Generic(format!(
+            "extractor exited with status {status}"
+        )));
+    }
+    Ok(())
+}
+
+/// Map the running platform to the Rust target triple the release
+/// workflow tags its assets with. Mirrors `install.sh`'s
+/// `detect_target` — kept here as a sanity net (the release wheel
+/// matrix wouldn't have shipped a binary for an unsupported
+/// target, so the running binary can only exist on a known one),
+/// but we still match explicitly so a future cross-build for a
+/// new triple gets caught before the GitHub URL 404s.
+fn current_target() -> Result<&'static str, CliError> {
+    let target = match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("linux", "x86_64") => "x86_64-unknown-linux-gnu",
+        ("linux", "aarch64") => "aarch64-unknown-linux-gnu",
+        ("macos", "x86_64") => "x86_64-apple-darwin",
+        ("macos", "aarch64") => "aarch64-apple-darwin",
+        ("windows", "x86_64") => "x86_64-pc-windows-msvc",
+        (os, arch) => {
+            return Err(CliError::Generic(format!(
+                "no release binary published for {os}/{arch} — install from source"
+            )));
+        }
+    };
+    Ok(target)
+}
+
+/// Print a notice (not an error) if the install path looks
+/// package-manager-owned. Updating in place still works, but the
+/// package manager will overwrite our binary on its next upgrade.
+fn warn_if_package_manager_owned(install_dir: &Path) {
+    // Conservative list — match the path prefixes the common
+    // installers use, not arbitrary substrings, to avoid false
+    // positives. Skipping `~/.local/bin` (where the curl|sh
+    // installer lives) and `/usr/local/bin` (often used manually).
+    let path = install_dir.to_string_lossy();
+    let owned_by: Option<&str> = if path.contains("/Cellar/") || path.starts_with("/opt/homebrew/")
+    {
+        Some("Homebrew")
+    } else if path.contains("/.local/share/uv/tools/") || path.contains("/.local/pipx/") {
+        Some("uv / pipx")
+    } else if path.contains("/site-packages/") {
+        Some("pip")
+    } else {
+        None
+    };
+    if let Some(mgr) = owned_by {
+        eprintln!(
+            "warning: mergify looks like it was installed by {mgr}. \
+             `self-update` will overwrite the binary, but {mgr} will \
+             restore its own version on the next upgrade. Use \
+             {mgr}'s upgrade command instead for a durable update."
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_archive() -> Vec<u8> {
+        b"pretend-this-is-a-tar.gz".to_vec()
+    }
+
+    #[test]
+    fn verify_checksum_accepts_a_matching_entry() {
+        let archive = fixture_archive();
+        let mut h = Sha256::new();
+        h.update(&archive);
+        let hash = format!("{:x}", h.finalize());
+        let sums = format!("{hash}  mergify-x86_64-unknown-linux-gnu.tar.gz\n");
+        verify_checksum(&archive, "mergify-x86_64-unknown-linux-gnu.tar.gz", &sums).unwrap();
+    }
+
+    #[test]
+    fn verify_checksum_rejects_mismatch() {
+        let archive = fixture_archive();
+        let wrong = "0".repeat(64);
+        let sums = format!("{wrong}  mergify-x86_64-unknown-linux-gnu.tar.gz\n");
+        let err = verify_checksum(&archive, "mergify-x86_64-unknown-linux-gnu.tar.gz", &sums)
+            .unwrap_err();
+        assert!(err.to_string().contains("checksum mismatch"));
+    }
+
+    #[test]
+    fn verify_checksum_rejects_missing_entry() {
+        let sums = "deadbeef  mergify-aarch64-apple-darwin.tar.gz\n";
+        let err =
+            verify_checksum(&[], "mergify-x86_64-unknown-linux-gnu.tar.gz", sums).unwrap_err();
+        assert!(err.to_string().contains("no checksum entry"));
+    }
+
+    #[test]
+    fn verify_checksum_does_not_accept_suffix_match() {
+        // Regression for the pre-fix `ends_with` lookup: a sibling
+        // asset whose name *ends in* `asset_name` (here
+        // `mergify-x86_64-pc-windows-msvc.zip` ending in `.zip`)
+        // could be matched and pass even when the requested asset
+        // wasn't in the file. The literal second-field match must
+        // reject this.
+        let archive = fixture_archive();
+        let mut h = Sha256::new();
+        h.update(&archive);
+        let hash = format!("{:x}", h.finalize());
+        let sums = format!("{hash}  mergify-x86_64-pc-windows-msvc.zip\n");
+        let err = verify_checksum(&archive, "msvc.zip", &sums).unwrap_err();
+        assert!(
+            err.to_string().contains("no checksum entry"),
+            "expected 'no checksum entry', got: {err}",
+        );
+    }
+
+    #[test]
+    fn verify_checksum_rejects_extra_fields_on_the_entry_line() {
+        // Defence-in-depth against a doctored SHA256SUMS smuggling
+        // extra fields after the asset name (e.g. an injected
+        // `; rm -rf /` for a downstream shell consumer). Canonical
+        // `sha256sum` output is exactly two fields, anything else
+        // is treated as a missing entry.
+        let archive = fixture_archive();
+        let mut h = Sha256::new();
+        h.update(&archive);
+        let hash = format!("{:x}", h.finalize());
+        let sums = format!("{hash}  mergify-x86_64-unknown-linux-gnu.tar.gz extra\n");
+        let err = verify_checksum(&archive, "mergify-x86_64-unknown-linux-gnu.tar.gz", &sums)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("no checksum entry"),
+            "expected 'no checksum entry', got: {err}",
+        );
+    }
+
+    #[test]
+    fn verify_checksum_rejects_malformed_hash_field() {
+        // Right asset name, wrong-shape hash. install.sh validates
+        // the same way so a corrupted SHA256SUMS can't slip past
+        // sha256sum's warn-but-pass behaviour; mirror it here.
+        let sums = "bogus  mergify-x86_64-unknown-linux-gnu.tar.gz\n";
+        let err =
+            verify_checksum(&[], "mergify-x86_64-unknown-linux-gnu.tar.gz", sums).unwrap_err();
+        assert!(err.to_string().contains("malformed checksum entry"));
+    }
+
+    #[test]
+    fn current_target_picks_one_of_the_known_triples() {
+        // We don't ship for anything else, so the call must
+        // succeed in the test harness — and it must return one of
+        // the five tagged triples we publish assets for.
+        let target = current_target().unwrap();
+        assert!(
+            [
+                "x86_64-unknown-linux-gnu",
+                "aarch64-unknown-linux-gnu",
+                "x86_64-apple-darwin",
+                "aarch64-apple-darwin",
+                "x86_64-pc-windows-msvc",
+            ]
+            .contains(&target),
+            "unexpected target: {target}",
+        );
+    }
+}


### PR DESCRIPTION
In-place upgrade for `curl | sh` users. Same release assets, same
`SHA256SUMS` verification, same target-triple mapping as
`install.sh` — the two install paths converge on identical
guarantees.

Flow (in `crates/mergify-cli/src/self_update.rs`):

  1. GET `/repos/Mergifyio/mergify-cli/releases/latest` for the tag.
  2. If `tag == crate::VERSION` and `--force` wasn't passed, print
     "already up to date" and return.
  3. Download `mergify-<target>.tar.gz` + `SHA256SUMS` from the
     matching release.
  4. Verify the asset's SHA256 against `SHA256SUMS`, validating the
     line shape (64 hex chars + two spaces + filename) so a
     corrupted sums file can't pass — same defensive check
     `install.sh` does.
  5. Shell out to `tar -xzf` for extraction (Windows: PowerShell's
     `Expand-Archive`). Same extractor `install.sh` uses; matches
     the existing surface area.
  6. `self_replace::self_replace` does the atomic binary swap. On
     Unix this is `rename(new, current)` over the running binary
     (kernel keeps the in-use inode alive). On Windows it renames
     the current binary aside, then renames the new one into place
     — there's no truly atomic rename-over-a-running-exe there, but
     the orphaned `.old` file is cleaned up on next process exit.

Surfaces:

  - `mergify self-update`             — perform the upgrade.
  - `mergify self-update --check`     — print current + latest tags.
  - `mergify self-update --force`     — re-install at the same tag.

`MERGIFY_BASE_URL` env override (mirroring `install.sh`'s knob)
points all HTTP traffic at a single base — used by the new
`self-update-smoke` CI job to run the full download/verify/swap
path against a `python3 -m http.server` fixture, plus a negative
case proving a tampered `SHA256SUMS` rejects (binary stays
untouched, hash before == hash after).

Three small new deps: `reqwest = 0.13` (aligned with workspace),
`self-replace = 1`, `sha2 = 0.10`, `tempfile = 3`.

Package-manager-installed binaries get a warning (Homebrew, uv,
pipx, pip paths). The update still proceeds — best-effort signal,
not a refusal.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>