### PR TITLE
fix(stack): preserve rebase-conflict recovery guidance and exit code

### DIFF
--- a/crates/mergify-stack/src/changes.rs
+++ b/crates/mergify-stack/src/changes.rs
@@ -153,6 +153,118 @@ fn pop_matching(
     Some(remote_changes.swap_remove(idx))
 }
 
+/// First 7 characters of a SHA — the short form every log line
+/// uses.
+fn short_sha(sha: &str) -> String {
+    sha.chars().take(7).collect()
+}
+
+/// Plain-text log line describing one planned change. `dry_run`
+/// selects the would-be wording ("to create") shown in the plan
+/// preview vs the past-tense ("created") shown after the push
+/// lands. `dest_branch` is the branch the PR will live on — used
+/// as the URL placeholder until the PR exists.
+///
+/// Ported from Python `LocalChange.get_log_from_local_change`,
+/// minus the Rich colour tags: this CLI prints plain lines so log
+/// scrapers don't have to strip ANSI (see `render_stack_list_text`).
+#[must_use]
+pub fn format_local_change_log(
+    change: &LocalChange,
+    dest_branch: &str,
+    dry_run: bool,
+    create_as_draft: bool,
+) -> String {
+    let url = match change.pull.as_ref() {
+        Some(pull) => pull
+            .get("html_url")
+            .and_then(Value::as_str)
+            .unwrap_or("<unknown>")
+            .to_string(),
+        None => format!("<{dest_branch}>"),
+    };
+
+    let mut flags = String::new();
+    let draft = change
+        .pull
+        .as_ref()
+        .and_then(|p| p.get("draft"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if draft || (matches!(change.action, Action::Create) && create_as_draft) {
+        flags.push_str(" (draft)");
+    }
+
+    let commit_short = short_sha(&change.commit_sha);
+    let (action, commit_info) = match change.action {
+        Action::Create => (
+            if dry_run { "to create" } else { "created" }.to_string(),
+            commit_short,
+        ),
+        Action::Update => {
+            let head = change
+                .pull
+                .as_ref()
+                .and_then(|p| p.pointer("/head/sha"))
+                .and_then(Value::as_str)
+                .map(short_sha)
+                .unwrap_or_default();
+            (
+                if dry_run { "to update" } else { "updated" }.to_string(),
+                format!("{head} -> {commit_short}"),
+            )
+        }
+        Action::SkipCreate => (
+            "skip, --only-update-existing-pulls".to_string(),
+            commit_short,
+        ),
+        Action::SkipMerged => {
+            flags.push_str(" (merged)");
+            // The merge commit's short SHA when the PR really merged,
+            // else the local commit's. (Python sliced `[7:]` here —
+            // a typo; the short SHA is the first 7 chars.)
+            let info = change
+                .pull
+                .as_ref()
+                .filter(|p| p.get("merged_at").is_some_and(|v| !v.is_null()))
+                .and_then(|p| p.get("merge_commit_sha"))
+                .and_then(Value::as_str)
+                .map(short_sha)
+                .unwrap_or(commit_short);
+            ("merged".to_string(), info)
+        }
+        Action::SkipNextOnly => ("skip, --next-only".to_string(), commit_short),
+        Action::SkipUpToDate => ("up-to-date".to_string(), commit_short),
+    };
+
+    format!(
+        "* [{action}] '{commit_info} - {title}{flags} {url}",
+        title = change.title,
+    )
+}
+
+/// Plain-text log line for an orphan PR (one whose Change-Id left
+/// the local stack) being deleted. `dry_run` toggles "to delete"
+/// vs "deleted". Ported from
+/// `OrphanChange.get_log_from_orphan_change`.
+#[must_use]
+pub fn format_orphan_change_log(pull: &Value, dry_run: bool) -> String {
+    let action = if dry_run { "to delete" } else { "deleted" };
+    let title = pull
+        .get("title")
+        .and_then(Value::as_str)
+        .unwrap_or("<unknown>");
+    let url = pull
+        .get("html_url")
+        .and_then(Value::as_str)
+        .unwrap_or("<unknown>");
+    let sha = pull
+        .pointer("/head/sha")
+        .and_then(Value::as_str)
+        .map_or_else(|| "<unknown>".to_string(), short_sha);
+    format!("* [{action}] '{sha} - {title} {url}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -261,5 +373,99 @@ mod tests {
         )
         .unwrap();
         assert!(res.orphans.is_empty());
+    }
+
+    fn change(action: Action, pull: Option<Value>) -> LocalChange {
+        LocalChange {
+            commit_sha: "abc1234def5678".to_string(),
+            title: "Add feature".to_string(),
+            message: String::new(),
+            change_id: "Iaaaa".to_string(),
+            action,
+            pull,
+            note: String::new(),
+        }
+    }
+
+    #[test]
+    fn format_create_plan_uses_branch_placeholder_url() {
+        let c = change(Action::Create, None);
+        let line = format_local_change_log(&c, "stack/feat/x", true, false);
+        assert_eq!(line, "* [to create] 'abc1234 - Add feature <stack/feat/x>");
+    }
+
+    #[test]
+    fn format_create_done_uses_pull_url_and_draft_flag() {
+        let pull = json!({"html_url": "https://gh/pull/7", "draft": true});
+        let c = change(Action::Create, Some(pull));
+        let line = format_local_change_log(&c, "stack/feat/x", false, false);
+        assert_eq!(
+            line,
+            "* [created] 'abc1234 - Add feature (draft) https://gh/pull/7"
+        );
+    }
+
+    #[test]
+    fn format_create_as_draft_flag_applies_without_pull() {
+        let c = change(Action::Create, None);
+        let line = format_local_change_log(&c, "stack/feat/x", true, true);
+        assert_eq!(
+            line,
+            "* [to create] 'abc1234 - Add feature (draft) <stack/feat/x>"
+        );
+    }
+
+    #[test]
+    fn format_update_shows_old_to_new_head() {
+        let pull = json!({"html_url": "https://gh/pull/7", "head": {"sha": "fff0000aaa"}});
+        let c = change(Action::Update, Some(pull));
+        let line = format_local_change_log(&c, "stack/feat/x", true, false);
+        assert_eq!(
+            line,
+            "* [to update] 'fff0000 -> abc1234 - Add feature https://gh/pull/7"
+        );
+    }
+
+    #[test]
+    fn format_skip_up_to_date() {
+        let pull = json!({"html_url": "https://gh/pull/7", "head": {"sha": "abc1234def5678"}});
+        let c = change(Action::SkipUpToDate, Some(pull));
+        let line = format_local_change_log(&c, "stack/feat/x", false, false);
+        assert_eq!(
+            line,
+            "* [up-to-date] 'abc1234 - Add feature https://gh/pull/7"
+        );
+    }
+
+    #[test]
+    fn format_skip_merged_uses_merge_commit_and_flag() {
+        let pull = json!({
+            "html_url": "https://gh/pull/7",
+            "merged_at": "2025-01-01T00:00:00Z",
+            "merge_commit_sha": "9998887ccc",
+        });
+        let c = change(Action::SkipMerged, Some(pull));
+        let line = format_local_change_log(&c, "stack/feat/x", false, false);
+        assert_eq!(
+            line,
+            "* [merged] '9998887 - Add feature (merged) https://gh/pull/7"
+        );
+    }
+
+    #[test]
+    fn format_orphan_plan_and_deleted() {
+        let pull = json!({
+            "title": "Old PR",
+            "html_url": "https://gh/pull/9",
+            "head": {"sha": "deadbeef0000"},
+        });
+        assert_eq!(
+            format_orphan_change_log(&pull, true),
+            "* [to delete] 'deadbee - Old PR https://gh/pull/9"
+        );
+        assert_eq!(
+            format_orphan_change_log(&pull, false),
+            "* [deleted] 'deadbee - Old PR https://gh/pull/9"
+        );
     }
 }

--- a/crates/mergify-stack/src/commands/push.rs
+++ b/crates/mergify-stack/src/commands/push.rs
@@ -261,8 +261,8 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
             change_type::fetch_old_pr_heads(Some(&repo_dir), remote, &updated_pr_numbers)
         {
             log_lines.push(format!(
-                "[orange]Could not fetch old PR heads; revision-history \
-                 change types will fall back to 'unknown': {e}[/]",
+                "Could not fetch old PR heads; revision-history \
+                 change types will fall back to 'unknown': {e}",
             ));
         }
         for entry in &planned.locals {

--- a/crates/mergify-stack/src/commands/push.rs
+++ b/crates/mergify-stack/src/commands/push.rs
@@ -176,7 +176,7 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
     )
     .await?;
 
-    let mut log_lines: Vec<String> = Vec::new();
+    let mut log_lines: Vec<String> = vec!["Stacked pull request plan:".into()];
 
     if opts.dry_run {
         let commits_behind = git_count_behind(&repo_dir, &trunk_ref)?;
@@ -190,6 +190,8 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         if rebase_decision.should_rebase && commits_behind > 0 {
             plan::promote_skip_up_to_date_to_update(&mut planned);
         }
+        push_plan_preview(&mut log_lines, &planned, opts.create_as_draft);
+        log_lines.push("Finished (dry-run mode).".into());
         return Ok(Outcome::DryRun {
             planned,
             rebase: rebase_decision,
@@ -231,6 +233,11 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
     } else if let Some(line) = rebase_log::rebase_skipped(&dest_branch, &rebase_decision) {
         log_lines.push(line);
     }
+
+    // Plan preview (what will happen) — emitted before the push so
+    // the order matches Python's `display_plan`. `planned` is now
+    // final (re-planned above if a rebase ran).
+    push_plan_preview(&mut log_lines, &planned, opts.create_as_draft);
 
     // Pre-push: optional change-type detection for the
     // revision-history comment. Order matters — must happen
@@ -373,6 +380,20 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         upserted.push(pull);
     }
 
+    // Per-PR outcome lines — every local change (not just
+    // create/update) so skip/up-to-date/merged rows show too, now
+    // with the freshly-known PR URLs. Mirrors Python's
+    // post-`gather` log loop.
+    log_lines.push("Updating and/or creating stacked pull requests:".into());
+    for p in &planned.locals {
+        log_lines.push(crate::changes::format_local_change_log(
+            &p.change,
+            &p.dest_branch,
+            false,
+            opts.create_as_draft,
+        ));
+    }
+
     // Stack comments (only when stack has > 1 PR — the upserter
     // also guards on this but we pre-filter to avoid a useless
     // GET when total_pulls == 1).
@@ -477,6 +498,7 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
             continue;
         };
         pr_upsert::delete_orphan_branch(opts.client, opts.user, opts.repo, head_ref).await?;
+        log_lines.push(crate::changes::format_orphan_change_log(orphan, false));
     }
 
     log_lines.push("Finished.".into());
@@ -487,6 +509,23 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         upserted,
         log_lines,
     })
+}
+
+/// Append the "what will happen" preview lines (locals first, then
+/// orphans), in the would-be wording. Mirrors Python's
+/// `changes.display_plan`.
+fn push_plan_preview(log: &mut Vec<String>, planned: &PlannedChanges, create_as_draft: bool) {
+    for p in &planned.locals {
+        log.push(crate::changes::format_local_change_log(
+            &p.change,
+            &p.dest_branch,
+            true,
+            create_as_draft,
+        ));
+    }
+    for orphan in &planned.orphans {
+        log.push(crate::changes::format_orphan_change_log(orphan, true));
+    }
 }
 
 /// Build a `StackEntry` from a `PlannedChange` — pulls every

--- a/crates/mergify-stack/src/git.rs
+++ b/crates/mergify-stack/src/git.rs
@@ -104,9 +104,16 @@ pub fn spawn_rebase(
         .status()
         .map_err(|e| CliError::Generic(format!("failed to spawn `git rebase -i`: {e}")))?;
     if !status.success() {
-        return Err(CliError::Generic(format!(
-            "`git rebase -i {base}` exited {status}"
-        )));
+        // A non-zero `git rebase -i` almost always means conflicts.
+        // Surface the recovery steps and map to the dedicated
+        // Conflict exit code (4) so scripts can branch on it — same
+        // contract as the Python `run_scripted_rebase`.
+        return Err(CliError::Conflict(
+            "rebase failed — there may be conflicts\n\
+             Resolve conflicts then run: git rebase --continue\n\
+             Or abort the rebase with: git rebase --abort"
+                .to_string(),
+        ));
     }
     Ok(())
 }

--- a/crates/mergify-stack/src/notes_push.rs
+++ b/crates/mergify-stack/src/notes_push.rs
@@ -199,11 +199,23 @@ pub fn push_branches(
     // updates, …). Always cleanup, even on failure.
     let mut cmd = git_cmd(repo_dir);
     cmd.args(&arg_refs).env(PUSH_ENV_MARKER, "1");
-    let status = cmd
-        .status()
+    // Capture stdio rather than inherit it: `git push` narrates the
+    // branch creation, `remote:` ruleset-bypass notices, and the
+    // "create a pull request by visiting …" hint, all of which are
+    // noise next to the orchestrator's own plan/created summary.
+    // Keep it for the failure path only. Mirrors `run_git_silent`
+    // and the Python `utils.git` wrapper.
+    let output = cmd
+        .output()
         .map_err(|e| CliError::Generic(format!("failed to spawn `git push`: {e}")))?;
-    if !status.success() {
-        return Err(CliError::Generic(format!("`git push` exited {status}")));
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim();
+        return Err(CliError::Generic(if stderr.is_empty() {
+            format!("`git push` exited {}", output.status)
+        } else {
+            format!("`git push` exited {}:\n{stderr}", output.status)
+        }));
     }
     Ok(())
 }

--- a/crates/mergify-stack/src/rebase_log.rs
+++ b/crates/mergify-stack/src/rebase_log.rs
@@ -103,8 +103,8 @@ pub fn rebase_dry_run(
             let n = decision.approved_pulls.len();
             let plural = if n == 1 { "" } else { "s" };
             let mut lines = vec![format!(
-                "[orange]branch `{dest_branch}` rebase would be skipped: \
-                 approvals detected on {n} PR{plural}[/]",
+                "branch `{dest_branch}` rebase would be skipped: \
+                 approvals detected on {n} PR{plural}",
             )];
             for pull in &decision.approved_pulls {
                 let number = pull.get("number").and_then(Value::as_u64).unwrap_or(0);
@@ -117,13 +117,13 @@ pub fn rebase_dry_run(
         RebaseReason::ConflictOverride => {
             let numbers = pull_numbers_csv(&decision.approved_pulls);
             vec![format!(
-                "[orange]branch `{dest_branch}` would be rebased on `{remote}/{base_branch}` \
-                 (bottom PR has conflicts; approvals on PR(s) {numbers} would be dismissed)[/]",
+                "branch `{dest_branch}` would be rebased on `{remote}/{base_branch}` \
+                 (bottom PR has conflicts; approvals on PR(s) {numbers} would be dismissed)",
             )]
         }
         RebaseReason::Forced => vec![format!(
-            "[orange]branch `{dest_branch}` would be rebased on `{remote}/{base_branch}` \
-             (--force-rebase; approvals may be dismissed)[/]",
+            "branch `{dest_branch}` would be rebased on `{remote}/{base_branch}` \
+             (--force-rebase; approvals may be dismissed)",
         )],
         RebaseReason::NoApprovals => {
             // Match Python's "only warn if behind" — silent
@@ -137,8 +137,8 @@ pub fn rebase_dry_run(
                 "commits"
             };
             vec![format!(
-                "[orange]branch `{dest_branch}` is behind `{remote}/{base_branch}` \
-                 by {commits_behind} {plural}, commit SHAs will differ after rebase[/]",
+                "branch `{dest_branch}` is behind `{remote}/{base_branch}` \
+                 by {commits_behind} {plural}, commit SHAs will differ after rebase",
             )]
         }
     }


### PR DESCRIPTION
A failed `git rebase -i` in spawn_rebase returned a generic "exited <status>" error mapped to exit 1. Every rebase-driving command (drop, squash, fixup, reorder, reword, move, edit, sync) routes through this helper, so all of them lost the conflict recovery instructions and the dedicated Conflict exit code (4) that automation keys on. Return CliError::Conflict with the resolve/continue/abort guidance, matching the Python run_scripted_rebase contract.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #1615