### PR TITLE
fix(deps): update cargo minor/patch updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,11 +175,11 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -242,9 +242,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -318,6 +318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,9 +341,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -353,12 +359,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -387,11 +392,12 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -619,16 +625,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +784,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1581,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1591,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2080,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/crates/mergify-cli/Cargo.toml
+++ b/crates/mergify-cli/Cargo.toml
@@ -33,7 +33,7 @@ mergify-stack = { path = "../mergify-stack" }
 # can't-rename-over-a-running-exe dance cross-platform.
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
 self-replace = "1"
-sha2 = "0.10"
+sha2 = "0.11"
 tempfile = "3"
 # Backs the `_internal dump-cli-schema` generator (serializing the
 # clap command tree) and the Python-migration helpers (`_internal

--- a/crates/mergify-cli/src/self_update.rs
+++ b/crates/mergify-cli/src/self_update.rs
@@ -203,6 +203,18 @@ async fn download_text(client: &reqwest::Client, url: &str) -> Result<String, Cl
         .map_err(|e| CliError::Generic(format!("non-UTF8 body from {url}: {e}")))
 }
 
+/// Render digest bytes as a lowercase hex string. `sha2` 0.11 returns
+/// a `hybrid_array::Array` from `finalize()` that no longer implements
+/// `LowerHex`, so we format the bytes ourselves.
+fn hex_encode(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
 /// Verify the downloaded archive's SHA256 against the entry for
 /// `asset_name` in `SHA256SUMS`. Mirrors `install.sh` exactly: the
 /// line must split as `<hash> <name>` on whitespace where the
@@ -237,7 +249,7 @@ fn verify_checksum(archive: &[u8], asset_name: &str, sums: &str) -> Result<(), C
     }
     let mut hasher = Sha256::new();
     hasher.update(archive);
-    let actual = format!("{:x}", hasher.finalize());
+    let actual = hex_encode(&hasher.finalize());
     if actual.eq_ignore_ascii_case(expected) {
         Ok(())
     } else {
@@ -351,7 +363,7 @@ mod tests {
         let archive = fixture_archive();
         let mut h = Sha256::new();
         h.update(&archive);
-        let hash = format!("{:x}", h.finalize());
+        let hash = hex_encode(&h.finalize());
         let sums = format!("{hash}  mergify-x86_64-unknown-linux-gnu.tar.gz\n");
         verify_checksum(&archive, "mergify-x86_64-unknown-linux-gnu.tar.gz", &sums).unwrap();
     }
@@ -385,7 +397,7 @@ mod tests {
         let archive = fixture_archive();
         let mut h = Sha256::new();
         h.update(&archive);
-        let hash = format!("{:x}", h.finalize());
+        let hash = hex_encode(&h.finalize());
         let sums = format!("{hash}  mergify-x86_64-pc-windows-msvc.zip\n");
         let err = verify_checksum(&archive, "msvc.zip", &sums).unwrap_err();
         assert!(
@@ -404,7 +416,7 @@ mod tests {
         let archive = fixture_archive();
         let mut h = Sha256::new();
         h.update(&archive);
-        let hash = format!("{:x}", h.finalize());
+        let hash = hex_encode(&h.finalize());
         let sums = format!("{hash}  mergify-x86_64-unknown-linux-gnu.tar.gz extra\n");
         let err = verify_checksum(&archive, "mergify-x86_64-unknown-linux-gnu.tar.gz", &sums)
             .unwrap_err();


### PR DESCRIPTION
Bumps the Cargo minor/patch updates from #1593 and fixes the code break the version-only bump left behind:

| Package | Update |
|---|---|
| chrono | `0.4.44` → `0.4.45` (patch) |
| prost | `0.14.3` → `0.14.4` (patch) |
| sha2 | `0.10` → `0.11` (minor) |

## Why a new PR

#1593 (Renovate) bumped only the manifest/lockfile. `sha2` 0.11 pulls in `digest` 0.11, whose `finalize()` now returns a `hybrid_array::Array` that no longer implements `LowerHex` — so the `format!("{:x}", …)` digest formatting in `self_update` no longer compiles, and every CI job on #1593 fails.

This PR adds a small `hex_encode` helper over the digest bytes and uses it at all four call sites, so the bump actually builds and passes.

## Verification

- `cargo build -p mergify-cli` ✅
- `cargo test -p mergify-cli` (self_update tests) ✅
- `cargo clippy --all-targets --workspace -- -D warnings` ✅
- `cargo fmt --check` ✅

Closes #1593.

🤖 Generated with [Claude Code](https://claude.com/claude-code)