### PR TITLE
feat(ci): let queue-info fetch metadata from a PR URL

### DIFF
--- a/crates/mergify-ci/src/queue_info.rs
+++ b/crates/mergify-ci/src/queue_info.rs
@@ -1,39 +1,126 @@
 //! `mergify ci queue-info` — print the merge-queue batch metadata
-//! that's embedded in the current merge-queue draft PR.
+//! that's embedded in a merge-queue draft PR.
 //!
-//! Output is pretty-printed JSON on stdout. When the step isn't
-//! running against an MQ draft the command exits with
-//! `INVALID_STATE` — same behavior as Python.
+//! Two ways in:
 //!
-//! When `$GITHUB_OUTPUT` is set (GitHub Actions runner), the command
+//! - **No argument (in CI):** read the MQ draft PR from the GitHub
+//!   Actions event payload (`$GITHUB_EVENT_PATH`).
+//! - **PR URL argument (anywhere):** fetch the PR via the GitHub API
+//!   and read the metadata out of its body. The URL host drives the
+//!   API base (github.com vs GitHub Enterprise Server).
+//!
+//! Both paths apply the same MQ-draft gate (`extract_from_event`) and
+//! exit with `INVALID_STATE` when the PR isn't an MQ draft.
+//!
+//! Output is pretty-printed JSON on stdout. When `$GITHUB_OUTPUT` is
+//! set (GitHub Actions runner) **and** no URL was given, the command
 //! also appends the metadata as `queue_metadata` under a random
 //! `ghadelimiter_<uuid>` heredoc, matching the pattern the workflow
-//! runtime expects for multi-line outputs.
+//! runtime expects for multi-line outputs. An explicit PR lookup is a
+//! local/interactive use and never writes GHA outputs.
 
 use std::env;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::PathBuf;
 
+use mergify_core::ApiFlavor;
 use mergify_core::CliError;
 use mergify_core::Output;
+use mergify_core::auth;
+use mergify_core::http::Client;
+use mergify_core::pull_request::PullRequestRef;
+use url::Url;
 
+use crate::github_event::GitHubEvent;
+use crate::github_event::PullRequest;
 use crate::queue_metadata::MergeQueueMetadata;
 use crate::queue_metadata::detect;
+use crate::queue_metadata::extract_from_event;
+
+/// Options for the `ci queue-info` command.
+pub struct QueueInfoOptions<'a> {
+    /// When set, fetch the PR via the GitHub API instead of reading
+    /// the CI event payload.
+    pub pull_request: Option<&'a PullRequestRef>,
+    /// GitHub token. Resolved through the usual flag → env →
+    /// `gh auth token` chain when fetching a PR by URL; ignored on the
+    /// in-CI (no-argument) path.
+    pub token: Option<&'a str>,
+}
 
 /// Run the `ci queue-info` command.
-pub fn run(output: &mut dyn Output) -> Result<(), CliError> {
-    let Some(metadata) = detect(output)? else {
+pub async fn run(opts: QueueInfoOptions<'_>, output: &mut dyn Output) -> Result<(), CliError> {
+    let metadata = match opts.pull_request {
+        Some(pr_ref) => fetch_via_api(pr_ref, opts.token, output).await?,
+        None => detect(output)?,
+    };
+    let Some(metadata) = metadata else {
         return Err(CliError::InvalidState(
-            "Not running in a merge queue context. \
-             This command must be run on a merge queue draft pull request."
+            "Not a merge queue draft pull request. \
+             queue-info only works on a merge queue draft pull request."
                 .to_string(),
         ));
     };
 
     emit_json(output, &metadata)?;
-    write_github_output(&metadata)?;
+    // Only the in-CI path emits the GHA output; an explicit PR lookup
+    // is a local/interactive use that shouldn't write workflow outputs.
+    if opts.pull_request.is_none() {
+        write_github_output(&metadata)?;
+    }
     Ok(())
+}
+
+/// Resolve a token + the right GitHub API base from the PR URL host,
+/// fetch the PR, and run it through the same MQ-draft gate the event
+/// path uses.
+async fn fetch_via_api(
+    pr_ref: &PullRequestRef,
+    token: Option<&str>,
+    output: &mut dyn Output,
+) -> Result<Option<MergeQueueMetadata>, CliError> {
+    let token = auth::resolve_token(token)?;
+    let client = Client::new(github_api_base(&pr_ref.host)?, token, ApiFlavor::GitHub)?;
+    fetch_pr_metadata(&client, pr_ref, output).await
+}
+
+/// Fetch the PR payload and extract its MQ metadata.
+///
+/// The GitHub PR JSON deserializes straight into [`PullRequest`]
+/// (which ignores unknown fields), so wrapping it in a synthetic
+/// [`GitHubEvent`] lets us reuse [`extract_from_event`] verbatim —
+/// the title/body gate, the stderr warnings, and the `None`-means-
+/// not-an-MQ-draft contract are all shared with the event path.
+async fn fetch_pr_metadata(
+    client: &Client,
+    pr_ref: &PullRequestRef,
+    output: &mut dyn Output,
+) -> Result<Option<MergeQueueMetadata>, CliError> {
+    let path = format!("/repos/{}/pulls/{}", pr_ref.repository, pr_ref.pull_number);
+    let pull_request: PullRequest = client.get(&path).await?;
+    let event = GitHubEvent {
+        pull_request: Some(pull_request),
+        ..Default::default()
+    };
+    Ok(extract_from_event(&event, output)?)
+}
+
+/// Map a PR URL host to its GitHub REST API base. `github.com` →
+/// `api.github.com`; any other host is treated as GitHub Enterprise
+/// Server (`https://<host>/api/v3`). Always https — the inverse of
+/// the api→html mapping in `mergify-stack`'s `revision_history`.
+fn github_api_base(host: &str) -> Result<Url, CliError> {
+    // Hosts are case-insensitive, so a pasted `GitHub.com` must still
+    // take the dotcom branch. `host` is already userinfo-free
+    // (`parse_pr_url` rejects `@`), so formatting it into the
+    // authority is safe.
+    let raw = if host.eq_ignore_ascii_case("github.com") {
+        "https://api.github.com/".to_string()
+    } else {
+        format!("https://{host}/api/v3/")
+    };
+    Url::parse(&raw).map_err(|e| CliError::GitHubApi(format!("invalid GitHub host {host:?}: {e}")))
 }
 
 fn emit_json(output: &mut dyn Output, metadata: &MergeQueueMetadata) -> std::io::Result<()> {
@@ -84,6 +171,12 @@ mod tests {
     use mergify_core::ExitCode;
     use mergify_test_support::Captured;
     use tempfile::TempDir;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::header;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
 
     use super::*;
 
@@ -99,18 +192,44 @@ mod tests {
         path
     }
 
-    #[test]
-    fn errors_when_not_in_mq_context() {
+    fn no_pr() -> QueueInfoOptions<'static> {
+        QueueInfoOptions {
+            pull_request: None,
+            token: None,
+        }
+    }
+
+    /// Build a client pointed at the mock server — the `run`/
+    /// `fetch_via_api` rebuilds the base URL from the PR host
+    /// (discarding the mock server's address), so the per-fetch path
+    /// is exercised through `fetch_pr_metadata` with an injected
+    /// client instead of through `run`.
+    fn mock_client(server: &MockServer) -> Client {
+        Client::new(
+            Url::parse(&server.uri()).unwrap(),
+            "test-token".to_string(),
+            ApiFlavor::GitHub,
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn errors_when_not_in_mq_context() {
         let mut cap = Captured::human();
-        let err = temp_env::with_vars_unset(["GITHUB_EVENT_NAME", "GITHUB_EVENT_PATH"], || {
-            run(&mut cap.output).unwrap_err()
-        });
+        let err = temp_env::async_with_vars(
+            [
+                ("GITHUB_EVENT_NAME", None::<&str>),
+                ("GITHUB_EVENT_PATH", None),
+            ],
+            async { run(no_pr(), &mut cap.output).await.unwrap_err() },
+        )
+        .await;
         assert!(matches!(err, CliError::InvalidState(_)));
         assert_eq!(err.exit_code(), ExitCode::InvalidState);
     }
 
-    #[test]
-    fn prints_metadata_for_mq_pr() {
+    #[tokio::test]
+    async fn prints_metadata_for_mq_pr() {
         let dir = tempfile::tempdir().unwrap();
         let path = write_event_file(
             &dir,
@@ -119,22 +238,23 @@ mod tests {
         );
 
         let mut cap = Captured::human();
-        temp_env::with_vars(
+        temp_env::async_with_vars(
             [
                 ("GITHUB_EVENT_NAME", Some("pull_request")),
                 ("GITHUB_EVENT_PATH", Some(path.to_str().unwrap())),
                 ("GITHUB_OUTPUT", None),
             ],
-            || run(&mut cap.output).unwrap(),
-        );
+            async { run(no_pr(), &mut cap.output).await.unwrap() },
+        )
+        .await;
 
         let stdout = cap.stdout();
         assert!(stdout.contains("\"checking_base_sha\": \"abc123\""));
         assert!(stdout.contains("\"number\": 10"));
     }
 
-    #[test]
-    fn appends_to_github_output_when_set() {
+    #[tokio::test]
+    async fn appends_to_github_output_when_set() {
         let dir = tempfile::tempdir().unwrap();
         let event_path = write_event_file(
             &dir,
@@ -144,17 +264,121 @@ mod tests {
         let gha_output = dir.path().join("gha_output");
 
         let mut cap = Captured::human();
-        temp_env::with_vars(
+        temp_env::async_with_vars(
             [
                 ("GITHUB_EVENT_NAME", Some("pull_request")),
                 ("GITHUB_EVENT_PATH", Some(event_path.to_str().unwrap())),
                 ("GITHUB_OUTPUT", Some(gha_output.to_str().unwrap())),
             ],
-            || run(&mut cap.output).unwrap(),
-        );
+            async { run(no_pr(), &mut cap.output).await.unwrap() },
+        )
+        .await;
 
         let written = std::fs::read_to_string(&gha_output).unwrap();
         assert!(written.starts_with("queue_metadata<<ghadelimiter_"));
         assert!(written.contains("\"checking_base_sha\":\"deadbeef\""));
+    }
+
+    #[test]
+    fn github_api_base_maps_dotcom_to_api_host() {
+        assert_eq!(
+            github_api_base("github.com").unwrap().as_str(),
+            "https://api.github.com/",
+        );
+    }
+
+    #[test]
+    fn github_api_base_maps_ghes_host_to_api_v3() {
+        assert_eq!(
+            github_api_base("ghe.example.com").unwrap().as_str(),
+            "https://ghe.example.com/api/v3/",
+        );
+    }
+
+    #[test]
+    fn github_api_base_matches_dotcom_case_insensitively() {
+        // Hosts are case-insensitive; a pasted `GitHub.com` must not
+        // fall through to the GHES `/api/v3` path.
+        assert_eq!(
+            github_api_base("GitHub.com").unwrap().as_str(),
+            "https://api.github.com/",
+        );
+    }
+
+    fn pr_ref() -> PullRequestRef {
+        PullRequestRef {
+            host: "github.com".to_string(),
+            repository: "owner/repo".to_string(),
+            pull_number: 1234,
+        }
+    }
+
+    #[tokio::test]
+    async fn fetches_pr_and_extracts_metadata() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/owner/repo/pulls/1234"))
+            // The resolved token must reach GitHub as a bearer header,
+            // otherwise private-repo lookups would 404.
+            .and(header("Authorization", "Bearer test-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "title": "merge queue: batch",
+                "body": "intro\n```yaml\nchecking_base_sha: cafef00d\npull_requests:\n  - number: 7\n```",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server);
+        let mut cap = Captured::human();
+        let meta = fetch_pr_metadata(&client, &pr_ref(), &mut cap.output)
+            .await
+            .unwrap()
+            .expect("expected MQ metadata");
+        assert_eq!(meta.checking_base_sha, "cafef00d");
+        assert_eq!(meta.pull_requests[0].number, 7);
+    }
+
+    #[tokio::test]
+    async fn fetched_non_mq_pr_yields_none() {
+        // A regular PR (title not `merge queue: …`) must surface as
+        // `None` so `run` maps it to INVALID_STATE — same gate the
+        // event path uses.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/owner/repo/pulls/1234"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "title": "feat: something",
+                "body": "no metadata here",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server);
+        let mut cap = Captured::human();
+        let meta = fetch_pr_metadata(&client, &pr_ref(), &mut cap.output)
+            .await
+            .unwrap();
+        assert!(meta.is_none(), "got: {meta:?}");
+    }
+
+    #[tokio::test]
+    async fn fetched_pr_api_error_propagates() {
+        // A GitHub API failure (e.g. 404 for a wrong PR number) must
+        // surface as a GitHubApi error, not a silent None.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/owner/repo/pulls/1234"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("Not Found"))
+            .mount(&server)
+            .await;
+
+        let client = mock_client(&server);
+        let mut cap = Captured::human();
+        let err = fetch_pr_metadata(&client, &pr_ref(), &mut cap.output)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CliError::GitHubApi(_)), "got: {err:?}");
     }
 }

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -17,16 +17,17 @@ use clap::Subcommand;
 use mergify_ci::git_refs::Format as GitRefsFormat;
 use mergify_ci::git_refs::GitRefsOptions;
 use mergify_ci::junit_process::JunitProcessOptions;
+use mergify_ci::queue_info::QueueInfoOptions;
 use mergify_ci::scopes_send::ScopesSendOptions;
 use mergify_ci::tests_quarantine::GetOptions;
 use mergify_ci::tests_quarantine::QuarantineOptions;
 use mergify_ci::tests_quarantine::QuarantinedOptions;
 use mergify_ci::tests_quarantine::UnquarantineOptions;
 use mergify_ci::tests_show::TestsShowOptions;
-use mergify_config::simulate::PullRequestRef;
 use mergify_config::simulate::SimulateOptions;
 use mergify_core::OutputMode;
 use mergify_core::StdioOutput;
+use mergify_core::pull_request::PullRequestRef;
 use mergify_freeze::common::parse_naive_datetime;
 use mergify_freeze::create::CreateOptions as FreezeCreateOptions;
 use mergify_freeze::delete::DeleteOptions as FreezeDeleteOptions;
@@ -159,7 +160,7 @@ enum NativeCommand {
     CiGitRefs {
         format: GitRefsFormat,
     },
-    CiQueueInfo,
+    CiQueueInfo(CiQueueInfoOpts),
     CiJunitProcess(CiJunitProcessOpts),
     /// Deprecated alias for `CiJunitProcess`. Same orchestrator,
     /// same args; the dispatcher prints a deprecation warning to
@@ -475,6 +476,11 @@ struct CiScopesOpts {
     base: Option<String>,
     head: Option<String>,
     write: Option<PathBuf>,
+}
+
+struct CiQueueInfoOpts {
+    pull_request: Option<PullRequestRef>,
+    token: Option<String>,
 }
 
 struct CiScopesSendOpts {
@@ -1041,8 +1047,15 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
             command: CiSubcommand::GitRefs(GitRefsCliArgs { format }),
         }) => Dispatch::Native(NativeCommand::CiGitRefs { format }),
         Subcommands::Ci(CiArgs {
-            command: CiSubcommand::QueueInfo,
-        }) => Dispatch::Native(NativeCommand::CiQueueInfo),
+            command:
+                CiSubcommand::QueueInfo(QueueInfoCliArgs {
+                    pull_request,
+                    token,
+                }),
+        }) => Dispatch::Native(NativeCommand::CiQueueInfo(CiQueueInfoOpts {
+            pull_request,
+            token,
+        })),
         Subcommands::Tests(TestsArgs {
             command:
                 TestsSubcommand::Show(TestsShowCliArgs {
@@ -1514,9 +1527,15 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 mergify_ci::git_refs::run(&GitRefsOptions { format }, &mut output)
                     .map(|()| mergify_core::ExitCode::Success)
             }
-            NativeCommand::CiQueueInfo => {
-                mergify_ci::queue_info::run(&mut output).map(|()| mergify_core::ExitCode::Success)
-            }
+            NativeCommand::CiQueueInfo(opts) => mergify_ci::queue_info::run(
+                QueueInfoOptions {
+                    pull_request: opts.pull_request.as_ref(),
+                    token: opts.token.as_deref(),
+                },
+                &mut output,
+            )
+            .await
+            .map(|()| mergify_core::ExitCode::Success),
             NativeCommand::CiJunitProcess(opts) => {
                 mergify_ci::junit_process::run(
                     JunitProcessOptions {
@@ -3448,7 +3467,7 @@ struct ValidateArgs {}
 #[derive(clap::Args)]
 struct SimulateCliArgs {
     /// Pull request URL (e.g. <https://github.com/owner/repo/pull/123>).
-    #[arg(value_name = "PULL_REQUEST_URL", value_parser = mergify_config::simulate::parse_pr_url)]
+    #[arg(value_name = "PULL_REQUEST_URL", value_parser = mergify_core::pull_request::parse_pr_url)]
     pull_request: PullRequestRef,
 
     /// Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and
@@ -3481,9 +3500,9 @@ enum CiSubcommand {
     /// Print the base/head git references for the current build.
     #[command(name = "git-refs")]
     GitRefs(GitRefsCliArgs),
-    /// Print the merge queue batch metadata for the current draft PR.
+    /// Print the merge queue batch metadata for a merge queue draft PR.
     #[command(name = "queue-info")]
-    QueueInfo,
+    QueueInfo(QueueInfoCliArgs),
     /// Give the list of scopes impacted by changed files.
     Scopes(ScopesCliArgs),
     /// Upload JUnit XML reports and ignore failed tests with
@@ -3506,6 +3525,21 @@ struct GitRefsCliArgs {
         value_parser = mergify_ci::git_refs::Format::parse,
     )]
     format: GitRefsFormat,
+}
+
+#[derive(clap::Args)]
+struct QueueInfoCliArgs {
+    /// Pull request URL (e.g. <https://github.com/owner/repo/pull/123>).
+    /// When omitted, reads the metadata from the CI event payload
+    /// (`GITHUB_EVENT_PATH`) — the in-CI default.
+    #[arg(value_name = "PULL_REQUEST_URL", value_parser = mergify_core::pull_request::parse_pr_url)]
+    pull_request: Option<PullRequestRef>,
+
+    /// GitHub token used to fetch the pull request. Falls back to
+    /// ``MERGIFY_TOKEN``, then ``GITHUB_TOKEN``, then `gh auth token`.
+    /// Only used when a pull request URL is given.
+    #[arg(long, short = 't')]
+    token: Option<String>,
 }
 
 #[derive(clap::Args)]

--- a/crates/mergify-config/src/simulate.rs
+++ b/crates/mergify-config/src/simulate.rs
@@ -24,51 +24,11 @@ use mergify_core::CliError;
 use mergify_core::HttpClient;
 use mergify_core::Output;
 use mergify_core::auth;
+use mergify_core::pull_request::PullRequestRef;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::paths::resolve_config_path;
-
-/// Deserialized shape of the `(owner/repo, number)` pair parsed from
-/// a pull-request URL.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PullRequestRef {
-    pub repository: String,
-    pub pull_number: u64,
-}
-
-/// Clap value-parser for the positional PR URL argument.
-///
-/// Returning `Err(String)` makes clap exit with status 2 (argument
-/// validation error) rather than our CLI's `ConfigurationError` —
-/// matching the Python CLI's behavior where `_parse_pr_url` raises
-/// `click.BadParameter` (also exit 2).
-///
-/// # Errors
-///
-/// Returns a human-readable message when `url` is not a valid
-/// GitHub-style pull request URL.
-pub fn parse_pr_url(url: &str) -> Result<PullRequestRef, String> {
-    let rest = url
-        .strip_prefix("https://")
-        .or_else(|| url.strip_prefix("http://"))
-        .ok_or_else(|| format!("Invalid pull request URL: {url}"))?;
-    let parts: Vec<&str> = rest.split('/').collect();
-    if parts.len() != 5 || parts[3] != "pull" {
-        return Err(format!("Invalid pull request URL: {url}"));
-    }
-    let [host, owner, repo, _pull, number] = [parts[0], parts[1], parts[2], parts[3], parts[4]];
-    if host.is_empty() || owner.is_empty() || repo.is_empty() {
-        return Err(format!("Invalid pull request URL: {url}"));
-    }
-    let pull_number: u64 = number
-        .parse()
-        .map_err(|_| format!("Invalid pull request URL: {url}"))?;
-    Ok(PullRequestRef {
-        repository: format!("{owner}/{repo}"),
-        pull_number,
-    })
-}
 
 #[derive(Serialize)]
 struct SimulatorRequest<'a> {
@@ -145,38 +105,6 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn parse_pr_url_accepts_canonical_github_url() {
-        let got = parse_pr_url("https://github.com/owner/repo/pull/42").unwrap();
-        assert_eq!(got.repository, "owner/repo");
-        assert_eq!(got.pull_number, 42);
-    }
-
-    #[test]
-    fn parse_pr_url_rejects_non_pull_path() {
-        assert!(parse_pr_url("https://github.com/owner/repo/issues/42").is_err());
-    }
-
-    #[test]
-    fn parse_pr_url_rejects_trailing_segments() {
-        assert!(parse_pr_url("https://github.com/owner/repo/pull/42/files").is_err());
-    }
-
-    #[test]
-    fn parse_pr_url_rejects_non_numeric_pull_number() {
-        assert!(parse_pr_url("https://github.com/owner/repo/pull/abc").is_err());
-    }
-
-    #[test]
-    fn parse_pr_url_rejects_missing_scheme() {
-        assert!(parse_pr_url("github.com/owner/repo/pull/42").is_err());
-    }
-
-    #[test]
-    fn parse_pr_url_rejects_empty_owner() {
-        assert!(parse_pr_url("https://github.com//repo/pull/42").is_err());
-    }
-
     #[tokio::test]
     async fn run_posts_config_and_prints_simulator_result() {
         let server = MockServer::start().await;
@@ -199,6 +127,7 @@ mod tests {
             .await;
 
         let pull_request = PullRequestRef {
+            host: "github.com".into(),
             repository: "owner/repo".into(),
             pull_number: 42,
         };

--- a/crates/mergify-core/src/lib.rs
+++ b/crates/mergify-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod error;
 pub mod exit_code;
 pub mod http;
 pub mod output;
+pub mod pull_request;
 
 pub use command_context::CommandContext;
 pub use error::CliError;

--- a/crates/mergify-core/src/pull_request.rs
+++ b/crates/mergify-core/src/pull_request.rs
@@ -1,0 +1,119 @@
+//! Parse a GitHub-style pull-request URL into its parts.
+//!
+//! Shared by every command that takes a PR URL on the command line
+//! (`config simulate`, `ci queue-info`). Lives in `mergify-core`
+//! next to `auth`/`http` rather than in any one command crate so
+//! both call sites use a single parser instead of copies.
+
+/// The `(host, owner/repo, number)` triple parsed from a pull-request
+/// URL.
+///
+/// `host` is kept so callers that talk to the GitHub API (rather than
+/// the Mergify API) can derive the right API base — `github.com` vs a
+/// GitHub Enterprise Server host. Callers that don't need it (e.g.
+/// `config simulate`, which always hits the Mergify API) simply
+/// ignore the field.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PullRequestRef {
+    pub host: String,
+    pub repository: String,
+    pub pull_number: u64,
+}
+
+/// Clap value-parser for a positional PR URL argument.
+///
+/// Returning `Err(String)` makes clap exit with status 2 (argument
+/// validation error) rather than our CLI's `ConfigurationError` —
+/// matching the Python CLI's behavior where `_parse_pr_url` raises
+/// `click.BadParameter` (also exit 2).
+///
+/// # Errors
+///
+/// Returns a human-readable message when `url` is not a valid
+/// GitHub-style pull request URL.
+pub fn parse_pr_url(url: &str) -> Result<PullRequestRef, String> {
+    let rest = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+        .ok_or_else(|| format!("Invalid pull request URL: {url}"))?;
+    let parts: Vec<&str> = rest.split('/').collect();
+    if parts.len() != 5 || parts[3] != "pull" {
+        return Err(format!("Invalid pull request URL: {url}"));
+    }
+    let [host, owner, repo, _pull, number] = [parts[0], parts[1], parts[2], parts[3], parts[4]];
+    if host.is_empty() || owner.is_empty() || repo.is_empty() {
+        return Err(format!("Invalid pull request URL: {url}"));
+    }
+    // A real GitHub PR URL has a bare host with no userinfo. Reject
+    // `user@host` shapes: a host segment is later used as the GitHub
+    // API authority (see `mergify-ci`'s `github_api_base`), and
+    // `https://github.com@evil.com/...` parses to host `evil.com` with
+    // `github.com` as decoy userinfo — which would send the bearer
+    // token to the attacker host.
+    if host.contains('@') {
+        return Err(format!("Invalid pull request URL: {url}"));
+    }
+    let pull_number: u64 = number
+        .parse()
+        .map_err(|_| format!("Invalid pull request URL: {url}"))?;
+    Ok(PullRequestRef {
+        host: host.to_string(),
+        repository: format!("{owner}/{repo}"),
+        pull_number,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_pr_url_accepts_canonical_github_url() {
+        let got = parse_pr_url("https://github.com/owner/repo/pull/42").unwrap();
+        assert_eq!(got.host, "github.com");
+        assert_eq!(got.repository, "owner/repo");
+        assert_eq!(got.pull_number, 42);
+    }
+
+    #[test]
+    fn parse_pr_url_keeps_ghes_host() {
+        let got = parse_pr_url("https://ghe.example.com/owner/repo/pull/7").unwrap();
+        assert_eq!(got.host, "ghe.example.com");
+        assert_eq!(got.repository, "owner/repo");
+        assert_eq!(got.pull_number, 7);
+    }
+
+    #[test]
+    fn parse_pr_url_rejects_non_pull_path() {
+        assert!(parse_pr_url("https://github.com/owner/repo/issues/42").is_err());
+    }
+
+    #[test]
+    fn parse_pr_url_rejects_trailing_segments() {
+        assert!(parse_pr_url("https://github.com/owner/repo/pull/42/files").is_err());
+    }
+
+    #[test]
+    fn parse_pr_url_rejects_non_numeric_pull_number() {
+        assert!(parse_pr_url("https://github.com/owner/repo/pull/abc").is_err());
+    }
+
+    #[test]
+    fn parse_pr_url_rejects_missing_scheme() {
+        assert!(parse_pr_url("github.com/owner/repo/pull/42").is_err());
+    }
+
+    #[test]
+    fn parse_pr_url_rejects_empty_owner() {
+        assert!(parse_pr_url("https://github.com//repo/pull/42").is_err());
+    }
+
+    #[test]
+    fn parse_pr_url_rejects_userinfo_host() {
+        // `github.com@evil.com` parses (via Url) to host `evil.com`
+        // with `github.com` as userinfo — rejecting `@` keeps a
+        // crafted link from redirecting the GitHub API base (and the
+        // bearer token) to an attacker host.
+        assert!(parse_pr_url("https://github.com@evil.com/owner/repo/pull/1").is_err());
+    }
+}

--- a/skills/mergify-ci/SKILL.md
+++ b/skills/mergify-ci/SKILL.md
@@ -296,14 +296,24 @@ A null `branch` renders as `*` (the quarantine applies to all branches).
 
 ## Queue Info (`queue-info`)
 
-Outputs merge queue batch metadata from the current pull request event. Only works on merge queue draft pull requests. Writes output to `GITHUB_OUTPUT` when running in GitHub Actions.
+Outputs merge queue batch metadata as JSON. Only works on merge queue draft pull requests; exits `INVALID_STATE` (7) otherwise.
+
+Two ways to point it at a PR:
 
 ```bash
+# In CI: read the MQ draft PR from the GitHub Actions event payload.
+# Also writes the metadata to GITHUB_OUTPUT when running in GitHub Actions.
 mergify ci queue-info
-# Output: JSON with batch metadata
+
+# Anywhere: fetch the PR via the GitHub API by URL. Does NOT write
+# GITHUB_OUTPUT (it's a local/interactive lookup). The URL host drives
+# the API base (github.com or a GitHub Enterprise Server host).
+mergify ci queue-info https://github.com/owner/repo/pull/1234
 ```
 
-This command is useful in CI workflows that need to know whether the current run is part of a merge queue batch and what other PRs are in the batch.
+The URL form needs a GitHub token: `--token`/`-t`, else `MERGIFY_TOKEN`, then `GITHUB_TOKEN`, then `gh auth token`. It errors clearly when none is available.
+
+This command is useful in CI workflows that need to know whether the current run is part of a merge queue batch and what other PRs are in the batch, and for inspecting a batch by URL from your laptop.
 
 ## Common Patterns
 


### PR DESCRIPTION
`mergify ci queue-info` only read the merge-queue batch metadata from
the GitHub Actions event payload, so it only worked inside a CI job on
the MQ draft PR. Add an optional positional PR URL argument so the batch
metadata can be inspected from anywhere:

    mergify ci queue-info https://github.com/owner/repo/pull/1234

With a URL, the PR is fetched via the GitHub API (the URL host drives
the API base: github.com vs GHES /api/v3) and its body runs through the
same MQ-draft gate as the event path. With no argument, behavior is
unchanged (event payload + $GITHUB_OUTPUT heredoc). The URL path is a
local/interactive lookup and never writes $GITHUB_OUTPUT.

The PR-URL parser (parse_pr_url / PullRequestRef) moves from
mergify-config::simulate to mergify-core::pull_request and gains a host
field so both call sites share one parser. The parser now rejects a
user@host authority so a crafted github.com@evil.com link can't redirect
the API base, and the bearer token, to an attacker host.

Docs: skills/mergify-ci/SKILL.md.

Fixes MRGFY-7614

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>