### PR TITLE
fix(release): embed version in binary asset names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,8 +151,11 @@ jobs:
           target=$(rustc -vV | awk '/^host:/ {print $2}')
           echo "Building fixture for target: ${target}"
           mkdir -p fixture/release
-          tar -C target/release -czf "fixture/release/mergify-${target}.tar.gz" mergify
-          (cd fixture/release && shasum -a 256 "mergify-${target}.tar.gz" > SHA256SUMS)
+          # install.sh resolves the version from latest-release.json (fixture
+          # mode) before building the per-version asset name.
+          echo '{"tag_name":"2099.1.1.1"}' > fixture/release/latest-release.json
+          tar -C target/release -czf "fixture/release/mergify-2099.1.1.1-${target}.tar.gz" mergify
+          (cd fixture/release && shasum -a 256 "mergify-2099.1.1.1-${target}.tar.gz" > SHA256SUMS)
           ls -la fixture/release
 
       - name: Serve fixture
@@ -193,7 +196,7 @@ jobs:
         run: |
           set -euo pipefail
           target=$(rustc -vV | awk '/^host:/ {print $2}')
-          asset="mergify-${target}.tar.gz"
+          asset="mergify-2099.1.1.1-${target}.tar.gz"
           # Keep a clean copy so the malformed test below can write
           # its own bad version without losing the original.
           cp fixture/release/SHA256SUMS fixture/release/SHA256SUMS.orig
@@ -263,8 +266,8 @@ jobs:
           # Pretend a far-future release is available so the
           # `current == latest` short-circuit doesn't fire.
           echo '{"tag_name":"2099.1.1.1"}' > fixture/su/latest-release.json
-          tar -C target/release -czf "fixture/su/mergify-${target}.tar.gz" mergify
-          (cd fixture/su && shasum -a 256 "mergify-${target}.tar.gz" > SHA256SUMS)
+          tar -C target/release -czf "fixture/su/mergify-2099.1.1.1-${target}.tar.gz" mergify
+          (cd fixture/su && shasum -a 256 "mergify-2099.1.1.1-${target}.tar.gz" > SHA256SUMS)
           ls -la fixture/su
 
       - name: Serve fixture
@@ -304,7 +307,7 @@ jobs:
           cp target/release/mergify /tmp/mergify-su-tamper
           before=$(shasum -a 256 /tmp/mergify-su-tamper | awk '{print $1}')
           # Replace SHA256SUMS with a wrong-but-well-formed hash.
-          printf '%064d  mergify-%s.tar.gz\n' 0 "${target}" > fixture/su/SHA256SUMS
+          printf '%064d  mergify-2099.1.1.1-%s.tar.gz\n' 0 "${target}" > fixture/su/SHA256SUMS
           ! MERGIFY_BASE_URL=http://127.0.0.1:8766 /tmp/mergify-su-tamper self-update \
               > /tmp/su-tamper.log 2>&1
           grep -q 'checksum mismatch' /tmp/su-tamper.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ name: release
 #   Maintainer opens Actions → "release" → "Run workflow" → enters
 #   the tag (e.g. `2026.6.12.1`). The workflow builds the wheel
 #   matrix, extracts the binary from each wheel, packages
-#   `mergify-<target>.{tar.gz,zip}` + `SHA256SUMS`, and creates the
+#   `mergify-<version>-<target>.{tar.gz,zip}` + `SHA256SUMS`, and creates the
 #   GitHub Release as a *draft* with all assets attached and notes
 #   auto-generated from the commit log via `--generate-notes`.
 #
@@ -167,13 +167,15 @@ jobs:
 
       # Each `wheel-<target>` artifact is a maturin-built wheel with
       # the `mergify` binary at `<dist>.data/scripts/mergify[.exe]`.
-      # Extract it, normalise into `mergify-<target>.{tar.gz,zip}`,
-      # then hash the lot with sha256 so the installer can verify
-      # what it pulled. Stable names (no embedded version) so the
-      # `releases/latest/download/...` redirect keeps working for
-      # the `install.sh` consumers — the version is still observable
-      # via `mergify --version` after install.
+      # Extract it, normalise into
+      # `mergify-<version>-<target>.{tar.gz,zip}`, then hash the lot
+      # with sha256 so the installer can verify what it pulled.
+      # Embedding the version (before the Rust triple) lets
+      # Homebrew's dotted-version parser win over the fallback stem
+      # regex that would otherwise mangle `x86_64` assets.
       - name: Extract binaries and repack
+        env:
+          INPUT_TAG: ${{ needs.compute-tag.outputs.tag }}
         shell: bash
         run: |
           set -euo pipefail
@@ -199,10 +201,10 @@ jobs:
             # want `<bin>` extracted at the workdir root.
             unzip -joq "${whl}" "*/scripts/${bin}" -d "${workdir}"
             if [[ "${target}" == *windows* ]]; then
-              (cd "${workdir}" && zip -q "${OLDPWD}/dist/mergify-${target}.zip" "${bin}")
+              (cd "${workdir}" && zip -q "${OLDPWD}/dist/mergify-${INPUT_TAG}-${target}.zip" "${bin}")
             else
               chmod +x "${workdir}/${bin}"
-              tar -C "${workdir}" -czf "dist/mergify-${target}.tar.gz" "${bin}"
+              tar -C "${workdir}" -czf "dist/mergify-${INPUT_TAG}-${target}.tar.gz" "${bin}"
             fi
             rm -rf "${workdir}"
           done
@@ -270,11 +272,11 @@ jobs:
           printf '  %s\n' "${attached[@]}"
 
           expected=(
-            mergify-x86_64-unknown-linux-gnu.tar.gz
-            mergify-aarch64-unknown-linux-gnu.tar.gz
-            mergify-x86_64-apple-darwin.tar.gz
-            mergify-aarch64-apple-darwin.tar.gz
-            mergify-x86_64-pc-windows-msvc.zip
+            "mergify-${tag}-x86_64-unknown-linux-gnu.tar.gz"
+            "mergify-${tag}-aarch64-unknown-linux-gnu.tar.gz"
+            "mergify-${tag}-x86_64-apple-darwin.tar.gz"
+            "mergify-${tag}-aarch64-apple-darwin.tar.gz"
+            "mergify-${tag}-x86_64-pc-windows-msvc.zip"
             SHA256SUMS
           )
           missing=()

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ or pin a version with `MERGIFY_VERSION=2026.4.23.1`. Once installed, upgrade wit
 For Windows, or to bypass the script, grab the matching archive from the
 [latest release](https://github.com/Mergifyio/mergify-cli/releases/latest):
 
-- **Windows** — download `mergify-x86_64-pc-windows-msvc.zip`, extract it,
-  and put `mergify.exe` anywhere on your `PATH`.
-- **Linux / macOS** — download `mergify-<target>.tar.gz` (e.g.
-  `mergify-aarch64-apple-darwin.tar.gz`), extract with `tar -xzf`, and put
-  the resulting `mergify` binary anywhere on your `PATH`.
+- **Windows** — download `mergify-<version>-x86_64-pc-windows-msvc.zip`,
+  extract it, and put `mergify.exe` anywhere on your `PATH`.
+- **Linux / macOS** — download `mergify-<version>-<target>.tar.gz` (e.g.
+  `mergify-2026.4.23.1-aarch64-apple-darwin.tar.gz`), extract with `tar -xzf`,
+  and put the resulting `mergify` binary anywhere on your `PATH`.
 
 Verify against `SHA256SUMS` from the same release if you care.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,12 +30,12 @@ minutes.
 1. Go to **Releases** → the new draft.
 2. Review the auto-generated notes; edit if needed (drafts are
    mutable).
-3. Confirm all six asset names are listed:
-   - `mergify-x86_64-unknown-linux-gnu.tar.gz`
-   - `mergify-aarch64-unknown-linux-gnu.tar.gz`
-   - `mergify-x86_64-apple-darwin.tar.gz`
-   - `mergify-aarch64-apple-darwin.tar.gz`
-   - `mergify-x86_64-pc-windows-msvc.zip`
+3. Confirm all six asset names are listed (each prefixed with the release version):
+   - `mergify-<version>-x86_64-unknown-linux-gnu.tar.gz`
+   - `mergify-<version>-aarch64-unknown-linux-gnu.tar.gz`
+   - `mergify-<version>-x86_64-apple-darwin.tar.gz`
+   - `mergify-<version>-aarch64-apple-darwin.tar.gz`
+   - `mergify-<version>-x86_64-pc-windows-msvc.zip`
    - `SHA256SUMS`
 4. Click **Publish release**.
 

--- a/crates/mergify-cli/src/self_update.rs
+++ b/crates/mergify-cli/src/self_update.rs
@@ -13,8 +13,8 @@
 //!    tag.
 //! 2. If `tag == crate::VERSION` and `--force` wasn't passed,
 //!    print "already up to date" and return.
-//! 3. Download `mergify-<target>.tar.gz` + `SHA256SUMS` from the
-//!    matching release.
+//! 3. Download `mergify-<version>-<target>.{tar.gz,zip}` + `SHA256SUMS`
+//!    from the matching release (`.zip` on Windows, `.tar.gz` elsewhere).
 //! 4. Verify the asset SHA256 against `SHA256SUMS`. Mirrors
 //!    `install.sh`'s line-shape validation so a malformed
 //!    `SHA256SUMS` can't slip past.
@@ -110,7 +110,7 @@ pub async fn run(opts: &Options) -> Result<(), CliError> {
     // extension is determined by `cfg!(windows)` here, not by
     // target string-sniffing.
     let ext = if cfg!(windows) { "zip" } else { "tar.gz" };
-    let asset = format!("mergify-{target}.{ext}");
+    let asset = format!("mergify-{latest}-{target}.{ext}");
     let ep = endpoints(&latest);
     let archive = download(&client, &format!("{}/{asset}", ep.asset_base)).await?;
     let sums = download_text(&client, &format!("{}/SHA256SUMS", ep.asset_base)).await?;
@@ -219,7 +219,7 @@ fn hex_encode(bytes: &[u8]) -> String {
 /// `asset_name` in `SHA256SUMS`. Mirrors `install.sh` exactly: the
 /// line must split as `<hash> <name>` on whitespace where the
 /// second field equals `asset_name` *literally* (not `ends_with`,
-/// so `mergify-fooX-target.tar.gz` can't accidentally pass the
+/// so `mergify-2099.1.1.1-fooX-target.tar.gz` can't accidentally pass the
 /// check for `target.tar.gz`), and the hash field must be 64 hex
 /// chars. Both layers fail closed.
 fn verify_checksum(archive: &[u8], asset_name: &str, sums: &str) -> Result<(), CliError> {
@@ -364,25 +364,38 @@ mod tests {
         let mut h = Sha256::new();
         h.update(&archive);
         let hash = hex_encode(&h.finalize());
-        let sums = format!("{hash}  mergify-x86_64-unknown-linux-gnu.tar.gz\n");
-        verify_checksum(&archive, "mergify-x86_64-unknown-linux-gnu.tar.gz", &sums).unwrap();
+        let sums = format!("{hash}  mergify-2099.1.1.1-x86_64-unknown-linux-gnu.tar.gz\n");
+        verify_checksum(
+            &archive,
+            "mergify-2099.1.1.1-x86_64-unknown-linux-gnu.tar.gz",
+            &sums,
+        )
+        .unwrap();
     }
 
     #[test]
     fn verify_checksum_rejects_mismatch() {
         let archive = fixture_archive();
         let wrong = "0".repeat(64);
-        let sums = format!("{wrong}  mergify-x86_64-unknown-linux-gnu.tar.gz\n");
-        let err = verify_checksum(&archive, "mergify-x86_64-unknown-linux-gnu.tar.gz", &sums)
-            .unwrap_err();
+        let sums = format!("{wrong}  mergify-2099.1.1.1-x86_64-unknown-linux-gnu.tar.gz\n");
+        let err = verify_checksum(
+            &archive,
+            "mergify-2099.1.1.1-x86_64-unknown-linux-gnu.tar.gz",
+            &sums,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("checksum mismatch"));
     }
 
     #[test]
     fn verify_checksum_rejects_missing_entry() {
-        let sums = "deadbeef  mergify-aarch64-apple-darwin.tar.gz\n";
-        let err =
-            verify_checksum(&[], "mergify-x86_64-unknown-linux-gnu.tar.gz", sums).unwrap_err();
+        let sums = "deadbeef  mergify-2099.1.1.1-aarch64-apple-darwin.tar.gz\n";
+        let err = verify_checksum(
+            &[],
+            "mergify-2099.1.1.1-x86_64-unknown-linux-gnu.tar.gz",
+            sums,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("no checksum entry"));
     }
 
@@ -390,15 +403,15 @@ mod tests {
     fn verify_checksum_does_not_accept_suffix_match() {
         // Regression for the pre-fix `ends_with` lookup: a sibling
         // asset whose name *ends in* `asset_name` (here
-        // `mergify-x86_64-pc-windows-msvc.zip` ending in `.zip`)
-        // could be matched and pass even when the requested asset
-        // wasn't in the file. The literal second-field match must
-        // reject this.
+        // `mergify-2099.1.1.1-x86_64-pc-windows-msvc.zip` ending in
+        // `.zip`) could be matched and pass even when the requested
+        // asset wasn't in the file. The literal second-field match
+        // must reject this.
         let archive = fixture_archive();
         let mut h = Sha256::new();
         h.update(&archive);
         let hash = hex_encode(&h.finalize());
-        let sums = format!("{hash}  mergify-x86_64-pc-windows-msvc.zip\n");
+        let sums = format!("{hash}  mergify-2099.1.1.1-x86_64-pc-windows-msvc.zip\n");
         let err = verify_checksum(&archive, "msvc.zip", &sums).unwrap_err();
         assert!(
             err.to_string().contains("no checksum entry"),
@@ -417,9 +430,13 @@ mod tests {
         let mut h = Sha256::new();
         h.update(&archive);
         let hash = hex_encode(&h.finalize());
-        let sums = format!("{hash}  mergify-x86_64-unknown-linux-gnu.tar.gz extra\n");
-        let err = verify_checksum(&archive, "mergify-x86_64-unknown-linux-gnu.tar.gz", &sums)
-            .unwrap_err();
+        let sums = format!("{hash}  mergify-2099.1.1.1-x86_64-unknown-linux-gnu.tar.gz extra\n");
+        let err = verify_checksum(
+            &archive,
+            "mergify-2099.1.1.1-x86_64-unknown-linux-gnu.tar.gz",
+            &sums,
+        )
+        .unwrap_err();
         assert!(
             err.to_string().contains("no checksum entry"),
             "expected 'no checksum entry', got: {err}",
@@ -431,9 +448,13 @@ mod tests {
         // Right asset name, wrong-shape hash. install.sh validates
         // the same way so a corrupted SHA256SUMS can't slip past
         // sha256sum's warn-but-pass behaviour; mirror it here.
-        let sums = "bogus  mergify-x86_64-unknown-linux-gnu.tar.gz\n";
-        let err =
-            verify_checksum(&[], "mergify-x86_64-unknown-linux-gnu.tar.gz", sums).unwrap_err();
+        let sums = "bogus  mergify-2099.1.1.1-x86_64-unknown-linux-gnu.tar.gz\n";
+        let err = verify_checksum(
+            &[],
+            "mergify-2099.1.1.1-x86_64-unknown-linux-gnu.tar.gz",
+            sums,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("malformed checksum entry"));
     }
 

--- a/install.sh
+++ b/install.sh
@@ -23,11 +23,6 @@ set -eu
 REPO="Mergifyio/mergify-cli"
 INSTALL_DIR="${MERGIFY_INSTALL_DIR:-${HOME}/.local/bin}"
 VERSION="${MERGIFY_VERSION:-latest}"
-if [ "${VERSION}" = "latest" ]; then
-    BASE_URL="${MERGIFY_BASE_URL:-https://github.com/${REPO}/releases/latest/download}"
-else
-    BASE_URL="${MERGIFY_BASE_URL:-https://github.com/${REPO}/releases/download/${VERSION}}"
-fi
 
 die() {
     printf 'error: %s\n' "$1" >&2
@@ -72,8 +67,31 @@ main() {
     command -v curl > /dev/null 2>&1 || die "curl is required"
     command -v tar  > /dev/null 2>&1 || die "tar is required"
 
+    # Resolve VERSION to the actual tag so we can embed it in the
+    # asset filename. When MERGIFY_BASE_URL is set (fixture mode used
+    # by the CI smoke test) the fixture already serves a
+    # `latest-release.json` stub; otherwise call the GitHub API.
+    if [ "${VERSION}" = "latest" ]; then
+        if [ -n "${MERGIFY_BASE_URL:-}" ]; then
+            # Fixture mode: the stub JSON lives next to the assets.
+            VERSION=$(curl -fsSL "${MERGIFY_BASE_URL}/latest-release.json" \
+                | grep -o '"tag_name":[[:space:]]*"[^"]*"' \
+                | sed 's/.*"tag_name":[[:space:]]*"//; s/".*//')
+        else
+            VERSION=$(curl -fsSL \
+                "https://api.github.com/repos/${REPO}/releases/latest" \
+                | grep -o '"tag_name":[[:space:]]*"[^"]*"' \
+                | sed 's/.*"tag_name":[[:space:]]*"//; s/".*//')
+        fi
+        [ -n "${VERSION}" ] || die "could not resolve latest release version"
+    fi
+
+    # With the version known, build the per-version asset name and
+    # the base URL for this release.
+    BASE_URL="${MERGIFY_BASE_URL:-https://github.com/${REPO}/releases/download/${VERSION}}"
+
     target=$(detect_target)
-    asset="mergify-${target}.tar.gz"
+    asset="mergify-${VERSION}-${target}.tar.gz"
     url="${BASE_URL}/${asset}"
     sums_url="${BASE_URL}/SHA256SUMS"
 


### PR DESCRIPTION
## Summary

Homebrew's URL→version detection misparses the **x86_64** release assets: `mergify-x86_64-unknown-linux-gnu.tar.gz` is read as version `64-unknown-linux-gnu` (a fallback stem regex grabs the `_64` before the GitHub release-path parser runs). `aarch64` parses fine, so only amd64 breaks. This blocks the Homebrew tap's `brew audit --strict`.

**Fix:** embed the release version *before* the Rust target triple — `mergify-<version>-<triple>.{tar.gz,zip}` — so Homebrew's dotted-version parser wins on every arch. The tap then auto-detects the version from the URL (no explicit `version` line, no misparse, no "redundant version" complaint).

## Changes
- **`release.yml`** — repack emits `mergify-${tag}-${target}.{tar.gz,zip}`; `SHA256SUMS` + asset-presence check follow.
- **`self_update.rs`** — builds `mergify-{latest}-{target}.{ext}` (already resolves the latest tag); tests updated.
- **`install.sh`** — resolves the latest tag (GitHub API, or a `latest-release.json` stub in fixture mode) before constructing the per-version asset name. (The `releases/latest/download/<asset>` redirect can't be used once the version is in the filename.)
- **`ci.yaml`** — install/self-update fixtures use the new names + serve `latest-release.json`.
- **`README.md` / `RELEASING.md`** — documented asset names updated.

Complementary to #1602 (which fixes the Linux binaries self-reporting `0.0.0`): #1602 fixes `mergify --version`; this fixes Homebrew's URL parsing.