### PR TITLE
docs(readme): recommend the Homebrew tap as the primary install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ CI insights, merge queue, scheduled freezes, and configuration management.
 
 ## Installation
 
-### Homebrew (recommended — macOS + Linux)
+### Homebrew (recommended for macOS)
 
 ```shell
 brew install mergifyio/tap/mergify-cli
@@ -16,7 +16,7 @@ The fully-qualified name taps and installs in one step. Upgrade with
 Homebrew-managed binary. See the [tap](https://github.com/Mergifyio/homebrew-tap)
 for tap-trust and short-name details.
 
-### Install script (macOS + Linux, x86_64 and aarch64)
+### Install script (recommended for Linux; also macOS — x86_64 and aarch64)
 
 ```shell
 curl -fsSL https://raw.githubusercontent.com/Mergifyio/mergify-cli/main/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -5,17 +5,29 @@ CI insights, merge queue, scheduled freezes, and configuration management.
 
 ## Installation
 
-Linux + macOS (x86_64 and aarch64):
+### Homebrew (recommended — macOS + Linux)
+
+```shell
+brew install mergifyio/tap/mergify-cli
+```
+
+The fully-qualified name taps and installs in one step. Upgrade with
+`brew upgrade mergify-cli` — not `mergify self-update`, which overwrites the
+Homebrew-managed binary. See the [tap](https://github.com/Mergifyio/homebrew-tap)
+for tap-trust and short-name details.
+
+### Install script (macOS + Linux, x86_64 and aarch64)
 
 ```shell
 curl -fsSL https://raw.githubusercontent.com/Mergifyio/mergify-cli/main/install.sh | sh
 ```
 
 Installs to `~/.local/bin/mergify`. Override with `MERGIFY_INSTALL_DIR=/usr/local/bin`
-or pin a version with `MERGIFY_VERSION=2026.4.23.1`. Once installed, upgrade with
-`mergify self-update`.
+or pin a version with `MERGIFY_VERSION=2026.4.23.1`. Upgrade with `mergify self-update`.
 
-For Windows, or to bypass the script, grab the matching archive from the
+### Manual download (Windows, or to bypass the script)
+
+Grab the matching archive from the
 [latest release](https://github.com/Mergifyio/mergify-cli/releases/latest):
 
 - **Windows** — download `mergify-<version>-x86_64-pc-windows-msvc.zip`,

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ curl -fsSL https://raw.githubusercontent.com/Mergifyio/mergify-cli/main/install.
 ```
 
 Installs to `~/.local/bin/mergify`. Override with `MERGIFY_INSTALL_DIR=/usr/local/bin`
-or pin a version with `MERGIFY_VERSION=2026.4.23.1`. Upgrade with `mergify self-update`.
+or pin a version with `MERGIFY_VERSION=<version>`. Upgrade with `mergify self-update`.
 
 ### Manual download (Windows, or to bypass the script)
 


### PR DESCRIPTION
Promote `brew install mergifyio/tap/mergify-cli` to the top of the README's Installation section as the **recommended** route for macOS.

## What changed

- Restructured the Installation section into three labelled methods, ranked:
  1. **Homebrew (recommended for macOS)** → `brew install mergifyio/tap/mergify-cli`, links to the [tap](https://github.com/Mergifyio/homebrew-tap) for tap-trust / short-name details
  2. **Install script (recommended for Linux; also macOS)** → unchanged `curl … | sh`
  3. **Manual download (Windows, or to bypass the script)** → unchanged archive instructions
- Made upgrade guidance **method-specific**: Homebrew installs upgrade with `brew upgrade mergify-cli`, not `mergify self-update` (which overwrites the brew-managed binary). The previous README told *every* install to use `mergify self-update`.

Windows stays on the manual download since the tap doesn't ship a Windows formula.

🤖 Generated with [Claude Code](https://claude.com/claude-code)