### PR TITLE
feat(ci): expose last failed batch draft PR from queue-info

### DIFF
--- a/crates/mergify-ci/src/queue_info.rs
+++ b/crates/mergify-ci/src/queue_info.rs
@@ -14,9 +14,12 @@
 //! on stdout — every field the engine wrote, including ones this CLI
 //! doesn't model — so new engine attributes show up without a CLI
 //! change. When `$GITHUB_OUTPUT` is set (GitHub Actions runner) the
-//! command also appends it as `queue_metadata` under a random
-//! `ghadelimiter_<uuid>` heredoc, matching the pattern the workflow
-//! runtime expects for multi-line outputs.
+//! command also appends two outputs: the full payload as `queue_metadata`
+//! under a random `ghadelimiter_<uuid>` heredoc (the pattern the workflow
+//! runtime expects for multi-line outputs), and `last_failed_draft_pr` —
+//! the most recent failed batch's draft PR number as a plain single line
+//! (empty when there are none), so a workflow can branch on it without
+//! parsing the JSON.
 
 use std::env;
 use std::fs::OpenOptions;
@@ -110,6 +113,20 @@ fn write_github_output(metadata: &Value) -> Result<(), CliError> {
     let delimiter = format!("ghadelimiter_{}", random_delimiter_suffix()?);
     let compact = serde_json::to_string(metadata)
         .map_err(|e| CliError::Generic(format!("failed to serialize queue metadata: {e}")))?;
+    // Surface the most recent failed batch's draft PR number as a plain
+    // single-line output so workflows don't have to parse the
+    // `queue_metadata` JSON. `previous_failed_batches` is ordered
+    // oldest→newest, so the last element is the most recent. Empty string
+    // when the field is absent or empty, which makes the output falsy
+    // (`if: steps.x.outputs.last_failed_draft_pr`).
+    let last_failed_draft_pr = metadata
+        .get("previous_failed_batches")
+        .and_then(Value::as_array)
+        .and_then(|batches| batches.last())
+        .and_then(|batch| batch.get("draft_pr_number"))
+        .and_then(Value::as_u64)
+        .map(|n| n.to_string())
+        .unwrap_or_default();
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
@@ -117,6 +134,7 @@ fn write_github_output(metadata: &Value) -> Result<(), CliError> {
     writeln!(file, "queue_metadata<<{delimiter}")?;
     writeln!(file, "{compact}")?;
     writeln!(file, "{delimiter}")?;
+    writeln!(file, "last_failed_draft_pr={last_failed_draft_pr}")?;
     Ok(())
 }
 
@@ -200,5 +218,37 @@ mod tests {
         assert!(written.starts_with("queue_metadata<<ghadelimiter_"));
         assert!(written.contains("\"checking_base_sha\":\"abc123\""));
         assert!(written.contains("\"scopes\":[\"backend\"]"));
+        // `sample()` has an empty `previous_failed_batches`, so the
+        // convenience output is present but empty (falsy in workflow `if:`).
+        assert!(
+            written.contains("\nlast_failed_draft_pr=\n"),
+            "got: {written:?}"
+        );
+    }
+
+    #[test]
+    fn github_output_exposes_last_failed_draft_pr() {
+        let dir = tempfile::tempdir().unwrap();
+        let gha_output = dir.path().join("gha_output");
+        // Two failed batches — the last one (draft PR 99) is the most
+        // recent and is what the convenience output must surface.
+        let note = || {
+            Some(json!({
+                "checking_base_sha": "abc123",
+                "previous_failed_batches": [
+                    {"draft_pr_number": 42, "checked_pull_requests": [1, 2]},
+                    {"draft_pr_number": 99, "checked_pull_requests": [3]},
+                ],
+            }))
+        };
+        let mut cap = Captured::human();
+        temp_env::with_var("GITHUB_OUTPUT", Some(gha_output.to_str().unwrap()), || {
+            run_with_reader(&mut cap.output, &note).unwrap();
+        });
+        let written = std::fs::read_to_string(&gha_output).unwrap();
+        assert!(
+            written.contains("\nlast_failed_draft_pr=99\n"),
+            "got: {written:?}"
+        );
     }
 }

--- a/skills/mergify-ci/SKILL.md
+++ b/skills/mergify-ci/SKILL.md
@@ -309,6 +309,18 @@ mergify ci queue-info
 
 Mergify attaches the batch metadata as a git note to the MQ branch head commit, so reading it needs only git, no PR body and no GitHub token. The command runs `git fetch origin "refs/notes/mergify/*"` itself (notes aren't fetched by default), then returns the note attached to `HEAD`. Requirements: the `origin` remote is reachable and the checkout is at the MQ branch head commit, which is the normal state inside a merge-queue CI run. A detached HEAD is fine.
 
+On GitHub Actions (`$GITHUB_OUTPUT` set) it writes two outputs:
+
+- `queue_metadata` -- the full note payload as JSON (multi-line heredoc).
+- `last_failed_draft_pr` -- the most recent failed batch's draft PR number, as a plain single line. Empty when there are no failed batches, so it's falsy in a workflow `if:`. This saves parsing `queue_metadata` to reach `previous_failed_batches[-1].draft_pr_number`.
+
+```yaml
+- id: queue
+  run: mergify ci queue-info
+- if: steps.queue.outputs.last_failed_draft_pr
+  run: echo "last failed draft PR was #${{ steps.queue.outputs.last_failed_draft_pr }}"
+```
+
 This command is useful in CI workflows that need to know whether the current run is part of a merge queue batch and what other PRs are in the batch.
 
 ## Common Patterns


### PR DESCRIPTION
`mergify ci queue-info` prints the merge-queue note payload as JSON and
appends it to `$GITHUB_OUTPUT` as `queue_metadata`. A workflow that only
wants the most recent failed batch's draft PR number had to parse that
JSON and dig into `previous_failed_batches[-1].draft_pr_number`.

Add a second GHA output, `last_failed_draft_pr`, written next to
`queue_metadata`. `previous_failed_batches` is ordered oldest→newest so
the last element is the most recent; the value is that batch's
`draft_pr_number` as a plain single line, empty when the field is absent
or empty (falsy in a workflow `if:`).

Single-line `key=value` format matches the existing `test_results_upload`
output in `junit-process` — the value is numeric so no heredoc is needed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>