### PR TITLE
feat(ci): read queue-info metadata from the git note (CI-agnostic)

### DIFF
--- a/crates/mergify-ci/src/git.rs
+++ b/crates/mergify-ci/src/git.rs
@@ -1,0 +1,106 @@
+//! Tiny helpers for shelling out to `git`.
+//!
+//! The engine publishes merge-queue metadata as git notes under
+//! `refs/notes/mergify/*`. Both [`crate::git_refs`] and
+//! [`crate::queue_info`] fetch and read those notes the same way: run
+//! git, silence stderr, and treat any failure (no remote, no notes,
+//! not a repo) as "not found" so the caller falls through to another
+//! detection path. These two functions are that shared plumbing.
+
+use std::process::Command;
+use std::process::Stdio;
+
+/// Read the engine's merge-queue note at `notes_ref` for `rev`
+/// (`git notes --ref=<notes_ref> show <rev>`) and return its full
+/// payload as a JSON value. `notes_ref` may be the short
+/// `mergify/<branch>` form or a fully-qualified
+/// `refs/notes/mergify/<branch>` — git accepts both.
+///
+/// The note body is the engine's `TrainInfo` YAML dump. We parse it
+/// into a generic value rather than a fixed struct so the whole payload
+/// is preserved — every field, including any the engine adds later.
+/// Both `queue_info` (which prints the whole note) and `git_refs`
+/// (which deserializes it into a typed view to pull `checking_base_sha`)
+/// read it through here.
+///
+/// Returns `None` when there's no note at `rev`, or the body isn't a
+/// YAML mapping.
+#[must_use]
+pub(crate) fn read_note(notes_ref: &str, rev: &str) -> Option<serde_json::Value> {
+    let content = capture(&["notes", &format!("--ref={notes_ref}"), "show", rev])?;
+    parse_note(&content)
+}
+
+/// Parse a note body (YAML) into a JSON value, keeping every field.
+/// Restricted to mappings: a bare scalar or sequence isn't a
+/// merge-queue note and would make the JSON output meaningless.
+fn parse_note(content: &str) -> Option<serde_json::Value> {
+    let value: serde_json::Value = serde_yaml_ng::from_str(content).ok()?;
+    value.is_object().then_some(value)
+}
+
+/// Run a git subcommand for its exit status, discarding all output.
+/// Returns `true` only on a clean exit.
+#[must_use]
+pub(crate) fn succeeds(args: &[&str]) -> bool {
+    Command::new("git")
+        .args(args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+/// Run a git subcommand and capture stdout as UTF-8. Returns `None` on
+/// any failure: the process couldn't spawn, exited non-zero, or wrote
+/// non-UTF-8.
+#[must_use]
+pub(crate) fn capture(args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_note_keeps_whole_payload() {
+        // The note body is the engine's full TrainInfo dump. Every
+        // field must survive into the value — including top-level and
+        // per-PR `scopes`, which a fixed struct would have dropped.
+        let body = "\
+scopes:
+  - backend
+pull_requests:
+  - number: 7
+    scopes:
+      - backend
+previous_failed_batches:
+  - draft_pr_number: 42
+    checked_pull_requests:
+      - 7
+checking_base_sha: cafef00d
+";
+        let note = parse_note(body).expect("engine payload should parse");
+        assert_eq!(note["checking_base_sha"], "cafef00d");
+        assert_eq!(note["scopes"][0], "backend");
+        assert_eq!(note["pull_requests"][0]["number"], 7);
+        assert_eq!(note["pull_requests"][0]["scopes"][0], "backend");
+        assert_eq!(note["previous_failed_batches"][0]["draft_pr_number"], 42);
+    }
+
+    #[test]
+    fn parse_note_rejects_non_mapping() {
+        // A bare scalar or sequence isn't a merge-queue note.
+        assert!(parse_note("just a scalar\n").is_none());
+        assert!(parse_note("- a\n- b\n").is_none());
+    }
+}

--- a/crates/mergify-ci/src/git_refs.rs
+++ b/crates/mergify-ci/src/git_refs.rs
@@ -29,7 +29,6 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
-use std::process::Stdio;
 
 use mergify_core::CliError;
 use mergify_core::Output;
@@ -38,9 +37,7 @@ use serde::Serialize;
 use crate::github_event::GitHubEvent;
 use crate::github_event::PULL_REQUEST_EVENTS;
 use crate::github_event::load as load_event;
-use crate::queue_metadata::MergeQueueMetadata;
 use crate::queue_metadata::extract_from_event;
-use crate::queue_metadata::parse_yaml_block;
 
 const BUILDKITE_BASE_METADATA_KEY: &str = "mergify-ci.base";
 const BUILDKITE_HEAD_METADATA_KEY: &str = "mergify-ci.head";
@@ -84,12 +81,14 @@ pub struct References {
     pub source: ReferencesSource,
 }
 
-/// Trait-object-compatible hook for reading merge-queue git notes.
+/// Trait-object-compatible hook for reading the merge-queue checking
+/// base SHA from the engine's git note.
 ///
-/// The real implementation shells out to `git`. Tests inject a stub
-/// so detection can exercise the note-driven branches without
-/// touching a real repository.
-pub type NotesReader<'a> = &'a dyn Fn(&str, &str) -> Option<MergeQueueMetadata>;
+/// git-refs only needs that one field, so the reader yields it directly
+/// rather than a half-populated struct. The real implementation shells
+/// out to `git`; tests inject a stub so detection can exercise the
+/// note-driven branches without touching a real repository.
+pub type NotesReader<'a> = &'a dyn Fn(&str, &str) -> Option<String>;
 
 #[derive(Serialize)]
 struct JsonOutput<'a> {
@@ -198,9 +197,9 @@ fn detect_from_buildkite(notes_reader: NotesReader<'_>) -> Option<References> {
         .unwrap_or_else(|| "HEAD".to_string());
     if let Ok(branch) = env::var("BUILDKITE_BRANCH") {
         if !branch.is_empty() {
-            if let Some(note) = notes_reader(&branch, &commit) {
+            if let Some(base) = notes_reader(&branch, &commit) {
                 return Some(References {
-                    base: Some(note.checking_base_sha),
+                    base: Some(base),
                     head: commit,
                     source: ReferencesSource::MergeQueue,
                 });
@@ -231,9 +230,9 @@ fn detect_from_pull_request_event(
     if let Some(pr) = &event.pull_request {
         if let Some(head_ref) = &pr.head {
             if let Some(branch) = head_ref.r#ref.as_deref() {
-                if let Some(note) = notes_reader(branch, &head_ref.sha) {
+                if let Some(base) = notes_reader(branch, &head_ref.sha) {
                     return Ok(Some(References {
-                        base: Some(note.checking_base_sha),
+                        base: Some(base),
                         head,
                         source: ReferencesSource::MergeQueue,
                     }));
@@ -303,52 +302,38 @@ fn detect_from_push_event(event: &GitHubEvent) -> Option<References> {
 /// `git fetch` + `git notes show` and swallows any failure as `None`
 /// so callers can transparently fall through to other detection
 /// paths.
+///
+/// `read_note` returns the note's full payload; we pull just
+/// `checking_base_sha` out of it, so a note that lacks the field falls
+/// through to the other detection paths.
 #[must_use]
-pub fn real_notes_reader(branch: &str, head_sha: &str) -> Option<MergeQueueMetadata> {
+pub fn real_notes_reader(branch: &str, head_sha: &str) -> Option<String> {
     let notes_ref_short = format!("mergify/{branch}");
     let notes_ref = format!("refs/notes/{notes_ref_short}");
 
-    let fetch = Command::new("git")
-        .args([
-            "fetch",
-            "--no-tags",
-            "--quiet",
-            "origin",
-            &format!("+{notes_ref}:{notes_ref}"),
-        ])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .ok()?;
-    if !fetch.success() {
+    if !crate::git::succeeds(&[
+        "fetch",
+        "--no-tags",
+        "--quiet",
+        "origin",
+        &format!("+{notes_ref}:{notes_ref}"),
+    ]) {
         return None;
     }
 
-    let output = Command::new("git")
-        .args([
-            "notes",
-            &format!("--ref={notes_ref_short}"),
-            "show",
-            head_sha,
-        ])
-        .stderr(Stdio::null())
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let content = String::from_utf8(output.stdout).ok()?;
-    let meta: MergeQueueMetadata = serde_yaml_ng::from_str(&content).ok()?;
-    // Python also guards against non-dict payloads; `from_str` into
-    // our typed struct already enforces the shape, so just return.
-    Some(meta)
+    checking_base_sha(&crate::git::read_note(&notes_ref_short, head_sha)?)
 }
 
-#[allow(dead_code)]
-fn parse_notes_payload(content: &str) -> Option<MergeQueueMetadata> {
-    // Exposed for unit-testing the YAML parsing independently of
-    // the git subprocess.
-    parse_yaml_block(content).or_else(|| serde_yaml_ng::from_str(content).ok())
+/// Pull `checking_base_sha` out of a note payload. Accepts the YAML
+/// scalar as either a string or (defensively) a number — a SHA is
+/// always a string in practice, but reading it tolerantly avoids
+/// silently dropping a note over a formatting quirk.
+fn checking_base_sha(note: &serde_json::Value) -> Option<String> {
+    match note.get("checking_base_sha")? {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
 }
 
 fn emit(refs: &References, format: Format, output: &mut dyn Output) -> std::io::Result<()> {
@@ -447,8 +432,25 @@ mod tests {
 
     use super::*;
 
-    fn no_notes(_branch: &str, _sha: &str) -> Option<MergeQueueMetadata> {
+    fn no_notes(_branch: &str, _sha: &str) -> Option<String> {
         None
+    }
+
+    #[test]
+    fn checking_base_sha_extracts_string_or_number() {
+        use serde_json::json;
+        assert_eq!(
+            checking_base_sha(&json!({"checking_base_sha": "deadbeef", "scopes": ["x"]})),
+            Some("deadbeef".to_string()),
+        );
+        // A numeric-looking SHA is read tolerantly, matching the
+        // direct-YAML coercion the typed parse used to do.
+        assert_eq!(
+            checking_base_sha(&json!({"checking_base_sha": 1_234_567})),
+            Some("1234567".to_string()),
+        );
+        // No field → None, so detection falls back to the PR body.
+        assert_eq!(checking_base_sha(&json!({"pull_requests": []})), None);
     }
 
     fn write_event(dir: &TempDir, payload: &serde_json::Value) -> PathBuf {
@@ -558,11 +560,7 @@ mod tests {
         );
         let note_reader = |branch: &str, sha: &str| {
             if branch == "mq/main/0" && sha == "mq-head" {
-                Some(MergeQueueMetadata {
-                    checking_base_sha: "note-sha".to_string(),
-                    pull_requests: Vec::new(),
-                    previous_failed_batches: Vec::new(),
-                })
+                Some("note-sha".to_string())
             } else {
                 None
             }

--- a/crates/mergify-ci/src/lib.rs
+++ b/crates/mergify-ci/src/lib.rs
@@ -8,6 +8,7 @@
 //! `junit-process`, `scopes` outer command) reuse these helpers.
 
 pub mod detector;
+mod git;
 pub mod git_refs;
 pub mod github_event;
 pub mod junit_process;

--- a/crates/mergify-ci/src/queue_info.rs
+++ b/crates/mergify-ci/src/queue_info.rs
@@ -1,129 +1,101 @@
-//! `mergify ci queue-info` — print the merge-queue batch metadata
-//! that's embedded in a merge-queue draft PR.
+//! `mergify ci queue-info` — print the current build's merge-queue
+//! batch metadata, read from a git note.
 //!
-//! Two ways in:
+//! The engine attaches the batch metadata (a `TrainInfo` YAML dump) to
+//! the merge-queue branch head commit as a git note under
+//! `refs/notes/mergify/<mq_branch>`, precisely so CI providers can read
+//! it with plain git and no GitHub token. This command reads that note
+//! for the current `HEAD`, so it works in any CI (GitHub Actions,
+//! GitLab, `CircleCI`, Jenkins, ...) wherever the merge-queue branch is
+//! checked out. It exits with `INVALID_STATE` when no note is found —
+//! i.e. the build is not a merge-queue batch.
 //!
-//! - **No argument (in CI):** read the MQ draft PR from the GitHub
-//!   Actions event payload (`$GITHUB_EVENT_PATH`).
-//! - **PR URL argument (anywhere):** fetch the PR via the GitHub API
-//!   and read the metadata out of its body. The URL host drives the
-//!   API base (github.com vs GitHub Enterprise Server).
-//!
-//! Both paths apply the same MQ-draft gate (`extract_from_event`) and
-//! exit with `INVALID_STATE` when the PR isn't an MQ draft.
-//!
-//! Output is pretty-printed JSON on stdout. When `$GITHUB_OUTPUT` is
-//! set (GitHub Actions runner) **and** no URL was given, the command
-//! also appends the metadata as `queue_metadata` under a random
+//! The note's full payload is emitted verbatim as pretty-printed JSON
+//! on stdout — every field the engine wrote, including ones this CLI
+//! doesn't model — so new engine attributes show up without a CLI
+//! change. When `$GITHUB_OUTPUT` is set (GitHub Actions runner) the
+//! command also appends it as `queue_metadata` under a random
 //! `ghadelimiter_<uuid>` heredoc, matching the pattern the workflow
-//! runtime expects for multi-line outputs. An explicit PR lookup is a
-//! local/interactive use and never writes GHA outputs.
+//! runtime expects for multi-line outputs.
 
 use std::env;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::PathBuf;
 
-use mergify_core::ApiFlavor;
 use mergify_core::CliError;
 use mergify_core::Output;
-use mergify_core::auth;
-use mergify_core::http::Client;
-use mergify_core::pull_request::PullRequestRef;
-use url::Url;
+use serde_json::Value;
 
-use crate::github_event::GitHubEvent;
-use crate::github_event::PullRequest;
-use crate::queue_metadata::MergeQueueMetadata;
-use crate::queue_metadata::detect;
-use crate::queue_metadata::extract_from_event;
-
-/// Options for the `ci queue-info` command.
-pub struct QueueInfoOptions<'a> {
-    /// When set, fetch the PR via the GitHub API instead of reading
-    /// the CI event payload.
-    pub pull_request: Option<&'a PullRequestRef>,
-    /// GitHub token. Resolved through the usual flag → env →
-    /// `gh auth token` chain when fetching a PR by URL; ignored on the
-    /// in-CI (no-argument) path.
-    pub token: Option<&'a str>,
-}
+/// Reads the merge-queue git note attached to the current `HEAD`,
+/// returning its full payload.
+///
+/// The real implementation shells out to `git`; tests inject a stub so
+/// the command can be exercised without a checkout.
+pub type HeadNoteReader<'a> = &'a dyn Fn() -> Option<Value>;
 
 /// Run the `ci queue-info` command.
-pub async fn run(opts: QueueInfoOptions<'_>, output: &mut dyn Output) -> Result<(), CliError> {
-    let metadata = match opts.pull_request {
-        Some(pr_ref) => fetch_via_api(pr_ref, opts.token, output).await?,
-        None => detect(output)?,
-    };
-    let Some(metadata) = metadata else {
+pub fn run(output: &mut dyn Output) -> Result<(), CliError> {
+    run_with_reader(output, &real_head_note_reader)
+}
+
+/// Inner entrypoint with the git-note reader injected so tests can run
+/// without a real repository.
+fn run_with_reader(
+    output: &mut dyn Output,
+    head_note_reader: HeadNoteReader<'_>,
+) -> Result<(), CliError> {
+    let Some(metadata) = head_note_reader() else {
         return Err(CliError::InvalidState(
-            "Not a merge queue draft pull request. \
-             queue-info only works on a merge queue draft pull request."
+            "No merge queue metadata found. queue-info reads the \
+             refs/notes/mergify/<branch> git note the engine attaches to a \
+             merge queue draft branch head; run it on a merge queue batch \
+             build."
                 .to_string(),
         ));
     };
 
     emit_json(output, &metadata)?;
-    // Only the in-CI path emits the GHA output; an explicit PR lookup
-    // is a local/interactive use that shouldn't write workflow outputs.
-    if opts.pull_request.is_none() {
-        write_github_output(&metadata)?;
-    }
+    write_github_output(&metadata)?;
     Ok(())
 }
 
-/// Resolve a token + the right GitHub API base from the PR URL host,
-/// fetch the PR, and run it through the same MQ-draft gate the event
-/// path uses.
-async fn fetch_via_api(
-    pr_ref: &PullRequestRef,
-    token: Option<&str>,
-    output: &mut dyn Output,
-) -> Result<Option<MergeQueueMetadata>, CliError> {
-    let token = auth::resolve_token(token)?;
-    let client = Client::new(github_api_base(&pr_ref.host)?, token, ApiFlavor::GitHub)?;
-    fetch_pr_metadata(&client, pr_ref, output).await
-}
-
-/// Fetch the PR payload and extract its MQ metadata.
+/// Production [`HeadNoteReader`]: read the merge-queue note attached to
+/// the current `HEAD` commit using only plain git, no GitHub token.
 ///
-/// The GitHub PR JSON deserializes straight into [`PullRequest`]
-/// (which ignores unknown fields), so wrapping it in a synthetic
-/// [`GitHubEvent`] lets us reuse [`extract_from_event`] verbatim —
-/// the title/body gate, the stderr warnings, and the `None`-means-
-/// not-an-MQ-draft contract are all shared with the event path.
-async fn fetch_pr_metadata(
-    client: &Client,
-    pr_ref: &PullRequestRef,
-    output: &mut dyn Output,
-) -> Result<Option<MergeQueueMetadata>, CliError> {
-    let path = format!("/repos/{}/pulls/{}", pr_ref.repository, pr_ref.pull_number);
-    let pull_request: PullRequest = client.get(&path).await?;
-    let event = GitHubEvent {
-        pull_request: Some(pull_request),
-        ..Default::default()
-    };
-    Ok(extract_from_event(&event, output)?)
+/// The engine publishes the batch metadata as a git note under
+/// `refs/notes/mergify/<mq_branch>` attached to the MQ branch head
+/// commit. In CI the working tree is checked out at that commit, so we
+/// fetch every `refs/notes/mergify/*` ref and return the note that is
+/// attached to `HEAD`. Enumerating the refs rather than deriving the
+/// branch name keeps this working under a detached `HEAD` (how most
+/// non-GitHub CIs check out a revision) and needs no CI-specific env.
+///
+/// Any git failure (no remote, notes never published, not a repo, a
+/// shallow clone that hid the commit) is swallowed as `None` so the
+/// caller surfaces `INVALID_STATE`.
+#[must_use]
+pub fn real_head_note_reader() -> Option<Value> {
+    // Notes aren't fetched by default, so pull them ourselves. The
+    // wildcard refspec mirrors the engine's `refs/notes/mergify/*`
+    // namespace; `+` force-updates so a re-queued branch's note wins.
+    if !crate::git::succeeds(&[
+        "fetch",
+        "--no-tags",
+        "--quiet",
+        "origin",
+        "+refs/notes/mergify/*:refs/notes/mergify/*",
+    ]) {
+        return None;
+    }
+    let refs =
+        crate::git::capture(&["for-each-ref", "--format=%(refname)", "refs/notes/mergify/"])?;
+    refs.lines()
+        .filter(|r| !r.is_empty())
+        .find_map(|notes_ref| crate::git::read_note(notes_ref, "HEAD"))
 }
 
-/// Map a PR URL host to its GitHub REST API base. `github.com` →
-/// `api.github.com`; any other host is treated as GitHub Enterprise
-/// Server (`https://<host>/api/v3`). Always https — the inverse of
-/// the api→html mapping in `mergify-stack`'s `revision_history`.
-fn github_api_base(host: &str) -> Result<Url, CliError> {
-    // Hosts are case-insensitive, so a pasted `GitHub.com` must still
-    // take the dotcom branch. `host` is already userinfo-free
-    // (`parse_pr_url` rejects `@`), so formatting it into the
-    // authority is safe.
-    let raw = if host.eq_ignore_ascii_case("github.com") {
-        "https://api.github.com/".to_string()
-    } else {
-        format!("https://{host}/api/v3/")
-    };
-    Url::parse(&raw).map_err(|e| CliError::GitHubApi(format!("invalid GitHub host {host:?}: {e}")))
-}
-
-fn emit_json(output: &mut dyn Output, metadata: &MergeQueueMetadata) -> std::io::Result<()> {
+fn emit_json(output: &mut dyn Output, metadata: &Value) -> std::io::Result<()> {
     output.emit(metadata, &mut |w: &mut dyn Write| {
         let rendered = serde_json::to_string_pretty(metadata)
             .map_err(|e| std::io::Error::other(e.to_string()))?;
@@ -131,7 +103,7 @@ fn emit_json(output: &mut dyn Output, metadata: &MergeQueueMetadata) -> std::io:
     })
 }
 
-fn write_github_output(metadata: &MergeQueueMetadata) -> Result<(), CliError> {
+fn write_github_output(metadata: &Value) -> Result<(), CliError> {
     let Some(path) = env::var("GITHUB_OUTPUT").ok().filter(|s| !s.is_empty()) else {
         return Ok(());
     };
@@ -170,215 +142,63 @@ fn random_delimiter_suffix() -> Result<String, CliError> {
 mod tests {
     use mergify_core::ExitCode;
     use mergify_test_support::Captured;
-    use tempfile::TempDir;
-    use wiremock::Mock;
-    use wiremock::MockServer;
-    use wiremock::ResponseTemplate;
-    use wiremock::matchers::header;
-    use wiremock::matchers::method;
-    use wiremock::matchers::path;
+    use serde_json::json;
 
     use super::*;
 
-    fn write_event_file(dir: &TempDir, body: &str, title: &str) -> PathBuf {
-        let path = dir.path().join("event.json");
-        let payload = serde_json::json!({
-            "pull_request": {
-                "title": title,
-                "body": body,
-            },
-        });
-        std::fs::write(&path, serde_json::to_vec(&payload).unwrap()).unwrap();
-        path
+    /// A note carrying fields the CLI doesn't model (`scopes`,
+    /// per-PR `scopes`) — they must still reach the output.
+    fn sample() -> Value {
+        json!({
+            "checking_base_sha": "abc123",
+            "pull_requests": [{"number": 10, "scopes": ["backend"]}],
+            "previous_failed_batches": [],
+            "scopes": ["backend"],
+        })
     }
 
-    fn no_pr() -> QueueInfoOptions<'static> {
-        QueueInfoOptions {
-            pull_request: None,
-            token: None,
-        }
+    fn no_note() -> Option<Value> {
+        None
     }
 
-    /// Build a client pointed at the mock server — the `run`/
-    /// `fetch_via_api` rebuilds the base URL from the PR host
-    /// (discarding the mock server's address), so the per-fetch path
-    /// is exercised through `fetch_pr_metadata` with an injected
-    /// client instead of through `run`.
-    fn mock_client(server: &MockServer) -> Client {
-        Client::new(
-            Url::parse(&server.uri()).unwrap(),
-            "test-token".to_string(),
-            ApiFlavor::GitHub,
-        )
-        .unwrap()
-    }
-
-    #[tokio::test]
-    async fn errors_when_not_in_mq_context() {
+    #[test]
+    fn errors_when_no_note() {
         let mut cap = Captured::human();
-        let err = temp_env::async_with_vars(
-            [
-                ("GITHUB_EVENT_NAME", None::<&str>),
-                ("GITHUB_EVENT_PATH", None),
-            ],
-            async { run(no_pr(), &mut cap.output).await.unwrap_err() },
-        )
-        .await;
+        let err = run_with_reader(&mut cap.output, &no_note).unwrap_err();
         assert!(matches!(err, CliError::InvalidState(_)));
         assert_eq!(err.exit_code(), ExitCode::InvalidState);
     }
 
-    #[tokio::test]
-    async fn prints_metadata_for_mq_pr() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = write_event_file(
-            &dir,
-            "intro\n```yaml\nchecking_base_sha: abc123\npull_requests:\n  - number: 10\n```",
-            "merge queue: batch",
-        );
-
+    #[test]
+    fn prints_whole_note_payload() {
+        let note = || Some(sample());
         let mut cap = Captured::human();
-        temp_env::async_with_vars(
-            [
-                ("GITHUB_EVENT_NAME", Some("pull_request")),
-                ("GITHUB_EVENT_PATH", Some(path.to_str().unwrap())),
-                ("GITHUB_OUTPUT", None),
-            ],
-            async { run(no_pr(), &mut cap.output).await.unwrap() },
-        )
-        .await;
-
+        temp_env::with_var("GITHUB_OUTPUT", None::<&str>, || {
+            run_with_reader(&mut cap.output, &note).unwrap();
+        });
         let stdout = cap.stdout();
         assert!(stdout.contains("\"checking_base_sha\": \"abc123\""));
         assert!(stdout.contains("\"number\": 10"));
+        // Fields the CLI doesn't model are passed through verbatim.
+        assert!(stdout.contains("\"scopes\""), "scopes missing: {stdout}");
+        assert!(
+            stdout.contains("\"backend\""),
+            "scope value missing: {stdout}"
+        );
     }
 
-    #[tokio::test]
-    async fn appends_to_github_output_when_set() {
+    #[test]
+    fn appends_to_github_output_when_set() {
         let dir = tempfile::tempdir().unwrap();
-        let event_path = write_event_file(
-            &dir,
-            "```yaml\nchecking_base_sha: deadbeef\n```",
-            "merge queue: tiny",
-        );
         let gha_output = dir.path().join("gha_output");
-
+        let note = || Some(sample());
         let mut cap = Captured::human();
-        temp_env::async_with_vars(
-            [
-                ("GITHUB_EVENT_NAME", Some("pull_request")),
-                ("GITHUB_EVENT_PATH", Some(event_path.to_str().unwrap())),
-                ("GITHUB_OUTPUT", Some(gha_output.to_str().unwrap())),
-            ],
-            async { run(no_pr(), &mut cap.output).await.unwrap() },
-        )
-        .await;
-
+        temp_env::with_var("GITHUB_OUTPUT", Some(gha_output.to_str().unwrap()), || {
+            run_with_reader(&mut cap.output, &note).unwrap();
+        });
         let written = std::fs::read_to_string(&gha_output).unwrap();
         assert!(written.starts_with("queue_metadata<<ghadelimiter_"));
-        assert!(written.contains("\"checking_base_sha\":\"deadbeef\""));
-    }
-
-    #[test]
-    fn github_api_base_maps_dotcom_to_api_host() {
-        assert_eq!(
-            github_api_base("github.com").unwrap().as_str(),
-            "https://api.github.com/",
-        );
-    }
-
-    #[test]
-    fn github_api_base_maps_ghes_host_to_api_v3() {
-        assert_eq!(
-            github_api_base("ghe.example.com").unwrap().as_str(),
-            "https://ghe.example.com/api/v3/",
-        );
-    }
-
-    #[test]
-    fn github_api_base_matches_dotcom_case_insensitively() {
-        // Hosts are case-insensitive; a pasted `GitHub.com` must not
-        // fall through to the GHES `/api/v3` path.
-        assert_eq!(
-            github_api_base("GitHub.com").unwrap().as_str(),
-            "https://api.github.com/",
-        );
-    }
-
-    fn pr_ref() -> PullRequestRef {
-        PullRequestRef {
-            host: "github.com".to_string(),
-            repository: "owner/repo".to_string(),
-            pull_number: 1234,
-        }
-    }
-
-    #[tokio::test]
-    async fn fetches_pr_and_extracts_metadata() {
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/repos/owner/repo/pulls/1234"))
-            // The resolved token must reach GitHub as a bearer header,
-            // otherwise private-repo lookups would 404.
-            .and(header("Authorization", "Bearer test-token"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "title": "merge queue: batch",
-                "body": "intro\n```yaml\nchecking_base_sha: cafef00d\npull_requests:\n  - number: 7\n```",
-            })))
-            .expect(1)
-            .mount(&server)
-            .await;
-
-        let client = mock_client(&server);
-        let mut cap = Captured::human();
-        let meta = fetch_pr_metadata(&client, &pr_ref(), &mut cap.output)
-            .await
-            .unwrap()
-            .expect("expected MQ metadata");
-        assert_eq!(meta.checking_base_sha, "cafef00d");
-        assert_eq!(meta.pull_requests[0].number, 7);
-    }
-
-    #[tokio::test]
-    async fn fetched_non_mq_pr_yields_none() {
-        // A regular PR (title not `merge queue: …`) must surface as
-        // `None` so `run` maps it to INVALID_STATE — same gate the
-        // event path uses.
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/repos/owner/repo/pulls/1234"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "title": "feat: something",
-                "body": "no metadata here",
-            })))
-            .expect(1)
-            .mount(&server)
-            .await;
-
-        let client = mock_client(&server);
-        let mut cap = Captured::human();
-        let meta = fetch_pr_metadata(&client, &pr_ref(), &mut cap.output)
-            .await
-            .unwrap();
-        assert!(meta.is_none(), "got: {meta:?}");
-    }
-
-    #[tokio::test]
-    async fn fetched_pr_api_error_propagates() {
-        // A GitHub API failure (e.g. 404 for a wrong PR number) must
-        // surface as a GitHubApi error, not a silent None.
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/repos/owner/repo/pulls/1234"))
-            .respond_with(ResponseTemplate::new(404).set_body_string("Not Found"))
-            .mount(&server)
-            .await;
-
-        let client = mock_client(&server);
-        let mut cap = Captured::human();
-        let err = fetch_pr_metadata(&client, &pr_ref(), &mut cap.output)
-            .await
-            .unwrap_err();
-        assert!(matches!(err, CliError::GitHubApi(_)), "got: {err:?}");
+        assert!(written.contains("\"checking_base_sha\":\"abc123\""));
+        assert!(written.contains("\"scopes\":[\"backend\"]"));
     }
 }

--- a/crates/mergify-ci/src/queue_metadata.rs
+++ b/crates/mergify-ci/src/queue_metadata.rs
@@ -1,18 +1,17 @@
 //! Extract merge-queue batch metadata from a GitHub event payload.
 //!
-//! Mirrors `mergify_cli.ci.queue.metadata`. The engine publishes the
-//! batch info as a ```yaml``` fenced block inside the MQ draft PR
-//! body. `detect` returns `None` when the current event has no such
-//! metadata — callers either fall back to other detection paths
-//! (`git_refs`) or surface it as an `INVALID_STATE` (`queue_info`).
+//! The engine embeds the batch info as a ```yaml``` fenced block inside
+//! the MQ draft PR body. [`extract_from_event`] reads it from a
+//! pull-request event and returns `None` when the event isn't an MQ
+//! draft or has no metadata; `git_refs` uses it as one of its base-SHA
+//! detection paths. (`queue-info` itself no longer reads the PR body —
+//! it reads the engine's git note; see `queue_info`.)
 
 use mergify_core::Output;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::github_event::GitHubEvent;
-use crate::github_event::PULL_REQUEST_EVENTS;
-use crate::github_event::load as load_event;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MergeQueuePullRequest {
@@ -87,21 +86,6 @@ pub fn extract_from_event(
         )?;
     }
     Ok(parsed)
-}
-
-/// Load the current event and extract merge-queue metadata.
-///
-/// Returns `None` when not in a pull-request event or when no MQ
-/// metadata is attached to the event's PR. Callers decide how to
-/// treat that `None` (skip, error, fall back).
-pub fn detect(output: &mut dyn Output) -> std::io::Result<Option<MergeQueueMetadata>> {
-    let Some((event_name, event)) = load_event() else {
-        return Ok(None);
-    };
-    if !PULL_REQUEST_EVENTS.contains(&event_name.as_str()) {
-        return Ok(None);
-    }
-    extract_from_event(&event, output)
 }
 
 #[cfg(test)]

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -17,7 +17,6 @@ use clap::Subcommand;
 use mergify_ci::git_refs::Format as GitRefsFormat;
 use mergify_ci::git_refs::GitRefsOptions;
 use mergify_ci::junit_process::JunitProcessOptions;
-use mergify_ci::queue_info::QueueInfoOptions;
 use mergify_ci::scopes_send::ScopesSendOptions;
 use mergify_ci::tests_quarantine::GetOptions;
 use mergify_ci::tests_quarantine::QuarantineOptions;
@@ -161,7 +160,7 @@ enum NativeCommand {
     CiGitRefs {
         format: GitRefsFormat,
     },
-    CiQueueInfo(CiQueueInfoOpts),
+    CiQueueInfo,
     CiJunitProcess(CiJunitProcessOpts),
     /// Deprecated alias for `CiJunitProcess`. Same orchestrator,
     /// same args; the dispatcher prints a deprecation warning to
@@ -480,11 +479,6 @@ struct CiScopesOpts {
     base: Option<String>,
     head: Option<String>,
     write: Option<PathBuf>,
-}
-
-struct CiQueueInfoOpts {
-    pull_request: Option<PullRequestRef>,
-    token: Option<String>,
 }
 
 struct CiScopesSendOpts {
@@ -1052,15 +1046,8 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
             command: CiSubcommand::GitRefs(GitRefsCliArgs { format }),
         }) => Dispatch::Native(NativeCommand::CiGitRefs { format }),
         Subcommands::Ci(CiArgs {
-            command:
-                CiSubcommand::QueueInfo(QueueInfoCliArgs {
-                    pull_request,
-                    token,
-                }),
-        }) => Dispatch::Native(NativeCommand::CiQueueInfo(CiQueueInfoOpts {
-            pull_request,
-            token,
-        })),
+            command: CiSubcommand::QueueInfo(QueueInfoCliArgs {}),
+        }) => Dispatch::Native(NativeCommand::CiQueueInfo),
         Subcommands::Tests(TestsArgs {
             command:
                 TestsSubcommand::Show(TestsShowCliArgs {
@@ -1532,15 +1519,8 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 mergify_ci::git_refs::run(&GitRefsOptions { format }, &mut output)
                     .map(|()| mergify_core::ExitCode::Success)
             }
-            NativeCommand::CiQueueInfo(opts) => mergify_ci::queue_info::run(
-                QueueInfoOptions {
-                    pull_request: opts.pull_request.as_ref(),
-                    token: opts.token.as_deref(),
-                },
-                &mut output,
-            )
-            .await
-            .map(|()| mergify_core::ExitCode::Success),
+            NativeCommand::CiQueueInfo => mergify_ci::queue_info::run(&mut output)
+                .map(|()| mergify_core::ExitCode::Success),
             NativeCommand::CiJunitProcess(opts) => {
                 mergify_ci::junit_process::run(
                     JunitProcessOptions {
@@ -3542,7 +3522,8 @@ enum CiSubcommand {
     /// Print the base/head git references for the current build.
     #[command(name = "git-refs")]
     GitRefs(GitRefsCliArgs),
-    /// Print the merge queue batch metadata for a merge queue draft PR.
+    /// Print the current build's merge queue batch metadata (from the
+    /// Mergify git note).
     #[command(name = "queue-info")]
     QueueInfo(QueueInfoCliArgs),
     /// Give the list of scopes impacted by changed files.
@@ -3569,20 +3550,11 @@ struct GitRefsCliArgs {
     format: GitRefsFormat,
 }
 
+/// `queue-info` reads the `refs/notes/mergify/<branch>` git note
+/// Mergify writes for the current `HEAD`, so it takes no arguments and
+/// needs no GitHub token — plain git in any CI.
 #[derive(clap::Args)]
-struct QueueInfoCliArgs {
-    /// Pull request URL (e.g. <https://github.com/owner/repo/pull/123>).
-    /// When omitted, reads the metadata from the CI event payload
-    /// (`GITHUB_EVENT_PATH`) — the in-CI default.
-    #[arg(value_name = "PULL_REQUEST_URL", value_parser = mergify_core::pull_request::parse_pr_url)]
-    pull_request: Option<PullRequestRef>,
-
-    /// GitHub token used to fetch the pull request. Falls back to
-    /// ``MERGIFY_TOKEN``, then ``GITHUB_TOKEN``, then `gh auth token`.
-    /// Only used when a pull request URL is given.
-    #[arg(long, short = 't')]
-    token: Option<String>,
-}
+struct QueueInfoCliArgs {}
 
 #[derive(clap::Args)]
 struct ScopesCliArgs {

--- a/crates/mergify-core/src/pull_request.rs
+++ b/crates/mergify-core/src/pull_request.rs
@@ -1,9 +1,9 @@
 //! Parse a GitHub-style pull-request URL into its parts.
 //!
 //! Shared by every command that takes a PR URL on the command line
-//! (`config simulate`, `ci queue-info`). Lives in `mergify-core`
-//! next to `auth`/`http` rather than in any one command crate so
-//! both call sites use a single parser instead of copies.
+//! (currently `config simulate`). Lives in `mergify-core` next to
+//! `auth`/`http` rather than in any one command crate so all call
+//! sites use a single parser instead of copies.
 
 /// The `(host, owner/repo, number)` triple parsed from a pull-request
 /// URL.
@@ -45,8 +45,8 @@ pub fn parse_pr_url(url: &str) -> Result<PullRequestRef, String> {
         return Err(format!("Invalid pull request URL: {url}"));
     }
     // A real GitHub PR URL has a bare host with no userinfo. Reject
-    // `user@host` shapes: a host segment is later used as the GitHub
-    // API authority (see `mergify-ci`'s `github_api_base`), and
+    // `user@host` shapes: a host segment can later be used to build an
+    // API authority (e.g. `config simulate`'s client), and
     // `https://github.com@evil.com/...` parses to host `evil.com` with
     // `github.com` as decoy userinfo — which would send the bearer
     // token to the attacker host.

--- a/skills/mergify-ci/SKILL.md
+++ b/skills/mergify-ci/SKILL.md
@@ -17,7 +17,7 @@ mergify ci junit-upload FILES...          # (Deprecated) Use junit-process inste
 mergify ci git-refs                       # Detect base/head git references for the current PR
 mergify ci scopes --config PATH           # Detect scopes impacted by changed files
 mergify ci scopes-send -s SCOPE           # Send scopes tied to a pull request to Mergify
-mergify ci queue-info                     # Output merge queue batch metadata from the current PR event
+mergify ci queue-info                     # Output the current build's merge queue batch metadata (from the git note)
 mergify tests show NAME...                # Look up tests by name and print health, ratios, last failure
 mergify tests quarantines add NAME        # Add a test to the CI Insights quarantine
 mergify tests quarantines remove NAME     # Remove a test from the CI Insights quarantine
@@ -296,24 +296,20 @@ A null `branch` renders as `*` (the quarantine applies to all branches).
 
 ## Queue Info (`queue-info`)
 
-Outputs merge queue batch metadata as JSON. Only works on merge queue draft pull requests; exits `INVALID_STATE` (7) otherwise.
+Outputs the current build's merge queue batch metadata as JSON. Reads the `refs/notes/mergify/<branch>` git note Mergify writes on the merge queue branch head for the current `HEAD`; exits `INVALID_STATE` (7) when no note is found (i.e. not a merge queue batch build). Takes no arguments and needs no GitHub token.
 
-Two ways to point it at a PR:
+The note's full payload is emitted verbatim (every field Mergify wrote, e.g. `checking_base_sha`, `pull_requests` with per-PR `scopes`, `previous_failed_batches`, top-level `scopes`). New fields appear automatically without a CLI update, so don't assume a fixed schema.
 
 ```bash
-# In CI: read the MQ draft PR from the GitHub Actions event payload.
-# Also writes the metadata to GITHUB_OUTPUT when running in GitHub Actions.
+# In CI, on a merge queue batch build. Works in any CI (GitHub Actions,
+# GitLab, CircleCI, Jenkins, ...) with plain git. When GITHUB_OUTPUT is
+# set (GitHub Actions runner) it also writes the metadata there.
 mergify ci queue-info
-
-# Anywhere: fetch the PR via the GitHub API by URL. Does NOT write
-# GITHUB_OUTPUT (it's a local/interactive lookup). The URL host drives
-# the API base (github.com or a GitHub Enterprise Server host).
-mergify ci queue-info https://github.com/owner/repo/pull/1234
 ```
 
-The URL form needs a GitHub token: `--token`/`-t`, else `MERGIFY_TOKEN`, then `GITHUB_TOKEN`, then `gh auth token`. It errors clearly when none is available.
+Mergify attaches the batch metadata as a git note to the MQ branch head commit, so reading it needs only git, no PR body and no GitHub token. The command runs `git fetch origin "refs/notes/mergify/*"` itself (notes aren't fetched by default), then returns the note attached to `HEAD`. Requirements: the `origin` remote is reachable and the checkout is at the MQ branch head commit, which is the normal state inside a merge-queue CI run. A detached HEAD is fine.
 
-This command is useful in CI workflows that need to know whether the current run is part of a merge queue batch and what other PRs are in the batch, and for inspecting a batch by URL from your laptop.
+This command is useful in CI workflows that need to know whether the current run is part of a merge queue batch and what other PRs are in the batch.
 
 ## Common Patterns
 


### PR DESCRIPTION
`mergify ci queue-info` read the merge-queue batch metadata from the
GitHub PR body — via the GHA event payload (no-arg) and a GitHub API
fetch by PR URL. Both are GitHub-specific and need a token.

The engine publishes the same TrainInfo YAML as a git note under
`refs/notes/mergify/<mq_branch>` on the MQ branch head commit, precisely
so CI providers can read it with plain git and no token. Make queue-info
read only that note for the current HEAD, dropping the PR-body and
PR-URL paths entirely. It now works in any CI (GitHub Actions, GitLab,
CircleCI, Jenkins, ...), takes no arguments and needs no token.

- Emit the note's full payload verbatim as JSON, parsed into a generic
  value rather than a fixed struct, so every engine field (top-level and
  per-PR `scopes`, and anything added later) shows up without a CLI
  change.
- Enumerate `refs/notes/mergify/*` and return the note attached to HEAD
  instead of deriving the branch name, so it works under a detached HEAD
  (how most non-GitHub CIs check out a revision) with no CI-specific env.
- Share the note read + git plumbing via `mergify-ci/src/git.rs`
  (`read_note`, `succeeds`, `capture`); `git_refs::real_notes_reader`
  reads the same note and pulls just `checking_base_sha`. Drop the
  now-unused `queue_metadata::detect` and the dead `parse_notes_payload`.

Fixes MRGFY-7664

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>