### PR TITLE
fix(release): switch draft preparation to workflow_dispatch

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -26,12 +26,25 @@ on:
       stamp-version:
         description: |
           When true, replace `version = "..."` in pyproject.toml
-          with the git tag value (`${GITHUB_REF#refs/tags/}`)
-          before maturin runs. Keep false for PR smoke builds so
-          CI exercises the full path with the placeholder version.
+          before maturin runs. Source is `inputs.override-version`
+          when set (the workflow_dispatch draft path doesn't have a
+          tag yet), otherwise `${GITHUB_REF#refs/tags/}`. Keep false
+          for PR smoke builds so CI exercises the full path with
+          the placeholder version.
         required: false
         default: false
         type: boolean
+      override-version:
+        description: |
+          Explicit version string to stamp into the wheel. Lets the
+          dispatch-driven draft job pass its `tag` input through —
+          no git tag exists yet at that point, so the build can't
+          derive it from `$GITHUB_REF`. Ignored when `stamp-version`
+          is false; required when both `stamp-version` is true and
+          the caller wasn't triggered by a `release` event.
+        required: false
+        default: ''
+        type: string
 
 jobs:
   build-wheels:
@@ -62,12 +75,25 @@ jobs:
         with:
           python-version: 3.14
 
-      - name: Stamp wheel version from git tag
+      - name: Stamp wheel version
         if: inputs.stamp-version
         shell: bash
         run: |
           set -eu
-          VERSION="${GITHUB_REF#refs/tags/}"
+          # `override-version` wins; falls back to the git tag the
+          # `release: published` flow rides on. The dispatch path
+          # passes `inputs.tag` here because no tag exists yet — it
+          # gets created by `gh release create` later in the
+          # workflow.
+          if [ -n "${{ inputs.override-version }}" ]; then
+              VERSION='${{ inputs.override-version }}'
+          else
+              VERSION="${GITHUB_REF#refs/tags/}"
+          fi
+          if [ -z "${VERSION}" ] || [ "${VERSION}" = "${GITHUB_REF}" ]; then
+              echo "::error::stamp-version is true but no version source is available (no tag in GITHUB_REF, no override-version input)"
+              exit 1
+          fi
           # `sed -i.bak`/rm form works on both BSD (macOS) and GNU
           # (Linux) sed without divergent flag handling. On Windows
           # the runner ships GNU sed via Git Bash, which honours the
@@ -131,12 +157,22 @@ jobs:
         with:
           python-version: 3.14
 
-      - name: Stamp wheel version from git tag
+      - name: Stamp wheel version
         if: inputs.stamp-version
         shell: bash
         run: |
           set -eu
-          VERSION="${GITHUB_REF#refs/tags/}"
+          # Same source-priority as the wheel job above —
+          # `override-version` wins, falls back to the tag.
+          if [ -n "${{ inputs.override-version }}" ]; then
+              VERSION='${{ inputs.override-version }}'
+          else
+              VERSION="${GITHUB_REF#refs/tags/}"
+          fi
+          if [ -z "${VERSION}" ] || [ "${VERSION}" = "${GITHUB_REF}" ]; then
+              echo "::error::stamp-version is true but no version source is available"
+              exit 1
+          fi
           sed -i.bak -E "s/^version = \".*\"$/version = \"${VERSION}\"/" pyproject.toml
           rm -f pyproject.toml.bak
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,50 +2,84 @@ name: release
 
 # Two-stage release flow, forced by GitHub's immutable-releases
 # policy (assets can't be added after publish — PR #1569 dropped a
-# prior `gh release upload` job for the same reason):
+# prior `gh release upload` job for the same reason). Naïvely you'd
+# expect `release: created` to fire for draft saves and let us
+# attach binaries before publish, but GitHub Actions filters
+# release events on drafts: nothing fires until the release becomes
+# visible. So the prepare stage runs from `workflow_dispatch`
+# instead — the maintainer drives it from the Actions UI.
 #
-# 1. `release: created` with `draft == true` — maintainer clicks
-#    "Save draft" in the UI. We build wheels, extract the binary
-#    from each, and attach `mergify-<target>.{tar.gz,zip}` +
-#    `SHA256SUMS` to the still-mutable draft. The assets appear in
-#    the draft's asset list within a few minutes.
+# Stage 1 — prepare-draft (`workflow_dispatch`):
+#   Maintainer opens Actions → "release" → "Run workflow" → enters
+#   the tag (e.g. `2026.6.12.1`). The workflow builds the wheel
+#   matrix, extracts the binary from each wheel, packages
+#   `mergify-<target>.{tar.gz,zip}` + `SHA256SUMS`, and creates the
+#   GitHub Release as a *draft* with all assets attached and notes
+#   auto-generated from the commit log via `--generate-notes`.
 #
-# 2. `release: published` — maintainer reviews the now-asset-laden
-#    draft and clicks "Publish release". We assert the expected
-#    asset names are attached (blocks the PyPI step with a clear
-#    error if the maintainer bypassed the draft flow and published
-#    directly — the release is then immutable and binaries can't be
-#    backfilled), then build wheels again and publish to PyPI.
+# Stage 2 — publish-stable (`release: published`):
+#   Maintainer goes to Releases, reviews the draft (notes + asset
+#   list), optionally edits, clicks "Publish release". This fires
+#   `release: published`. We assert the expected asset names are
+#   present (sanity net if the maintainer somehow stripped them
+#   before publish), then build wheels again and push to PyPI.
+#   The release is immutable from this point on.
 #
-# Yes, wheels are built twice (once per stage). The alternative —
-# stash wheels somewhere between runs — adds storage plumbing for
-# ~5 min of CI savings; not worth it. `build-wheels.yml` is shared
-# with `ci.yaml` so adding a new platform target there extends both
-# stages automatically.
+# Yes, wheels are built twice (once per stage). Stashing them
+# between two separately-triggered runs adds cross-run artifact
+# plumbing for ~5 min of CI savings; not worth it. `build-wheels.yml`
+# is shared with `ci.yaml` so adding a new platform target there
+# extends both stages automatically.
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: |
+          Release tag to publish (e.g. `2026.6.12.1`). The workflow
+          creates this tag and a matching draft release with all
+          platform binaries attached. The maintainer then publishes
+          the draft from the Releases UI.
+        required: true
+        type: string
+      target_commitish:
+        description: |
+          Branch or commit SHA to tag. Defaults to the branch the
+          workflow runs from — keep as-is unless you're cherry-
+          picking a release commit off an older line.
+        required: false
+        type: string
+        default: ''
   release:
-    types: [created, published]
+    types: [published]
 
 jobs:
-  # ---------------- Draft stage: attach binaries ----------------
+  # ---------------- Stage 1: prepare draft ----------------
 
   build-wheels-for-draft:
     name: build wheels (draft stage)
-    if: github.event.action == 'created' && github.event.release.draft
+    if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/build-wheels.yml
     with:
       stamp-version: true
+      override-version: ${{ inputs.tag }}
 
-  upload-binaries:
-    name: attach binaries to the draft release
-    if: github.event.action == 'created' && github.event.release.draft
+  create-draft-release:
+    name: create draft release with binaries
+    if: github.event_name == 'workflow_dispatch'
     needs: build-wheels-for-draft
     runs-on: ubuntu-24.04
     permissions:
-      # `gh release upload` writes to the release.
+      # `gh release create` writes the release.
       contents: write
     steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          # `--generate-notes` needs full history to walk back to
+          # the previous tag.
+          fetch-depth: 0
+          fetch-tags: true
+
       - uses: actions/download-artifact@v8
         with:
           # Skip `wheel-sdist` (single dash); each wheel artifact is
@@ -87,21 +121,49 @@ jobs:
           echo "Built release assets:"
           ls -la dist
 
-      - name: Upload assets to the draft release
+      - name: Create draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          # Read inputs via env, not `${{ }}` interpolation, so a
+          # tag or commitish value containing shell metacharacters
+          # can't break out of the script. With direct
+          # interpolation, `inputs.tag = "foo'; rm -rf /; '"` would
+          # render the script as runnable injected commands;
+          # through env they reach bash as plain string values.
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_TARGET: ${{ inputs.target_commitish }}
+        shell: bash
         run: |
-          # `--clobber` so re-saving the draft (which can re-fire
-          # `release: created`) replaces stale assets instead of
-          # erroring out.
-          gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber
+          set -euo pipefail
+          # Build the gh argument list as an array — keeps each
+          # element a single argv slot regardless of the value's
+          # contents.
+          args=(
+              "${INPUT_TAG}"
+              --draft
+              --generate-notes
+              --title "${INPUT_TAG}"
+          )
+          if [ -n "${INPUT_TARGET}" ]; then
+              args+=(--target "${INPUT_TARGET}")
+          fi
+          # `--draft` keeps the release mutable until the maintainer
+          # clicks Publish. `--generate-notes` builds a changelog
+          # from PRs merged since the previous tag — overridable in
+          # the UI before publish if needed.
+          gh release create "${args[@]}" dist/*
 
-  # ---------------- Publish stage: assert + PyPI ----------------
+          url=$(gh release view "${INPUT_TAG}" --json url --jq .url)
+          echo
+          echo "Draft release created: ${url}"
+          echo "Review the draft and click Publish in the Releases UI to ship."
+
+  # ---------------- Stage 2: publish + PyPI ----------------
 
   assert-binaries-present:
     name: assert binary assets attached
-    if: github.event.action == 'published'
+    if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -134,16 +196,15 @@ jobs:
             cat <<EOF >&2
           ::error::Release $tag is missing assets: ${missing[*]}
 
-          Binaries are attached by the 'upload-binaries' job, which only runs when
-          a release is saved as a *draft* (release: created event). It looks like
-          this release was published directly without first being saved as a
-          draft. Because release metadata is now immutable, the assets can't be
+          Binary assets are attached by the 'create-draft-release' job, which
+          runs from Actions → "release" → "Run workflow". Did you create this
+          release through the Releases UI directly instead? That path doesn't
+          attach binaries, and the release is now immutable so they can't be
           backfilled — the PyPI publish is being blocked so the package and the
           binary distributions don't diverge.
 
-          Recovery: delete this release, then re-create it via the UI making sure
-          to click "Save draft" first. Wait for the binaries to appear in the
-          draft's asset list before clicking "Publish".
+          Recovery: delete this release, then re-create it via Actions →
+          "release" → "Run workflow" with the same tag.
           EOF
             exit 1
           fi
@@ -151,7 +212,7 @@ jobs:
 
   build-wheels-for-publish:
     name: build wheels (publish stage)
-    if: github.event.action == 'published'
+    if: github.event_name == 'release' && github.event.action == 'published'
     needs: assert-binaries-present
     uses: ./.github/workflows/build-wheels.yml
     with:
@@ -159,7 +220,7 @@ jobs:
 
   publish:
     name: publish to PyPI
-    if: github.event.action == 'published'
+    if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: ubuntu-24.04
     needs:
       - assert-binaries-present

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,64 @@
+# Releasing `mergify-cli`
+
+Two-stage flow keyed off the immutable-releases policy on
+`Mergifyio/*` — once a release is published, asset metadata is
+locked. So binaries are attached to the release **as a draft**
+before the maintainer clicks Publish.
+
+## Stage 1 — build the draft
+
+1. Go to **Actions** → **release** → **Run workflow** (top right of
+   the workflow page).
+2. Fill in the **tag** field with the new calver, e.g.
+   `2026.6.12.1`. Leave **target_commitish** empty unless you're
+   cherry-picking a release commit off an older branch.
+3. Click **Run workflow**.
+
+The workflow builds the wheel matrix (Linux x86_64/aarch64, macOS
+x86_64/aarch64, Windows x86_64), extracts the `mergify` binary out
+of each, packages `mergify-<target>.{tar.gz,zip}` + `SHA256SUMS`,
+and runs `gh release create <tag> --draft --generate-notes` to
+create the release with the assets attached and notes
+auto-generated from PRs merged since the previous tag. Takes ~10
+minutes.
+
+## Stage 2 — review and publish
+
+1. Go to **Releases** → the new draft.
+2. Review the auto-generated notes; edit if needed (drafts are
+   mutable).
+3. Confirm all six asset names are listed:
+   - `mergify-x86_64-unknown-linux-gnu.tar.gz`
+   - `mergify-aarch64-unknown-linux-gnu.tar.gz`
+   - `mergify-x86_64-apple-darwin.tar.gz`
+   - `mergify-aarch64-apple-darwin.tar.gz`
+   - `mergify-x86_64-pc-windows-msvc.zip`
+   - `SHA256SUMS`
+4. Click **Publish release**.
+
+Publishing fires `release: published`, which kicks the second half
+of the workflow: assert all six assets are present, rebuild wheels
+with the same version stamp, and publish to PyPI through
+Trusted-Publisher. Takes ~10 minutes.
+
+## Do not
+
+- **Don't click "Draft a new release" in the Releases UI.** That
+  path creates a draft without binaries; once you publish it the
+  release is immutable and the asset assertion will fail, blocking
+  PyPI. To recover you'd have to delete the release and re-run
+  stage 1 with the same tag.
+- **Don't run `gh release create` from your laptop.** The
+  workflow does this so the binary build is reproducible and the
+  PyPI Trusted-Publisher identity matches the tag.
+
+## If stage 2 fails
+
+The release is already published and immutable. If the assert job
+fails (binaries missing) or the PyPI publish fails (transient
+PyPI outage, version conflict, etc.):
+
+- **Asset assertion failed** — someone bypassed the workflow.
+  Delete the release, re-run stage 1.
+- **PyPI publish failed** — re-run just the `publish` job from
+  Actions. The wheels were built; PyPI is the only step left.


### PR DESCRIPTION
The two-stage flow shipped in #1583 wired the binary-attach stage
to `release: created` on a draft save — but GitHub Actions
intentionally filters release events for drafts: nothing fires
until the release becomes visible. The webhook docs imply
otherwise, hence the bug. Result: a maintainer who saves a draft
via the UI sees no workflow run, no binaries attached, and ends
up publishing an empty release (which the assert job then blocks
from reaching PyPI).

Restructure stage 1 to run on `workflow_dispatch` instead. The
maintainer goes to Actions → "release" → "Run workflow", enters
the calver tag, and the workflow:

  1. Builds the wheel matrix with the tag stamped in (new
     `override-version` input on `build-wheels.yml`; the prior
     `${GITHUB_REF#refs/tags/}` derivation doesn't work here
     because no tag exists yet — it gets created by `gh release
     create` later in the run).
  2. Extracts the binary from each wheel, packages the
     `mergify-<target>.{tar.gz,zip}` + `SHA256SUMS` set.
  3. Creates the release via `gh release create <tag> --draft
     --generate-notes` with all assets attached and notes
     auto-generated from the commit log.

Stage 2 (`release: published`) is unchanged: assert the six
expected assets are present, rebuild wheels, push to PyPI.

`RELEASING.md` documents the new flow + the "do not click 'Draft a
new release' in the UI" gotcha — that path creates a draft without
binaries and ends up blocked at assert time.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>