### PR TITLE
fix(stack): restore full-stack action-plan previews

### DIFF
--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -1857,18 +1857,15 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                     },
                 )?;
                 match outcome {
-                    mergify_stack::commands::drop::Outcome::Dropped { dropped } => {
-                        for c in &dropped {
-                            let short = &c.sha[..c.sha.len().min(12)];
-                            println!("Dropping: {short} {subject}", subject = c.subject);
+                    mergify_stack::commands::drop::Outcome::Dropped { plan } => {
+                        for line in mergify_stack::plan_display::render_plan("Drop plan:", &plan) {
+                            println!("{line}");
                         }
                         println!("Commits dropped successfully.");
                     }
                     mergify_stack::commands::drop::Outcome::DryRun { plan } => {
-                        println!("Drop plan:");
-                        for c in &plan {
-                            let short = &c.sha[..c.sha.len().min(12)];
-                            println!("  drop {short} {subject}", subject = c.subject);
+                        for line in mergify_stack::plan_display::render_plan("Drop plan:", &plan) {
+                            println!("{line}");
                         }
                         println!("Dry run — no changes made");
                     }
@@ -1893,18 +1890,15 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                     },
                 )?;
                 match outcome {
-                    mergify_stack::commands::fixup::Outcome::Squashed { fixed_up } => {
-                        for c in &fixed_up {
-                            let short = &c.sha[..c.sha.len().min(12)];
-                            println!("Fixing up: {short} {subject}", subject = c.subject);
+                    mergify_stack::commands::fixup::Outcome::Squashed { plan } => {
+                        for line in mergify_stack::plan_display::render_plan("Fixup plan:", &plan) {
+                            println!("{line}");
                         }
                         println!("Commits squashed successfully.");
                     }
                     mergify_stack::commands::fixup::Outcome::DryRun { plan } => {
-                        println!("Fixup plan:");
-                        for c in &plan {
-                            let short = &c.sha[..c.sha.len().min(12)];
-                            println!("  fixup {short} {subject}", subject = c.subject);
+                        for line in mergify_stack::plan_display::render_plan("Fixup plan:", &plan) {
+                            println!("{line}");
                         }
                         println!("Dry run — no changes made");
                     }
@@ -1930,21 +1924,16 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                     },
                 )?;
                 match outcome {
-                    mergify_stack::commands::reword::Outcome::Reworded { commit } => {
-                        let short = &commit.sha[..commit.sha.len().min(12)];
-                        println!(
-                            "Reworded {short} {subject}",
-                            subject = commit.subject,
-                        );
+                    mergify_stack::commands::reword::Outcome::Reworded { plan } => {
+                        for line in mergify_stack::plan_display::render_plan("Reword plan:", &plan) {
+                            println!("{line}");
+                        }
+                        println!("Commit reworded successfully.");
                     }
-                    mergify_stack::commands::reword::Outcome::DryRun {
-                        commit,
-                        inline_message,
-                    } => {
-                        let short = &commit.sha[..commit.sha.len().min(12)];
-                        let verb = if inline_message { "amend" } else { "reword" };
-                        println!("Reword plan:");
-                        println!("  {verb} {short} {subject}", subject = commit.subject);
+                    mergify_stack::commands::reword::Outcome::DryRun { plan } => {
+                        for line in mergify_stack::plan_display::render_plan("Reword plan:", &plan) {
+                            println!("{line}");
+                        }
                         println!("Dry run — no changes made");
                     }
                     mergify_stack::commands::reword::Outcome::EmptyStack => {
@@ -1970,10 +1959,9 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 match outcome {
                     mergify_stack::commands::reorder::Outcome::Reordered { plan }
                     | mergify_stack::commands::reorder::Outcome::DryRun { plan } => {
-                        println!("Reorder plan:");
-                        for (i, c) in plan.iter().enumerate() {
-                            let short = &c.sha[..c.sha.len().min(12)];
-                            println!("  {n}. {short} {subject}", n = i + 1, subject = c.subject);
+                        for line in mergify_stack::plan_display::render_plan("Reorder plan:", &plan)
+                        {
+                            println!("{line}");
                         }
                         if opts.dry_run {
                             println!("Dry run — no changes made");
@@ -2015,10 +2003,8 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 match outcome {
                     mergify_stack::commands::move_cmd::Outcome::Moved { plan }
                     | mergify_stack::commands::move_cmd::Outcome::DryRun { plan } => {
-                        println!("Move plan:");
-                        for (i, c) in plan.iter().enumerate() {
-                            let short = &c.sha[..c.sha.len().min(12)];
-                            println!("  {n}. {short} {subject}", n = i + 1, subject = c.subject);
+                        for line in mergify_stack::plan_display::render_plan("Move plan:", &plan) {
+                            println!("{line}");
                         }
                         if opts.dry_run {
                             println!("Dry run — no changes made");
@@ -2054,10 +2040,8 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 match outcome {
                     mergify_stack::commands::squash::Outcome::Squashed { plan }
                     | mergify_stack::commands::squash::Outcome::DryRun { plan } => {
-                        println!("Squash plan:");
-                        for (i, c) in plan.iter().enumerate() {
-                            let short = &c.sha[..c.sha.len().min(12)];
-                            println!("  {n}. {short} {subject}", n = i + 1, subject = c.subject);
+                        for line in mergify_stack::plan_display::render_plan("Squash plan:", &plan) {
+                            println!("{line}");
                         }
                         if opts.dry_run {
                             println!("Dry run — no changes made");

--- a/crates/mergify-stack/src/changes.rs
+++ b/crates/mergify-stack/src/changes.rs
@@ -153,6 +153,118 @@ fn pop_matching(
     Some(remote_changes.swap_remove(idx))
 }
 
+/// First 7 characters of a SHA — the short form every log line
+/// uses.
+fn short_sha(sha: &str) -> String {
+    sha.chars().take(7).collect()
+}
+
+/// Plain-text log line describing one planned change. `dry_run`
+/// selects the would-be wording ("to create") shown in the plan
+/// preview vs the past-tense ("created") shown after the push
+/// lands. `dest_branch` is the branch the PR will live on — used
+/// as the URL placeholder until the PR exists.
+///
+/// Ported from Python `LocalChange.get_log_from_local_change`,
+/// minus the Rich colour tags: this CLI prints plain lines so log
+/// scrapers don't have to strip ANSI (see `render_stack_list_text`).
+#[must_use]
+pub fn format_local_change_log(
+    change: &LocalChange,
+    dest_branch: &str,
+    dry_run: bool,
+    create_as_draft: bool,
+) -> String {
+    let url = match change.pull.as_ref() {
+        Some(pull) => pull
+            .get("html_url")
+            .and_then(Value::as_str)
+            .unwrap_or("<unknown>")
+            .to_string(),
+        None => format!("<{dest_branch}>"),
+    };
+
+    let mut flags = String::new();
+    let draft = change
+        .pull
+        .as_ref()
+        .and_then(|p| p.get("draft"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if draft || (matches!(change.action, Action::Create) && create_as_draft) {
+        flags.push_str(" (draft)");
+    }
+
+    let commit_short = short_sha(&change.commit_sha);
+    let (action, commit_info) = match change.action {
+        Action::Create => (
+            if dry_run { "to create" } else { "created" }.to_string(),
+            commit_short,
+        ),
+        Action::Update => {
+            let head = change
+                .pull
+                .as_ref()
+                .and_then(|p| p.pointer("/head/sha"))
+                .and_then(Value::as_str)
+                .map(short_sha)
+                .unwrap_or_default();
+            (
+                if dry_run { "to update" } else { "updated" }.to_string(),
+                format!("{head} -> {commit_short}"),
+            )
+        }
+        Action::SkipCreate => (
+            "skip, --only-update-existing-pulls".to_string(),
+            commit_short,
+        ),
+        Action::SkipMerged => {
+            flags.push_str(" (merged)");
+            // The merge commit's short SHA when the PR really merged,
+            // else the local commit's. (Python sliced `[7:]` here —
+            // a typo; the short SHA is the first 7 chars.)
+            let info = change
+                .pull
+                .as_ref()
+                .filter(|p| p.get("merged_at").is_some_and(|v| !v.is_null()))
+                .and_then(|p| p.get("merge_commit_sha"))
+                .and_then(Value::as_str)
+                .map(short_sha)
+                .unwrap_or(commit_short);
+            ("merged".to_string(), info)
+        }
+        Action::SkipNextOnly => ("skip, --next-only".to_string(), commit_short),
+        Action::SkipUpToDate => ("up-to-date".to_string(), commit_short),
+    };
+
+    format!(
+        "* [{action}] '{commit_info} - {title}{flags} {url}",
+        title = change.title,
+    )
+}
+
+/// Plain-text log line for an orphan PR (one whose Change-Id left
+/// the local stack) being deleted. `dry_run` toggles "to delete"
+/// vs "deleted". Ported from
+/// `OrphanChange.get_log_from_orphan_change`.
+#[must_use]
+pub fn format_orphan_change_log(pull: &Value, dry_run: bool) -> String {
+    let action = if dry_run { "to delete" } else { "deleted" };
+    let title = pull
+        .get("title")
+        .and_then(Value::as_str)
+        .unwrap_or("<unknown>");
+    let url = pull
+        .get("html_url")
+        .and_then(Value::as_str)
+        .unwrap_or("<unknown>");
+    let sha = pull
+        .pointer("/head/sha")
+        .and_then(Value::as_str)
+        .map_or_else(|| "<unknown>".to_string(), short_sha);
+    format!("* [{action}] '{sha} - {title} {url}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -261,5 +373,99 @@ mod tests {
         )
         .unwrap();
         assert!(res.orphans.is_empty());
+    }
+
+    fn change(action: Action, pull: Option<Value>) -> LocalChange {
+        LocalChange {
+            commit_sha: "abc1234def5678".to_string(),
+            title: "Add feature".to_string(),
+            message: String::new(),
+            change_id: "Iaaaa".to_string(),
+            action,
+            pull,
+            note: String::new(),
+        }
+    }
+
+    #[test]
+    fn format_create_plan_uses_branch_placeholder_url() {
+        let c = change(Action::Create, None);
+        let line = format_local_change_log(&c, "stack/feat/x", true, false);
+        assert_eq!(line, "* [to create] 'abc1234 - Add feature <stack/feat/x>");
+    }
+
+    #[test]
+    fn format_create_done_uses_pull_url_and_draft_flag() {
+        let pull = json!({"html_url": "https://gh/pull/7", "draft": true});
+        let c = change(Action::Create, Some(pull));
+        let line = format_local_change_log(&c, "stack/feat/x", false, false);
+        assert_eq!(
+            line,
+            "* [created] 'abc1234 - Add feature (draft) https://gh/pull/7"
+        );
+    }
+
+    #[test]
+    fn format_create_as_draft_flag_applies_without_pull() {
+        let c = change(Action::Create, None);
+        let line = format_local_change_log(&c, "stack/feat/x", true, true);
+        assert_eq!(
+            line,
+            "* [to create] 'abc1234 - Add feature (draft) <stack/feat/x>"
+        );
+    }
+
+    #[test]
+    fn format_update_shows_old_to_new_head() {
+        let pull = json!({"html_url": "https://gh/pull/7", "head": {"sha": "fff0000aaa"}});
+        let c = change(Action::Update, Some(pull));
+        let line = format_local_change_log(&c, "stack/feat/x", true, false);
+        assert_eq!(
+            line,
+            "* [to update] 'fff0000 -> abc1234 - Add feature https://gh/pull/7"
+        );
+    }
+
+    #[test]
+    fn format_skip_up_to_date() {
+        let pull = json!({"html_url": "https://gh/pull/7", "head": {"sha": "abc1234def5678"}});
+        let c = change(Action::SkipUpToDate, Some(pull));
+        let line = format_local_change_log(&c, "stack/feat/x", false, false);
+        assert_eq!(
+            line,
+            "* [up-to-date] 'abc1234 - Add feature https://gh/pull/7"
+        );
+    }
+
+    #[test]
+    fn format_skip_merged_uses_merge_commit_and_flag() {
+        let pull = json!({
+            "html_url": "https://gh/pull/7",
+            "merged_at": "2025-01-01T00:00:00Z",
+            "merge_commit_sha": "9998887ccc",
+        });
+        let c = change(Action::SkipMerged, Some(pull));
+        let line = format_local_change_log(&c, "stack/feat/x", false, false);
+        assert_eq!(
+            line,
+            "* [merged] '9998887 - Add feature (merged) https://gh/pull/7"
+        );
+    }
+
+    #[test]
+    fn format_orphan_plan_and_deleted() {
+        let pull = json!({
+            "title": "Old PR",
+            "html_url": "https://gh/pull/9",
+            "head": {"sha": "deadbeef0000"},
+        });
+        assert_eq!(
+            format_orphan_change_log(&pull, true),
+            "* [to delete] 'deadbee - Old PR https://gh/pull/9"
+        );
+        assert_eq!(
+            format_orphan_change_log(&pull, false),
+            "* [deleted] 'deadbee - Old PR https://gh/pull/9"
+        );
     }
 }

--- a/crates/mergify-stack/src/commands/drop.rs
+++ b/crates/mergify-stack/src/commands/drop.rs
@@ -15,11 +15,11 @@ use mergify_core::CliError;
 use crate::change_id;
 use crate::git::{resolve_repo_toplevel, run_git_capture, shell_quote, spawn_rebase};
 use crate::local_commits::{self, LocalCommit};
+use crate::plan_display::PlanRow;
 use crate::trunk;
 
-/// One commit the caller wants to drop. Returned in order so the
-/// binary handler can render the "Drop plan" header without a
-/// second walk.
+/// One commit the caller wants to drop, used for prefix
+/// resolution before building the full-stack plan.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DroppedCommit {
     pub sha: String,
@@ -28,12 +28,11 @@ pub struct DroppedCommit {
 
 #[derive(Debug, Clone)]
 pub enum Outcome {
-    /// Drop ran to completion. `dropped` is the resolved set of
-    /// commits in the order the user passed them — printed as
-    /// `Commits dropped successfully.`.
-    Dropped { dropped: Vec<DroppedCommit> },
-    /// `--dry-run` short-circuit. Plan was rendered, no git rebase.
-    DryRun { plan: Vec<DroppedCommit> },
+    /// Drop ran to completion. `plan` is the full stack in
+    /// `base..HEAD` order with `[drop]` tags on the dropped rows.
+    Dropped { plan: Vec<PlanRow> },
+    /// `--dry-run` short-circuit. Same full-stack `plan`, no rebase.
+    DryRun { plan: Vec<PlanRow> },
     /// Stack is empty — Python prints `No commits in the stack`
     /// and exits 0.
     EmptyStack,
@@ -85,14 +84,26 @@ pub fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         resolved.push(matched);
     }
 
+    let plan: Vec<PlanRow> = commits
+        .iter()
+        .map(|c| PlanRow {
+            sha: c.commit_sha.clone(),
+            subject: c.title.clone(),
+            change_id: c.change_id.clone(),
+            action: seen_shas
+                .contains(&c.commit_sha)
+                .then(|| "drop".to_string()),
+        })
+        .collect();
+
     if opts.dry_run {
-        return Ok(Outcome::DryRun { plan: resolved });
+        return Ok(Outcome::DryRun { plan });
     }
 
     let shas: Vec<String> = resolved.iter().map(|c| c.sha.clone()).collect();
     let editor = build_sequence_editor(opts.mergify_binary, &shas);
     spawn_rebase(&repo_dir, &base, Some(&editor))?;
-    Ok(Outcome::Dropped { dropped: resolved })
+    Ok(Outcome::Dropped { plan })
 }
 
 fn match_commit(prefix: &str, commits: &[LocalCommit]) -> Result<DroppedCommit, CliError> {
@@ -223,9 +234,14 @@ mod tests {
         .unwrap();
         match outcome {
             Outcome::DryRun { plan } => {
-                assert_eq!(plan.len(), 1);
-                assert_eq!(plan[0].sha, commits[1].0);
-                assert_eq!(plan[0].subject, "Commit B");
+                // Plan lists the whole stack (A, B, C); only B is
+                // tagged for drop.
+                assert_eq!(plan.len(), 3);
+                assert_eq!(plan[1].sha, commits[1].0);
+                assert_eq!(plan[1].subject, "Commit B");
+                assert_eq!(plan[1].action.as_deref(), Some("drop"));
+                assert_eq!(plan[0].action, None);
+                assert_eq!(plan[2].action, None);
             }
             other => panic!("unexpected: {other:?}"),
         }
@@ -269,7 +285,10 @@ mod tests {
         .unwrap();
         match outcome {
             Outcome::DryRun { plan } => {
-                assert_eq!(plan[0].sha, commits[2].0);
+                // C (index 2 in the stack) is the change-id match
+                // and the only tagged row.
+                assert_eq!(plan[2].sha, commits[2].0);
+                assert_eq!(plan[2].action.as_deref(), Some("drop"));
             }
             other => panic!("unexpected: {other:?}"),
         }

--- a/crates/mergify-stack/src/commands/fixup.rs
+++ b/crates/mergify-stack/src/commands/fixup.rs
@@ -20,6 +20,7 @@ use mergify_core::CliError;
 use crate::change_id;
 use crate::git::{resolve_repo_toplevel, run_git_capture, shell_quote, spawn_rebase};
 use crate::local_commits::{self, LocalCommit};
+use crate::plan_display::PlanRow;
 use crate::trunk;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,8 +31,15 @@ pub struct FixedUpCommit {
 
 #[derive(Debug, Clone)]
 pub enum Outcome {
-    Squashed { fixed_up: Vec<FixedUpCommit> },
-    DryRun { plan: Vec<FixedUpCommit> },
+    /// Fixup ran to completion. `plan` is the full stack in
+    /// `base..HEAD` order with `[fixup]` tags on the folded rows.
+    Squashed {
+        plan: Vec<PlanRow>,
+    },
+    /// `--dry-run` short-circuit. Same full-stack `plan`, no rebase.
+    DryRun {
+        plan: Vec<PlanRow>,
+    },
     EmptyStack,
 }
 
@@ -89,14 +97,26 @@ pub fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         resolved.push(matched);
     }
 
+    let plan: Vec<PlanRow> = commits
+        .iter()
+        .map(|c| PlanRow {
+            sha: c.commit_sha.clone(),
+            subject: c.title.clone(),
+            change_id: c.change_id.clone(),
+            action: seen_shas
+                .contains(&c.commit_sha)
+                .then(|| "fixup".to_string()),
+        })
+        .collect();
+
     if opts.dry_run {
-        return Ok(Outcome::DryRun { plan: resolved });
+        return Ok(Outcome::DryRun { plan });
     }
 
     let shas: Vec<String> = resolved.iter().map(|c| c.sha.clone()).collect();
     let editor = build_sequence_editor(opts.mergify_binary, &shas);
     spawn_rebase(&repo_dir, &base, Some(&editor))?;
-    Ok(Outcome::Squashed { fixed_up: resolved })
+    Ok(Outcome::Squashed { plan })
 }
 
 fn match_commit(prefix: &str, commits: &[LocalCommit]) -> Result<FixedUpCommit, CliError> {
@@ -244,8 +264,14 @@ mod tests {
         .unwrap();
         match outcome {
             Outcome::DryRun { plan } => {
-                assert_eq!(plan[0].sha, commits[1].0);
-                assert_eq!(plan[0].subject, "Commit B");
+                // Plan lists the whole stack (A, B, C); only B is
+                // tagged for fixup.
+                assert_eq!(plan.len(), 3);
+                assert_eq!(plan[1].sha, commits[1].0);
+                assert_eq!(plan[1].subject, "Commit B");
+                assert_eq!(plan[1].action.as_deref(), Some("fixup"));
+                assert_eq!(plan[0].action, None);
+                assert_eq!(plan[2].action, None);
             }
             other => panic!("unexpected: {other:?}"),
         }

--- a/crates/mergify-stack/src/commands/move_cmd.rs
+++ b/crates/mergify-stack/src/commands/move_cmd.rs
@@ -13,6 +13,7 @@ use mergify_core::CliError;
 use crate::change_id;
 use crate::git::{resolve_repo_toplevel, run_git_capture, shell_quote, spawn_rebase};
 use crate::local_commits::{self, LocalCommit};
+use crate::plan_display::PlanRow;
 use crate::trunk;
 
 /// Where to move the commit. Mirrors Python's positional value.
@@ -25,15 +26,23 @@ pub enum Position {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OrderedCommit {
-    pub sha: String,
-    pub subject: String,
+struct OrderedCommit {
+    sha: String,
+    subject: String,
+    change_id: String,
 }
 
 #[derive(Debug, Clone)]
 pub enum Outcome {
-    Moved { plan: Vec<OrderedCommit> },
-    DryRun { plan: Vec<OrderedCommit> },
+    /// Move ran to completion. `plan` is the new full-stack order
+    /// (tag-less, like Python's `display_plan`).
+    Moved {
+        plan: Vec<PlanRow>,
+    },
+    /// `--dry-run` short-circuit. Same full-stack `plan`, no rebase.
+    DryRun {
+        plan: Vec<PlanRow>,
+    },
     AlreadyInPosition,
     EmptyStack,
 }
@@ -90,52 +99,7 @@ pub fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         (Position::First | Position::Last, None) => None,
     };
 
-    let remaining_owned: Vec<OrderedCommit> = commits
-        .iter()
-        .filter(|c| c.commit_sha != commit.sha)
-        .map(|c| OrderedCommit {
-            sha: c.commit_sha.clone(),
-            subject: c.title.clone(),
-        })
-        .collect();
-
-    let new_order: Vec<OrderedCommit> = match opts.position {
-        Position::First => {
-            let mut v = Vec::with_capacity(remaining_owned.len() + 1);
-            v.push(commit.clone());
-            v.extend(remaining_owned);
-            v
-        }
-        Position::Last => {
-            let mut v = remaining_owned;
-            v.push(commit.clone());
-            v
-        }
-        Position::Before => {
-            let target = target.expect("target validated above");
-            let idx = remaining_owned
-                .iter()
-                .position(|c| c.sha == target.sha)
-                .expect("target was in stack");
-            let mut v = Vec::with_capacity(remaining_owned.len() + 1);
-            v.extend(remaining_owned[..idx].iter().cloned());
-            v.push(commit.clone());
-            v.extend(remaining_owned[idx..].iter().cloned());
-            v
-        }
-        Position::After => {
-            let target = target.expect("target validated above");
-            let idx = remaining_owned
-                .iter()
-                .position(|c| c.sha == target.sha)
-                .expect("target was in stack");
-            let mut v = Vec::with_capacity(remaining_owned.len() + 1);
-            v.extend(remaining_owned[..=idx].iter().cloned());
-            v.push(commit.clone());
-            v.extend(remaining_owned[idx + 1..].iter().cloned());
-            v
-        }
-    };
+    let new_order = compute_new_order(&commits, &commit, &opts.position, target.as_ref());
 
     let current_shas: Vec<&str> = commits.iter().map(|c| c.commit_sha.as_str()).collect();
     let new_shas: Vec<&str> = new_order.iter().map(|c| c.sha.as_str()).collect();
@@ -143,12 +107,75 @@ pub fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         return Ok(Outcome::AlreadyInPosition);
     }
 
+    let plan: Vec<PlanRow> = new_order
+        .iter()
+        .map(|c| PlanRow {
+            sha: c.sha.clone(),
+            subject: c.subject.clone(),
+            change_id: c.change_id.clone(),
+            action: None,
+        })
+        .collect();
+
     if opts.dry_run {
-        return Ok(Outcome::DryRun { plan: new_order });
+        return Ok(Outcome::DryRun { plan });
     }
 
     spawn_reorder_rebase(&repo_dir, &base, opts.mergify_binary, &new_shas)?;
-    Ok(Outcome::Moved { plan: new_order })
+    Ok(Outcome::Moved { plan })
+}
+
+/// Build the reordered stack: every commit except `commit` in its
+/// original order, with `commit` reinserted at the requested
+/// `position` (relative to `target` for `Before` / `After`).
+fn compute_new_order(
+    commits: &[LocalCommit],
+    commit: &OrderedCommit,
+    position: &Position,
+    target: Option<&OrderedCommit>,
+) -> Vec<OrderedCommit> {
+    let remaining: Vec<OrderedCommit> = commits
+        .iter()
+        .filter(|c| c.commit_sha != commit.sha)
+        .map(|c| OrderedCommit {
+            sha: c.commit_sha.clone(),
+            subject: c.title.clone(),
+            change_id: c.change_id.clone(),
+        })
+        .collect();
+
+    match position {
+        Position::First => {
+            let mut v = Vec::with_capacity(remaining.len() + 1);
+            v.push(commit.clone());
+            v.extend(remaining);
+            v
+        }
+        Position::Last => {
+            let mut v = remaining;
+            v.push(commit.clone());
+            v
+        }
+        Position::Before | Position::After => {
+            let target = target.expect("target validated above");
+            let idx = remaining
+                .iter()
+                .position(|c| c.sha == target.sha)
+                .expect("target was in stack");
+            // `Before` inserts at the target's index; `After`
+            // inserts just past it.
+            let insert_at = if matches!(position, Position::After) {
+                idx + 1
+            } else {
+                idx
+            };
+            let mut v = Vec::with_capacity(remaining.len() + 1);
+            v.extend(remaining[..insert_at].iter().cloned());
+            v.push(commit.clone());
+            v.extend(remaining[insert_at..].iter().cloned());
+            v
+        }
+    }
 }
 
 fn position_name(p: &Position) -> &'static str {
@@ -185,6 +212,7 @@ fn match_commit(prefix: &str, commits: &[LocalCommit]) -> Result<OrderedCommit, 
         [only] => Ok(OrderedCommit {
             sha: only.commit_sha.clone(),
             subject: only.title.clone(),
+            change_id: only.change_id.clone(),
         }),
         many => {
             let listing = many

--- a/crates/mergify-stack/src/commands/push.rs
+++ b/crates/mergify-stack/src/commands/push.rs
@@ -261,8 +261,8 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
             change_type::fetch_old_pr_heads(Some(&repo_dir), remote, &updated_pr_numbers)
         {
             log_lines.push(format!(
-                "[orange]Could not fetch old PR heads; revision-history \
-                 change types will fall back to 'unknown': {e}[/]",
+                "Could not fetch old PR heads; revision-history \
+                 change types will fall back to 'unknown': {e}",
             ));
         }
         for entry in &planned.locals {

--- a/crates/mergify-stack/src/commands/push.rs
+++ b/crates/mergify-stack/src/commands/push.rs
@@ -176,7 +176,7 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
     )
     .await?;
 
-    let mut log_lines: Vec<String> = Vec::new();
+    let mut log_lines: Vec<String> = vec!["Stacked pull request plan:".into()];
 
     if opts.dry_run {
         let commits_behind = git_count_behind(&repo_dir, &trunk_ref)?;
@@ -190,6 +190,8 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         if rebase_decision.should_rebase && commits_behind > 0 {
             plan::promote_skip_up_to_date_to_update(&mut planned);
         }
+        push_plan_preview(&mut log_lines, &planned, opts.create_as_draft);
+        log_lines.push("Finished (dry-run mode).".into());
         return Ok(Outcome::DryRun {
             planned,
             rebase: rebase_decision,
@@ -231,6 +233,11 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
     } else if let Some(line) = rebase_log::rebase_skipped(&dest_branch, &rebase_decision) {
         log_lines.push(line);
     }
+
+    // Plan preview (what will happen) — emitted before the push so
+    // the order matches Python's `display_plan`. `planned` is now
+    // final (re-planned above if a rebase ran).
+    push_plan_preview(&mut log_lines, &planned, opts.create_as_draft);
 
     // Pre-push: optional change-type detection for the
     // revision-history comment. Order matters — must happen
@@ -373,6 +380,20 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         upserted.push(pull);
     }
 
+    // Per-PR outcome lines — every local change (not just
+    // create/update) so skip/up-to-date/merged rows show too, now
+    // with the freshly-known PR URLs. Mirrors Python's
+    // post-`gather` log loop.
+    log_lines.push("Updating and/or creating stacked pull requests:".into());
+    for p in &planned.locals {
+        log_lines.push(crate::changes::format_local_change_log(
+            &p.change,
+            &p.dest_branch,
+            false,
+            opts.create_as_draft,
+        ));
+    }
+
     // Stack comments (only when stack has > 1 PR — the upserter
     // also guards on this but we pre-filter to avoid a useless
     // GET when total_pulls == 1).
@@ -477,6 +498,7 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
             continue;
         };
         pr_upsert::delete_orphan_branch(opts.client, opts.user, opts.repo, head_ref).await?;
+        log_lines.push(crate::changes::format_orphan_change_log(orphan, false));
     }
 
     log_lines.push("Finished.".into());
@@ -487,6 +509,23 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         upserted,
         log_lines,
     })
+}
+
+/// Append the "what will happen" preview lines (locals first, then
+/// orphans), in the would-be wording. Mirrors Python's
+/// `changes.display_plan`.
+fn push_plan_preview(log: &mut Vec<String>, planned: &PlannedChanges, create_as_draft: bool) {
+    for p in &planned.locals {
+        log.push(crate::changes::format_local_change_log(
+            &p.change,
+            &p.dest_branch,
+            true,
+            create_as_draft,
+        ));
+    }
+    for orphan in &planned.orphans {
+        log.push(crate::changes::format_orphan_change_log(orphan, true));
+    }
 }
 
 /// Build a `StackEntry` from a `PlannedChange` — pulls every

--- a/crates/mergify-stack/src/commands/reorder.rs
+++ b/crates/mergify-stack/src/commands/reorder.rs
@@ -16,21 +16,26 @@ use mergify_core::CliError;
 use crate::change_id;
 use crate::git::{resolve_repo_toplevel, run_git_capture, shell_quote, spawn_rebase};
 use crate::local_commits::{self, LocalCommit};
+use crate::plan_display::PlanRow;
 use crate::trunk;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OrderedCommit {
-    pub sha: String,
-    pub subject: String,
+struct OrderedCommit {
+    sha: String,
+    subject: String,
+    change_id: String,
 }
 
 #[derive(Debug, Clone)]
 pub enum Outcome {
+    /// Reorder ran to completion. `plan` is the new full-stack
+    /// order (tag-less, like Python's `display_plan`).
     Reordered {
-        plan: Vec<OrderedCommit>,
+        plan: Vec<PlanRow>,
     },
+    /// `--dry-run` short-circuit. Same full-stack `plan`, no rebase.
     DryRun {
-        plan: Vec<OrderedCommit>,
+        plan: Vec<PlanRow>,
     },
     /// New order matches current order — no rebase needed.
     AlreadyInOrder,
@@ -89,12 +94,22 @@ pub fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         return Ok(Outcome::AlreadyInOrder);
     }
 
+    let plan: Vec<PlanRow> = resolved
+        .iter()
+        .map(|c| PlanRow {
+            sha: c.sha.clone(),
+            subject: c.subject.clone(),
+            change_id: c.change_id.clone(),
+            action: None,
+        })
+        .collect();
+
     if opts.dry_run {
-        return Ok(Outcome::DryRun { plan: resolved });
+        return Ok(Outcome::DryRun { plan });
     }
 
     spawn_reorder_rebase(&repo_dir, &base, opts.mergify_binary, &requested_shas)?;
-    Ok(Outcome::Reordered { plan: resolved })
+    Ok(Outcome::Reordered { plan })
 }
 
 fn match_commit(prefix: &str, commits: &[LocalCommit]) -> Result<OrderedCommit, CliError> {
@@ -122,6 +137,7 @@ fn match_commit(prefix: &str, commits: &[LocalCommit]) -> Result<OrderedCommit, 
         [only] => Ok(OrderedCommit {
             sha: only.commit_sha.clone(),
             subject: only.title.clone(),
+            change_id: only.change_id.clone(),
         }),
         many => {
             let listing = many

--- a/crates/mergify-stack/src/commands/reword.rs
+++ b/crates/mergify-stack/src/commands/reword.rs
@@ -24,6 +24,7 @@ use mergify_core::CliError;
 use crate::change_id;
 use crate::git::{resolve_repo_toplevel, run_git_capture, shell_quote, spawn_rebase};
 use crate::local_commits::{self, LocalCommit};
+use crate::plan_display::PlanRow;
 use crate::trunk;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -34,15 +35,15 @@ pub struct RewordedCommit {
 
 #[derive(Debug, Clone)]
 pub enum Outcome {
+    /// Reword ran to completion. `plan` is the full stack in
+    /// `base..HEAD` order with a `[reword]`/`[amend]` tag on the
+    /// target row.
     Reworded {
-        commit: RewordedCommit,
+        plan: Vec<PlanRow>,
     },
-    /// `--dry-run` short-circuit. `inline_message` is true when the
-    /// caller passed `-m`, which the printer surfaces as `amend`
-    /// instead of `reword` in the plan.
+    /// `--dry-run` short-circuit. Same full-stack `plan`, no rebase.
     DryRun {
-        commit: RewordedCommit,
-        inline_message: bool,
+        plan: Vec<PlanRow>,
     },
     EmptyStack,
 }
@@ -76,11 +77,25 @@ pub fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
 
     let target = match_commit(opts.commit_prefix, &commits)?;
 
+    // No `-m` opens an editor (`reword` verb); `-m` amends the
+    // message non-interactively (`amend`).
+    let action = if opts.message.is_some() {
+        "amend"
+    } else {
+        "reword"
+    };
+    let plan: Vec<PlanRow> = commits
+        .iter()
+        .map(|c| PlanRow {
+            sha: c.commit_sha.clone(),
+            subject: c.title.clone(),
+            change_id: c.change_id.clone(),
+            action: (c.commit_sha == target.sha).then(|| action.to_string()),
+        })
+        .collect();
+
     if opts.dry_run {
-        return Ok(Outcome::DryRun {
-            commit: target,
-            inline_message: opts.message.is_some(),
-        });
+        return Ok(Outcome::DryRun { plan });
     }
 
     let editor = if let Some(msg) = opts.message {
@@ -96,7 +111,7 @@ pub fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         build_sequence_editor_reword(opts.mergify_binary, &target.sha)
     };
     spawn_rebase(&repo_dir, &base, Some(&editor))?;
-    Ok(Outcome::Reworded { commit: target })
+    Ok(Outcome::Reworded { plan })
 }
 
 fn write_temp_message(message: &str) -> Result<PathBuf, CliError> {
@@ -245,13 +260,13 @@ mod tests {
         })
         .unwrap();
         match outcome {
-            Outcome::DryRun {
-                commit,
-                inline_message,
-            } => {
-                assert_eq!(commit.sha, commits[1]);
-                assert_eq!(commit.subject, "Commit B");
-                assert!(!inline_message);
+            Outcome::DryRun { plan } => {
+                // Full stack (A, B); B is the reworded target.
+                assert_eq!(plan.len(), 2);
+                assert_eq!(plan[1].sha, commits[1]);
+                assert_eq!(plan[1].subject, "Commit B");
+                assert_eq!(plan[1].action.as_deref(), Some("reword"));
+                assert_eq!(plan[0].action, None);
             }
             other => panic!("unexpected: {other:?}"),
         }
@@ -270,10 +285,10 @@ mod tests {
         })
         .unwrap();
         match outcome {
-            Outcome::DryRun {
-                inline_message: true,
-                ..
-            } => {}
+            Outcome::DryRun { plan } => {
+                // `-m` tags the target as `amend` rather than `reword`.
+                assert_eq!(plan[1].action.as_deref(), Some("amend"));
+            }
             other => panic!("unexpected: {other:?}"),
         }
     }

--- a/crates/mergify-stack/src/commands/squash.rs
+++ b/crates/mergify-stack/src/commands/squash.rs
@@ -17,18 +17,28 @@ use mergify_core::CliError;
 use crate::change_id;
 use crate::git::{resolve_repo_toplevel, run_git_capture, shell_quote, spawn_rebase};
 use crate::local_commits::{self, LocalCommit};
+use crate::plan_display::PlanRow;
 use crate::trunk;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OrderedCommit {
-    pub sha: String,
-    pub subject: String,
+struct OrderedCommit {
+    sha: String,
+    subject: String,
+    change_id: String,
 }
 
 #[derive(Debug, Clone)]
 pub enum Outcome {
-    Squashed { plan: Vec<OrderedCommit> },
-    DryRun { plan: Vec<OrderedCommit> },
+    /// Squash ran to completion. `plan` is the reordered full stack
+    /// (sources folded behind the target) with `[fixup]` tags on
+    /// the source rows.
+    Squashed {
+        plan: Vec<PlanRow>,
+    },
+    /// `--dry-run` short-circuit. Same full-stack `plan`, no rebase.
+    DryRun {
+        plan: Vec<PlanRow>,
+    },
     EmptyStack,
 }
 
@@ -91,14 +101,27 @@ pub fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         new_order.push(OrderedCommit {
             sha: c.commit_sha.clone(),
             subject: c.title.clone(),
+            change_id: c.change_id.clone(),
         });
         if c.commit_sha == target.sha {
             new_order.extend(srcs.iter().cloned());
         }
     }
 
+    let plan: Vec<PlanRow> = new_order
+        .iter()
+        .map(|c| PlanRow {
+            sha: c.sha.clone(),
+            subject: c.subject.clone(),
+            change_id: c.change_id.clone(),
+            action: src_sha_set
+                .contains(c.sha.as_str())
+                .then(|| "fixup".to_string()),
+        })
+        .collect();
+
     if opts.dry_run {
-        return Ok(Outcome::DryRun { plan: new_order });
+        return Ok(Outcome::DryRun { plan });
     }
 
     let ordered_shas: Vec<String> = new_order.iter().map(|c| c.sha.clone()).collect();
@@ -124,7 +147,7 @@ pub fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         exec_after_sha.as_deref(),
         exec_command.as_deref(),
     )?;
-    Ok(Outcome::Squashed { plan: new_order })
+    Ok(Outcome::Squashed { plan })
 }
 
 fn match_commit(prefix: &str, commits: &[LocalCommit]) -> Result<OrderedCommit, CliError> {
@@ -152,6 +175,7 @@ fn match_commit(prefix: &str, commits: &[LocalCommit]) -> Result<OrderedCommit, 
         [only] => Ok(OrderedCommit {
             sha: only.commit_sha.clone(),
             subject: only.title.clone(),
+            change_id: only.change_id.clone(),
         }),
         many => {
             let listing = many

--- a/crates/mergify-stack/src/git.rs
+++ b/crates/mergify-stack/src/git.rs
@@ -104,9 +104,16 @@ pub fn spawn_rebase(
         .status()
         .map_err(|e| CliError::Generic(format!("failed to spawn `git rebase -i`: {e}")))?;
     if !status.success() {
-        return Err(CliError::Generic(format!(
-            "`git rebase -i {base}` exited {status}"
-        )));
+        // A non-zero `git rebase -i` almost always means conflicts.
+        // Surface the recovery steps and map to the dedicated
+        // Conflict exit code (4) so scripts can branch on it — same
+        // contract as the Python `run_scripted_rebase`.
+        return Err(CliError::Conflict(
+            "rebase failed — there may be conflicts\n\
+             Resolve conflicts then run: git rebase --continue\n\
+             Or abort the rebase with: git rebase --abort"
+                .to_string(),
+        ));
     }
     Ok(())
 }

--- a/crates/mergify-stack/src/lib.rs
+++ b/crates/mergify-stack/src/lib.rs
@@ -83,6 +83,7 @@ pub mod git;
 pub mod local_commits;
 pub mod notes_push;
 pub mod plan;
+pub mod plan_display;
 pub mod pr_upsert;
 pub mod push_helpers;
 pub mod rebase_log;

--- a/crates/mergify-stack/src/notes_push.rs
+++ b/crates/mergify-stack/src/notes_push.rs
@@ -199,11 +199,23 @@ pub fn push_branches(
     // updates, …). Always cleanup, even on failure.
     let mut cmd = git_cmd(repo_dir);
     cmd.args(&arg_refs).env(PUSH_ENV_MARKER, "1");
-    let status = cmd
-        .status()
+    // Capture stdio rather than inherit it: `git push` narrates the
+    // branch creation, `remote:` ruleset-bypass notices, and the
+    // "create a pull request by visiting …" hint, all of which are
+    // noise next to the orchestrator's own plan/created summary.
+    // Keep it for the failure path only. Mirrors `run_git_silent`
+    // and the Python `utils.git` wrapper.
+    let output = cmd
+        .output()
         .map_err(|e| CliError::Generic(format!("failed to spawn `git push`: {e}")))?;
-    if !status.success() {
-        return Err(CliError::Generic(format!("`git push` exited {status}")));
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim();
+        return Err(CliError::Generic(if stderr.is_empty() {
+            format!("`git push` exited {}", output.status)
+        } else {
+            format!("`git push` exited {}:\n{stderr}", output.status)
+        }));
     }
     Ok(())
 }

--- a/crates/mergify-stack/src/plan_display.rs
+++ b/crates/mergify-stack/src/plan_display.rs
@@ -1,0 +1,189 @@
+//! Shared renderer for the full-stack action-plan previews printed
+//! by `drop`/`squash`/`fixup`/`reword`/`reorder`/`move`.
+//!
+//! Port of `mergify_cli/stack/reorder.py::{display_plan,
+//! display_action_plan}`. Every plan lists the ENTIRE stack in
+//! `base..HEAD` order, numbered 1..N, each row showing the 12-char
+//! SHA, the subject, the 12-char Change-Id (when present), and an
+//! optional ` [<action>]` tag. The render is plain text — no color,
+//! no Rich markup — matching the CLI's deliberate plain output.
+
+/// One row of a plan preview: a single stack commit plus the
+/// action (if any) that this command applies to it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanRow {
+    /// Full 40-hex commit SHA. Truncated to 12 chars when rendered.
+    pub sha: String,
+    /// Commit subject line.
+    pub subject: String,
+    /// The commit's `Change-Id:` trailer value, or empty string
+    /// when absent. Rendered as ` (<change_id[:12]>)` when non-empty.
+    pub change_id: String,
+    /// The action tag for this row (e.g. `drop`, `fixup`, `reword`,
+    /// `amend`), or `None` for untouched rows / tag-less plans.
+    pub action: Option<String>,
+}
+
+/// Render a plan preview: the `title` line followed by one
+/// formatted line per row, mirroring Python's
+/// `display_plan` / `display_action_plan`.
+///
+/// Each row is `  {idx}. {sha[:12]} {subject}{cid}{tag}` where
+/// `idx` is 1-based, `cid` is ` ({change_id[:12]})` when the
+/// Change-Id is non-empty, and `tag` is ` [{action}]` when an
+/// action is set.
+#[must_use]
+pub fn render_plan(title: &str, rows: &[PlanRow]) -> Vec<String> {
+    let mut out = Vec::with_capacity(rows.len() + 1);
+    out.push(title.to_string());
+    for (idx, row) in rows.iter().enumerate() {
+        let sha = truncate(&row.sha, 12);
+        let cid = if row.change_id.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", truncate(&row.change_id, 12))
+        };
+        let tag = match &row.action {
+            Some(action) => format!(" [{action}]"),
+            None => String::new(),
+        };
+        out.push(format!(
+            "  {n}. {sha} {subject}{cid}{tag}",
+            n = idx + 1,
+            subject = row.subject,
+        ));
+    }
+    out
+}
+
+fn truncate(s: &str, max: usize) -> &str {
+    &s[..s.len().min(max)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(sha: &str, subject: &str, change_id: &str, action: Option<&str>) -> PlanRow {
+        PlanRow {
+            sha: sha.to_string(),
+            subject: subject.to_string(),
+            change_id: change_id.to_string(),
+            action: action.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn title_only_when_no_rows() {
+        assert_eq!(render_plan("Drop plan:", &[]), vec!["Drop plan:"]);
+    }
+
+    #[test]
+    fn cid_shown_when_present() {
+        let rows = [row(
+            "abc123def4567890",
+            "Add the thing",
+            "I0123456789abcdef",
+            None,
+        )];
+        assert_eq!(
+            render_plan("Move plan:", &rows),
+            vec![
+                "Move plan:".to_string(),
+                "  1. abc123def456 Add the thing (I0123456789a)".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn cid_omitted_when_absent() {
+        let rows = [row("abc123def4567890", "No change id", "", None)];
+        assert_eq!(
+            render_plan("Move plan:", &rows),
+            vec![
+                "Move plan:".to_string(),
+                "  1. abc123def456 No change id".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn action_tag_appended_when_present() {
+        let rows = [row(
+            "abc123def4567890",
+            "Drop me",
+            "I0123456789abcdef",
+            Some("drop"),
+        )];
+        assert_eq!(
+            render_plan("Drop plan:", &rows),
+            vec![
+                "Drop plan:".to_string(),
+                "  1. abc123def456 Drop me (I0123456789a) [drop]".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn action_tag_without_cid() {
+        let rows = [row("abc123def4567890", "Drop me", "", Some("drop"))];
+        assert_eq!(
+            render_plan("Drop plan:", &rows),
+            vec![
+                "Drop plan:".to_string(),
+                "  1. abc123def456 Drop me [drop]".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn sha_and_change_id_truncated_to_twelve() {
+        // Full 40-hex SHA and full I+40-hex Change-Id both truncate
+        // to exactly 12 chars.
+        let rows = [row(
+            "0123456789abcdef0123456789abcdef01234567",
+            "Long ids",
+            "I0123456789abcdef0123456789abcdef01234567",
+            Some("fixup"),
+        )];
+        assert_eq!(
+            render_plan("Fixup plan:", &rows),
+            vec![
+                "Fixup plan:".to_string(),
+                "  1. 0123456789ab Long ids (I0123456789a) [fixup]".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn short_sha_and_cid_are_left_intact() {
+        // Inputs shorter than 12 chars must not panic and pass
+        // through unchanged.
+        let rows = [row("abc", "Short", "I12", None)];
+        assert_eq!(
+            render_plan("Reorder plan:", &rows),
+            vec![
+                "Reorder plan:".to_string(),
+                "  1. abc Short (I12)".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn multi_row_numbering_is_one_based_and_sequential() {
+        let rows = [
+            row("aaaa111111111111", "First", "Iaaaa11112222", Some("fixup")),
+            row("bbbb222222222222", "Second", "", None),
+            row("cccc333333333333", "Third", "Icccc33334444", None),
+        ];
+        assert_eq!(
+            render_plan("Squash plan:", &rows),
+            vec![
+                "Squash plan:".to_string(),
+                "  1. aaaa11111111 First (Iaaaa1111222) [fixup]".to_string(),
+                "  2. bbbb22222222 Second".to_string(),
+                "  3. cccc33333333 Third (Icccc3333444)".to_string(),
+            ],
+        );
+    }
+}

--- a/crates/mergify-stack/src/rebase_log.rs
+++ b/crates/mergify-stack/src/rebase_log.rs
@@ -103,8 +103,8 @@ pub fn rebase_dry_run(
             let n = decision.approved_pulls.len();
             let plural = if n == 1 { "" } else { "s" };
             let mut lines = vec![format!(
-                "[orange]branch `{dest_branch}` rebase would be skipped: \
-                 approvals detected on {n} PR{plural}[/]",
+                "branch `{dest_branch}` rebase would be skipped: \
+                 approvals detected on {n} PR{plural}",
             )];
             for pull in &decision.approved_pulls {
                 let number = pull.get("number").and_then(Value::as_u64).unwrap_or(0);
@@ -117,13 +117,13 @@ pub fn rebase_dry_run(
         RebaseReason::ConflictOverride => {
             let numbers = pull_numbers_csv(&decision.approved_pulls);
             vec![format!(
-                "[orange]branch `{dest_branch}` would be rebased on `{remote}/{base_branch}` \
-                 (bottom PR has conflicts; approvals on PR(s) {numbers} would be dismissed)[/]",
+                "branch `{dest_branch}` would be rebased on `{remote}/{base_branch}` \
+                 (bottom PR has conflicts; approvals on PR(s) {numbers} would be dismissed)",
             )]
         }
         RebaseReason::Forced => vec![format!(
-            "[orange]branch `{dest_branch}` would be rebased on `{remote}/{base_branch}` \
-             (--force-rebase; approvals may be dismissed)[/]",
+            "branch `{dest_branch}` would be rebased on `{remote}/{base_branch}` \
+             (--force-rebase; approvals may be dismissed)",
         )],
         RebaseReason::NoApprovals => {
             // Match Python's "only warn if behind" — silent
@@ -137,8 +137,8 @@ pub fn rebase_dry_run(
                 "commits"
             };
             vec![format!(
-                "[orange]branch `{dest_branch}` is behind `{remote}/{base_branch}` \
-                 by {commits_behind} {plural}, commit SHAs will differ after rebase[/]",
+                "branch `{dest_branch}` is behind `{remote}/{base_branch}` \
+                 by {commits_behind} {plural}, commit SHAs will differ after rebase",
             )]
         }
     }


### PR DESCRIPTION
drop/squash/fixup/reword/reorder/move printed only the affected commits, only on --dry-run, and dropped the Change-Id and per-commit action tags; real runs printed ad-hoc per-commit lines with no plan. Python printed the whole stack — numbered, with Change-Id and action tags — unconditionally on both dry-run and real runs.

Add a shared plan_display::render_plan mirroring Python's display_plan/display_action_plan, have each command's Outcome carry the full base..HEAD stack as PlanRow values (with Change-Id and the per-commit action), and render it on both paths followed by the existing success/dry-run footer.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #1616