### PR TITLE
fix(stack): restore prefix-match error detail and not-found exit codes

### DIFF
--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -2384,12 +2384,15 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                     } => {
                         println!("Opening PR #{pull_number}: {title}");
                         println!("  {pull_url}");
+                        Ok(mergify_core::ExitCode::Success)
                     }
                     mergify_stack::commands::open::Outcome::EmptyStack => {
+                        // Python exits STACK_NOT_FOUND (3) so callers
+                        // can detect the empty stack via `$?`.
                         println!("No commits in stack");
+                        Ok(mergify_core::ExitCode::StackNotFound)
                     }
                 }
-                Ok(mergify_core::ExitCode::Success)
             }
             NativeCommand::StackHooks(opts) => {
                 if opts.do_setup {

--- a/crates/mergify-stack/src/commands/drop.rs
+++ b/crates/mergify-stack/src/commands/drop.rs
@@ -125,22 +125,21 @@ fn match_commit(prefix: &str, commits: &[LocalCommit]) -> Result<DroppedCommit, 
         )
     };
     match matches.as_slice() {
-        [] => Err(CliError::StackNotFound(format!(
-            "no commit found matching {field} prefix '{prefix}'"
-        ))),
+        [] => Err(crate::match_commit::not_found(field, prefix)),
         [only] => Ok(DroppedCommit {
             sha: only.commit_sha.clone(),
             subject: only.title.clone(),
         }),
         many => {
-            let listing = many
+            let candidates: Vec<crate::match_commit::Candidate<'_>> = many
                 .iter()
-                .map(|c| format!("{} {}", &c.commit_sha[..7], c.title))
-                .collect::<Vec<_>>()
-                .join("\n  ");
-            Err(CliError::InvalidState(format!(
-                "{field} prefix '{prefix}' matches multiple commits:\n  {listing}"
-            )))
+                .map(|c| crate::match_commit::Candidate {
+                    commit_sha: &c.commit_sha,
+                    title: &c.title,
+                    change_id: &c.change_id,
+                })
+                .collect();
+            Err(crate::match_commit::ambiguous(field, prefix, &candidates))
         }
     }
 }

--- a/crates/mergify-stack/src/commands/edit.rs
+++ b/crates/mergify-stack/src/commands/edit.rs
@@ -116,22 +116,21 @@ fn match_commit(
         )
     };
     match matches.as_slice() {
-        [] => Err(CliError::StackNotFound(format!(
-            "no commit found matching {field} prefix '{prefix}'"
-        ))),
+        [] => Err(crate::match_commit::not_found(field, prefix)),
         [only] => Ok(EditingCommit {
             sha: only.commit_sha.clone(),
             subject: only.title.clone(),
         }),
         many => {
-            let listing = many
+            let candidates: Vec<crate::match_commit::Candidate<'_>> = many
                 .iter()
-                .map(|c| format!("{} {}", &c.commit_sha[..7], c.title))
-                .collect::<Vec<_>>()
-                .join("\n  ");
-            Err(CliError::InvalidState(format!(
-                "{field} prefix '{prefix}' matches multiple commits:\n  {listing}"
-            )))
+                .map(|c| crate::match_commit::Candidate {
+                    commit_sha: &c.commit_sha,
+                    title: &c.title,
+                    change_id: &c.change_id,
+                })
+                .collect();
+            Err(crate::match_commit::ambiguous(field, prefix, &candidates))
         }
     }
 }

--- a/crates/mergify-stack/src/commands/fixup.rs
+++ b/crates/mergify-stack/src/commands/fixup.rs
@@ -138,22 +138,21 @@ fn match_commit(prefix: &str, commits: &[LocalCommit]) -> Result<FixedUpCommit, 
         )
     };
     match matches.as_slice() {
-        [] => Err(CliError::StackNotFound(format!(
-            "no commit found matching {field} prefix '{prefix}'"
-        ))),
+        [] => Err(crate::match_commit::not_found(field, prefix)),
         [only] => Ok(FixedUpCommit {
             sha: only.commit_sha.clone(),
             subject: only.title.clone(),
         }),
         many => {
-            let listing = many
+            let candidates: Vec<crate::match_commit::Candidate<'_>> = many
                 .iter()
-                .map(|c| format!("{} {}", &c.commit_sha[..7], c.title))
-                .collect::<Vec<_>>()
-                .join("\n  ");
-            Err(CliError::InvalidState(format!(
-                "{field} prefix '{prefix}' matches multiple commits:\n  {listing}"
-            )))
+                .map(|c| crate::match_commit::Candidate {
+                    commit_sha: &c.commit_sha,
+                    title: &c.title,
+                    change_id: &c.change_id,
+                })
+                .collect();
+            Err(crate::match_commit::ambiguous(field, prefix, &candidates))
         }
     }
 }

--- a/crates/mergify-stack/src/commands/list.rs
+++ b/crates/mergify-stack/src/commands/list.rs
@@ -81,11 +81,12 @@ pub async fn run(opts: &Options<'_>) -> Result<StackListOutput, CliError> {
 
     let (remote, base_branch) = opts.trunk;
     if base_branch == dest_branch {
-        return Err(CliError::InvalidState(format!(
-            "your local branch `{dest_branch}` targets itself: `{remote}/{base_branch}`. \
-             Either fix the target branch (`git branch {dest_branch} \
-             --set-upstream-to=<remote>/<target>`) or rename it."
-        )));
+        return Err(stack_context::targets_itself_error(
+            Some(&repo_dir),
+            &dest_branch,
+            remote,
+            base_branch,
+        ));
     }
 
     let stack_prefix = if opts.branch_prefix.is_empty() {

--- a/crates/mergify-stack/src/commands/move_cmd.rs
+++ b/crates/mergify-stack/src/commands/move_cmd.rs
@@ -206,23 +206,22 @@ fn match_commit(prefix: &str, commits: &[LocalCommit]) -> Result<OrderedCommit, 
         )
     };
     match matches.as_slice() {
-        [] => Err(CliError::StackNotFound(format!(
-            "no commit found matching {field} prefix '{prefix}'"
-        ))),
+        [] => Err(crate::match_commit::not_found(field, prefix)),
         [only] => Ok(OrderedCommit {
             sha: only.commit_sha.clone(),
             subject: only.title.clone(),
             change_id: only.change_id.clone(),
         }),
         many => {
-            let listing = many
+            let candidates: Vec<crate::match_commit::Candidate<'_>> = many
                 .iter()
-                .map(|c| format!("{} {}", &c.commit_sha[..7], c.title))
-                .collect::<Vec<_>>()
-                .join("\n  ");
-            Err(CliError::InvalidState(format!(
-                "{field} prefix '{prefix}' matches multiple commits:\n  {listing}"
-            )))
+                .map(|c| crate::match_commit::Candidate {
+                    commit_sha: &c.commit_sha,
+                    title: &c.title,
+                    change_id: &c.change_id,
+                })
+                .collect();
+            Err(crate::match_commit::ambiguous(field, prefix, &candidates))
         }
     }
 }

--- a/crates/mergify-stack/src/commands/note.rs
+++ b/crates/mergify-stack/src/commands/note.rs
@@ -64,9 +64,11 @@ pub enum Outcome {
 ///
 /// Errors:
 /// - [`CliError::InvalidState`] for an empty message (inline `-m ""`
-///   or editor returning only comment lines), and for an
-///   ambiguous / missing Change-Id prefix match. Matches Python's
-///   `sys.exit(ExitCode.INVALID_STATE)` flow.
+///   or editor returning only comment lines) and for an ambiguous
+///   Change-Id prefix match (exit 7).
+/// - [`CliError::StackNotFound`] when a Change-Id prefix matches no
+///   commit in the stack (exit 3) — matches Python's
+///   `sys.exit(ExitCode.STACK_NOT_FOUND)`.
 /// - [`CliError::Generic`] for git invocation failures and editor
 ///   process errors.
 pub fn run(
@@ -183,19 +185,22 @@ fn resolve_change_id_prefix(repo_dir: Option<&Path>, prefix: &str) -> Result<Str
         .filter(|c| c.change_id.starts_with(prefix))
         .collect();
     match matches.as_slice() {
-        [] => Err(CliError::InvalidState(format!(
-            "no commit found matching Change-Id prefix '{prefix}'"
-        ))),
+        [] => Err(crate::match_commit::not_found("Change-Id", prefix)),
         [only] => Ok(only.commit_sha.clone()),
         many => {
-            let listing = many
+            let candidates: Vec<crate::match_commit::Candidate<'_>> = many
                 .iter()
-                .map(|c| format!("{} {}", &c.commit_sha[..7], c.title))
-                .collect::<Vec<_>>()
-                .join("\n  ");
-            Err(CliError::InvalidState(format!(
-                "Change-Id prefix '{prefix}' matches multiple commits:\n  {listing}"
-            )))
+                .map(|c| crate::match_commit::Candidate {
+                    commit_sha: &c.commit_sha,
+                    title: &c.title,
+                    change_id: &c.change_id,
+                })
+                .collect();
+            Err(crate::match_commit::ambiguous(
+                "Change-Id",
+                prefix,
+                &candidates,
+            ))
         }
     }
 }
@@ -604,7 +609,7 @@ mod tests {
         )
         .unwrap_err();
         match err {
-            CliError::InvalidState(m) => {
+            CliError::StackNotFound(m) => {
                 assert!(m.contains("no commit found matching Change-Id"), "got: {m}");
             }
             other => panic!("unexpected: {other:?}"),

--- a/crates/mergify-stack/src/commands/push.rs
+++ b/crates/mergify-stack/src/commands/push.rs
@@ -127,11 +127,12 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
 
     let (remote, base_branch) = opts.trunk;
     if base_branch == dest_branch {
-        return Err(CliError::InvalidState(format!(
-            "your local branch `{dest_branch}` targets itself: \
-             `{remote}/{base_branch}`. \
-             Switch off the trunk branch before pushing.",
-        )));
+        return Err(stack_context::targets_itself_error(
+            Some(&repo_dir),
+            &dest_branch,
+            remote,
+            base_branch,
+        ));
     }
 
     let stack_prefix = if opts.branch_prefix.is_empty() {

--- a/crates/mergify-stack/src/commands/reorder.rs
+++ b/crates/mergify-stack/src/commands/reorder.rs
@@ -131,23 +131,22 @@ fn match_commit(prefix: &str, commits: &[LocalCommit]) -> Result<OrderedCommit, 
         )
     };
     match matches.as_slice() {
-        [] => Err(CliError::StackNotFound(format!(
-            "no commit found matching {field} prefix '{prefix}'"
-        ))),
+        [] => Err(crate::match_commit::not_found(field, prefix)),
         [only] => Ok(OrderedCommit {
             sha: only.commit_sha.clone(),
             subject: only.title.clone(),
             change_id: only.change_id.clone(),
         }),
         many => {
-            let listing = many
+            let candidates: Vec<crate::match_commit::Candidate<'_>> = many
                 .iter()
-                .map(|c| format!("{} {}", &c.commit_sha[..7], c.title))
-                .collect::<Vec<_>>()
-                .join("\n  ");
-            Err(CliError::InvalidState(format!(
-                "{field} prefix '{prefix}' matches multiple commits:\n  {listing}"
-            )))
+                .map(|c| crate::match_commit::Candidate {
+                    commit_sha: &c.commit_sha,
+                    title: &c.title,
+                    change_id: &c.change_id,
+                })
+                .collect();
+            Err(crate::match_commit::ambiguous(field, prefix, &candidates))
         }
     }
 }

--- a/crates/mergify-stack/src/commands/reword.rs
+++ b/crates/mergify-stack/src/commands/reword.rs
@@ -152,22 +152,21 @@ fn match_commit(prefix: &str, commits: &[LocalCommit]) -> Result<RewordedCommit,
         )
     };
     match matches.as_slice() {
-        [] => Err(CliError::StackNotFound(format!(
-            "no commit found matching {field} prefix '{prefix}'"
-        ))),
+        [] => Err(crate::match_commit::not_found(field, prefix)),
         [only] => Ok(RewordedCommit {
             sha: only.commit_sha.clone(),
             subject: only.title.clone(),
         }),
         many => {
-            let listing = many
+            let candidates: Vec<crate::match_commit::Candidate<'_>> = many
                 .iter()
-                .map(|c| format!("{} {}", &c.commit_sha[..7], c.title))
-                .collect::<Vec<_>>()
-                .join("\n  ");
-            Err(CliError::InvalidState(format!(
-                "{field} prefix '{prefix}' matches multiple commits:\n  {listing}"
-            )))
+                .map(|c| crate::match_commit::Candidate {
+                    commit_sha: &c.commit_sha,
+                    title: &c.title,
+                    change_id: &c.change_id,
+                })
+                .collect();
+            Err(crate::match_commit::ambiguous(field, prefix, &candidates))
         }
     }
 }

--- a/crates/mergify-stack/src/commands/squash.rs
+++ b/crates/mergify-stack/src/commands/squash.rs
@@ -169,23 +169,22 @@ fn match_commit(prefix: &str, commits: &[LocalCommit]) -> Result<OrderedCommit, 
         )
     };
     match matches.as_slice() {
-        [] => Err(CliError::StackNotFound(format!(
-            "no commit found matching {field} prefix '{prefix}'"
-        ))),
+        [] => Err(crate::match_commit::not_found(field, prefix)),
         [only] => Ok(OrderedCommit {
             sha: only.commit_sha.clone(),
             subject: only.title.clone(),
             change_id: only.change_id.clone(),
         }),
         many => {
-            let listing = many
+            let candidates: Vec<crate::match_commit::Candidate<'_>> = many
                 .iter()
-                .map(|c| format!("{} {}", &c.commit_sha[..7], c.title))
-                .collect::<Vec<_>>()
-                .join("\n  ");
-            Err(CliError::InvalidState(format!(
-                "{field} prefix '{prefix}' matches multiple commits:\n  {listing}"
-            )))
+                .map(|c| crate::match_commit::Candidate {
+                    commit_sha: &c.commit_sha,
+                    title: &c.title,
+                    change_id: &c.change_id,
+                })
+                .collect();
+            Err(crate::match_commit::ambiguous(field, prefix, &candidates))
         }
     }
 }

--- a/crates/mergify-stack/src/commands/sync.rs
+++ b/crates/mergify-stack/src/commands/sync.rs
@@ -66,10 +66,12 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
 
     let (remote, base_branch) = opts.trunk;
     if base_branch == dest_branch {
-        return Err(CliError::InvalidState(format!(
-            "your local branch `{dest_branch}` targets itself: `{remote}/{base_branch}`. \
-             Switch off the trunk branch before syncing."
-        )));
+        return Err(stack_context::targets_itself_error(
+            Some(&repo_dir),
+            &dest_branch,
+            remote,
+            base_branch,
+        ));
     }
 
     let stack_prefix = if opts.branch_prefix.is_empty() {

--- a/crates/mergify-stack/src/lib.rs
+++ b/crates/mergify-stack/src/lib.rs
@@ -81,6 +81,7 @@ pub mod commands;
 pub mod comment_upsert;
 pub mod git;
 pub mod local_commits;
+pub mod match_commit;
 pub mod notes_push;
 pub mod plan;
 pub mod plan_display;

--- a/crates/mergify-stack/src/match_commit.rs
+++ b/crates/mergify-stack/src/match_commit.rs
@@ -1,0 +1,165 @@
+//! Shared formatting for the prefix-matching errors every stack
+//! subcommand emits.
+//!
+//! `drop`, `squash`, `fixup`, `edit`, `move`, `reword`, `reorder`,
+//! and `note` each resolve a user-supplied `<COMMIT>` argument
+//! against the stack by matching a SHA or Change-Id prefix. The
+//! zero-match and ambiguous-match wording must be identical across
+//! all of them and match the Python `reorder.py::match_commit`
+//! output, so the formatting lives here once.
+//!
+//! Each command builds a slice of [`Candidate`] (a borrowed view
+//! over its own per-commit type, all of which expose
+//! `commit_sha` / `title` / `change_id`) and delegates.
+
+use mergify_core::CliError;
+
+/// A single ambiguous-match candidate, borrowed from the caller's
+/// per-command commit type. `change_id` is empty when the commit
+/// carries no `Change-Id` trailer; the formatter omits the
+/// `(<change_id>)` suffix in that case.
+pub struct Candidate<'a> {
+    pub commit_sha: &'a str,
+    pub title: &'a str,
+    pub change_id: &'a str,
+}
+
+/// `field` is the human label for what the prefix matched against —
+/// either `"SHA"` or `"Change-Id"`.
+///
+/// Zero matches → [`CliError::StackNotFound`] (exit 3), matching
+/// Python's `sys.exit(ExitCode.STACK_NOT_FOUND)`.
+#[must_use]
+pub fn not_found(field: &str, prefix: &str) -> CliError {
+    CliError::StackNotFound(format!(
+        "no commit found matching {field} prefix '{prefix}'"
+    ))
+}
+
+/// Ambiguous match → [`CliError::InvalidState`] (exit 7), matching
+/// Python's `sys.exit(ExitCode.INVALID_STATE)`.
+///
+/// The message mirrors `reorder.py::match_commit`:
+/// `ambiguous {field} prefix '{prefix}' matches {N} commits:` then
+/// one line per candidate `  {sha[:12]} {title} ({change_id[:12]})`
+/// (the `(...)` suffix omitted when the candidate has no Change-Id).
+#[must_use]
+pub fn ambiguous(field: &str, prefix: &str, candidates: &[Candidate<'_>]) -> CliError {
+    let listing = candidates
+        .iter()
+        .map(format_candidate)
+        .collect::<Vec<_>>()
+        .join("\n  ");
+    CliError::InvalidState(format!(
+        "ambiguous {field} prefix '{prefix}' matches {n} commits:\n  {listing}",
+        n = candidates.len(),
+    ))
+}
+
+fn format_candidate(c: &Candidate<'_>) -> String {
+    let sha = &c.commit_sha[..c.commit_sha.len().min(12)];
+    if c.change_id.is_empty() {
+        format!("{sha} {title}", title = c.title)
+    } else {
+        let cid = &c.change_id[..c.change_id.len().min(12)];
+        format!("{sha} {title} ({cid})", title = c.title)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cand<'a>(sha: &'a str, title: &'a str, change_id: &'a str) -> Candidate<'a> {
+        Candidate {
+            commit_sha: sha,
+            title,
+            change_id,
+        }
+    }
+
+    #[test]
+    fn not_found_is_stack_not_found_with_field_and_prefix() {
+        match not_found("Change-Id", "Ibeef") {
+            CliError::StackNotFound(msg) => {
+                assert_eq!(msg, "no commit found matching Change-Id prefix 'Ibeef'");
+            }
+            other => panic!("expected StackNotFound, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ambiguous_is_invalid_state_with_count_and_header() {
+        let candidates = [
+            cand(
+                "aaaaaaaaaaaa1111111111111111111111111111",
+                "first",
+                "Iaaaaaaaaaaaa1111111111111111111111111111",
+            ),
+            cand(
+                "bbbbbbbbbbbb2222222222222222222222222222",
+                "second",
+                "Ibbbbbbbbbbbb2222222222222222222222222222",
+            ),
+        ];
+        match ambiguous("SHA", "ab", &candidates) {
+            CliError::InvalidState(msg) => {
+                // 12-char SHA + 12-char Change-Id (the `I` plus 11
+                // hex chars).
+                assert_eq!(
+                    msg,
+                    "ambiguous SHA prefix 'ab' matches 2 commits:\n  \
+                     aaaaaaaaaaaa first (Iaaaaaaaaaaa)\n  \
+                     bbbbbbbbbbbb second (Ibbbbbbbbbbb)"
+                );
+            }
+            other => panic!("expected InvalidState, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ambiguous_truncates_sha_and_change_id_to_twelve() {
+        let candidates = [cand(
+            "0123456789abcdef0123456789abcdef01234567",
+            "subject",
+            "I0123456789abcdef0123456789abcdef01234567",
+        )];
+        match ambiguous("SHA", "01", &candidates) {
+            CliError::InvalidState(msg) => {
+                // 12-char SHA, 12-char Change-Id (the `I` plus 11
+                // hex), not the 7-char SHA / no-Change-Id form the
+                // pre-fix code produced.
+                assert!(
+                    msg.contains("  0123456789ab subject (I0123456789a)"),
+                    "got: {msg}"
+                );
+            }
+            other => panic!("expected InvalidState, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ambiguous_omits_parens_when_no_change_id() {
+        let candidates = [cand("abcdef0123456789", "no cid", "")];
+        match ambiguous("SHA", "abc", &candidates) {
+            CliError::InvalidState(msg) => {
+                assert!(msg.contains("  abcdef012345 no cid"), "got: {msg}");
+                assert!(!msg.contains('('), "no parens expected: {msg}");
+            }
+            other => panic!("expected InvalidState, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ambiguous_handles_short_sha_and_change_id_without_panicking() {
+        // A SHA/Change-Id shorter than 12 chars must clamp rather
+        // than slice out of bounds.
+        let candidates = [cand("abc", "short", "Ixyz")];
+        match ambiguous("Change-Id", "Ix", &candidates) {
+            CliError::InvalidState(msg) => {
+                assert!(msg.contains("  abc short (Ixyz)"), "got: {msg}");
+            }
+            other => panic!("expected InvalidState, got: {other:?}"),
+        }
+    }
+}

--- a/crates/mergify-stack/src/stack_context.rs
+++ b/crates/mergify-stack/src/stack_context.rs
@@ -52,6 +52,36 @@ pub fn check_local_branch(branch_name: &str, branch_prefix: &str) -> Result<(), 
     Ok(())
 }
 
+/// Build the "your local branch targets itself" error every stack
+/// command that resolves a trunk raises when the checked-out branch
+/// *is* the trunk it would land on.
+///
+/// Mirrors `sync.py` / `list.py`: a first line carrying the resolved
+/// remote URL (`git remote get-url <remote>`, omitted gracefully
+/// when that fails) followed by the two copy-pasteable git commands.
+/// Returns [`CliError::InvalidState`] (exit 7), matching Python.
+#[must_use]
+pub fn targets_itself_error(
+    repo_dir: Option<&Path>,
+    dest_branch: &str,
+    remote: &str,
+    base_branch: &str,
+) -> CliError {
+    let location = run_git_capture(repo_dir, &["remote", "get-url", remote])
+        .ok()
+        .filter(|url| !url.is_empty())
+        .map(|url| format!(" (at {url}@{base_branch})"))
+        .unwrap_or_default();
+    CliError::InvalidState(format!(
+        "your local branch `{dest_branch}` targets itself: \
+         `{remote}/{base_branch}`{location}\n\
+         * To fix the target branch: \
+         `git branch {dest_branch} --set-upstream-to={remote}/{base_branch}`\n\
+         * To rename your local branch: \
+         `git branch -M {dest_branch} new-branch-name`"
+    ))
+}
+
 /// Owner + repository name pair, e.g. `("Mergifyio", "mergify-cli")`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RepoSlug {
@@ -236,6 +266,83 @@ mod tests {
         let slug = parse_slug("https://github.com/owner/repo.git").unwrap();
         assert_eq!(slug.owner, "owner");
         assert_eq!(slug.repo, "repo");
+    }
+
+    #[test]
+    fn targets_itself_includes_remote_url_and_both_git_commands() {
+        let dir = tempfile::tempdir().unwrap();
+        for args in [
+            &["init", "-q", "-b", "main"][..],
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/owner/repo.git",
+            ],
+        ] {
+            let ok = crate::test_env::isolated_git()
+                .arg("-C")
+                .arg(dir.path())
+                .args(args)
+                .status()
+                .unwrap()
+                .success();
+            assert!(ok, "git {args:?} failed");
+        }
+        let err = targets_itself_error(Some(dir.path()), "main", "origin", "main");
+        match err {
+            CliError::InvalidState(msg) => {
+                assert!(
+                    msg.contains(
+                        "your local branch `main` targets itself: `origin/main` \
+                         (at https://github.com/owner/repo.git@main)"
+                    ),
+                    "got: {msg}"
+                );
+                assert!(
+                    msg.contains(
+                        "* To fix the target branch: \
+                         `git branch main --set-upstream-to=origin/main`"
+                    ),
+                    "got: {msg}"
+                );
+                assert!(
+                    msg.contains(
+                        "* To rename your local branch: \
+                         `git branch -M main new-branch-name`"
+                    ),
+                    "got: {msg}"
+                );
+            }
+            other => panic!("expected InvalidState, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn targets_itself_omits_location_when_remote_url_unresolvable() {
+        let dir = tempfile::tempdir().unwrap();
+        let ok = crate::test_env::isolated_git()
+            .arg("-C")
+            .arg(dir.path())
+            .args(["init", "-q", "-b", "main"])
+            .status()
+            .unwrap()
+            .success();
+        assert!(ok);
+        // No remote configured → `git remote get-url` fails; the
+        // `(at ...)` parenthetical is dropped without erroring.
+        let err = targets_itself_error(Some(dir.path()), "main", "origin", "main");
+        match err {
+            CliError::InvalidState(msg) => {
+                assert!(
+                    msg.contains("targets itself: `origin/main`\n"),
+                    "location parenthetical should be absent: {msg}"
+                );
+                assert!(!msg.contains("(at "), "got: {msg}");
+                assert!(msg.contains("--set-upstream-to=origin/main"), "got: {msg}");
+            }
+            other => panic!("expected InvalidState, got: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/mergify-stack/src/trunk.rs
+++ b/crates/mergify-stack/src/trunk.rs
@@ -65,8 +65,15 @@ pub fn get_trunk(repo_dir: Option<&Path>) -> Result<Trunk, CliError> {
     }
 
     let (default_remote, default_branch) = get_default_remote_branch(repo_dir).map_err(|e| {
+        // Mirror Python's `get_trunk`: name the branch in a
+        // ready-to-run `git branch … --set-upstream-to=` hint so the
+        // user can fix the missing tracking without guessing the
+        // syntax. `<remote>/<branch>` stay literal — we couldn't
+        // resolve them, which is exactly why we're erroring.
         CliError::Generic(format!(
-            "can't detect the remote target branch for {current_branch}: {e}"
+            "can't detect the remote target branch for {current_branch}: {e}. \
+             Please set it with `git branch {current_branch} \
+             --set-upstream-to=<remote>/<branch>`"
         ))
     })?;
 


### PR DESCRIPTION
Ambiguous <COMMIT> resolution lost the "ambiguous" wording, the match count, each candidate's Change-Id, and used a 7-char SHA instead of 12. A no-match note target returned InvalidState (exit 7) instead of StackNotFound (3), and `stack open` on an empty stack exited 0 instead of 3, breaking $?-based detection. Add a shared match_commit helper (one copy of the Python reorder.py wording) used by drop/squash/fixup/edit/move/reword/reorder/note, and fix the two exit codes.

Also restore the remediation guidance Python printed: the `targets itself` error (sync/push/list) regains the remote URL and both `git branch` fix commands, and the trunk-not-resolvable error regains the concrete `--set-upstream-to` hint.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>