### PR TITLE
feat(release): attach the CLI schema as a release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,9 @@ name: release
 #   Maintainer opens Actions → "release" → "Run workflow" → enters
 #   the tag (e.g. `2026.6.12.1`). The workflow builds the wheel
 #   matrix, extracts the binary from each wheel, packages
-#   `mergify-<version>-<target>.{tar.gz,zip}` + `SHA256SUMS`, and creates the
-#   GitHub Release as a *draft* with all assets attached and notes
+#   `mergify-<version>-<target>.{tar.gz,zip}` + `SHA256SUMS`, dumps
+#   the CLI schema to `cli-schema.json`, and creates the GitHub
+#   Release as a *draft* with all assets attached and notes
 #   auto-generated from the commit log via `--generate-notes`.
 #
 # Stage 2 — publish-stable (`release: published`):
@@ -212,6 +213,26 @@ jobs:
           echo "Built release assets:"
           ls -la dist
 
+      # Dump the CLI schema straight off the released binary so the
+      # docs site renders the command reference from the same artifact
+      # it ships — it can't drift from the binary. The x86_64 Linux
+      # wheel's binary runs natively on the ubuntu-24.04 runner. Stable
+      # filename (the version is carried inside, under `cli.version`)
+      # so docs tooling can fetch it off the latest release without
+      # resolving the tag. Not added to SHA256SUMS — that file is the
+      # installer's binary-integrity manifest, not a docs artifact.
+      - name: Dump CLI schema
+        shell: bash
+        run: |
+          set -euo pipefail
+          whl=$(ls artifacts/wheel-x86_64-unknown-linux-gnu/*.whl | head -1)
+          workdir=$(mktemp -d)
+          unzip -joq "${whl}" "*/scripts/mergify" -d "${workdir}"
+          chmod +x "${workdir}/mergify"
+          "${workdir}/mergify" _internal dump-cli-schema > dist/cli-schema.json
+          rm -rf "${workdir}"
+          echo "Wrote dist/cli-schema.json ($(wc -c < dist/cli-schema.json) bytes)"
+
       - name: Create draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -278,10 +299,11 @@ jobs:
             "mergify-${tag}-aarch64-apple-darwin.tar.gz"
             "mergify-${tag}-x86_64-pc-windows-msvc.zip"
             SHA256SUMS
+            cli-schema.json
           )
           missing=()
           for asset in "${expected[@]}"; do
-            printf '%s\n' "${attached[@]}" | grep -qx "$asset" || missing+=("$asset")
+            printf '%s\n' "${attached[@]}" | grep -qxF "$asset" || missing+=("$asset")
           done
           if (( ${#missing[@]} > 0 )); then
             cat <<EOF >&2

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,28 +19,31 @@ before the maintainer clicks Publish.
 
 The workflow builds the wheel matrix (Linux x86_64/aarch64, macOS
 x86_64/aarch64, Windows x86_64), extracts the `mergify` binary out
-of each, packages `mergify-<target>.{tar.gz,zip}` + `SHA256SUMS`,
-and runs `gh release create <tag> --draft --generate-notes` to
-create the release with the assets attached and notes
-auto-generated from PRs merged since the previous tag. Takes ~10
-minutes.
+of each, packages `mergify-<version>-<target>.{tar.gz,zip}` +
+`SHA256SUMS`, dumps the CLI schema to `cli-schema.json` (rendered
+by the docs site into the command reference), and runs `gh release
+create <tag> --draft --generate-notes` to create the release with
+the assets attached and notes auto-generated from PRs merged since
+the previous tag. Takes ~10 minutes.
 
 ## Stage 2 — review and publish
 
 1. Go to **Releases** → the new draft.
 2. Review the auto-generated notes; edit if needed (drafts are
    mutable).
-3. Confirm all six asset names are listed (each prefixed with the release version):
+3. Confirm all seven asset names are listed (the binaries are each
+   prefixed with the release version):
    - `mergify-<version>-x86_64-unknown-linux-gnu.tar.gz`
    - `mergify-<version>-aarch64-unknown-linux-gnu.tar.gz`
    - `mergify-<version>-x86_64-apple-darwin.tar.gz`
    - `mergify-<version>-aarch64-apple-darwin.tar.gz`
    - `mergify-<version>-x86_64-pc-windows-msvc.zip`
    - `SHA256SUMS`
+   - `cli-schema.json`
 4. Click **Publish release**.
 
 Publishing fires `release: published`, which kicks the second half
-of the workflow: assert all six assets are present, rebuild wheels
+of the workflow: assert all seven assets are present, rebuild wheels
 with the same version stamp, and publish to PyPI through
 Trusted-Publisher. Takes ~10 minutes.
 


### PR DESCRIPTION
The draft stage runs the released x86_64 Linux binary's
`_internal dump-cli-schema` and attaches the output as
`cli-schema.json`, so the docs site renders the command reference
from the same artifact the release ships — it can't drift from the
binary. The version is carried inside under `cli.version`, so the
filename stays stable across releases for "latest" fetching.

Kept out of SHA256SUMS (the installer's binary-integrity manifest)
but added to the stage-2 asset assertion, so a missing schema
blocks the PyPI publish.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>