### PR TITLE
fix(stack): reapply cherry-picks when dropping merged commits during sync

### DIFF
--- a/crates/mergify-ci/src/git_refs.rs
+++ b/crates/mergify-ci/src/git_refs.rs
@@ -339,7 +339,11 @@ fn checking_base_sha(note: &serde_json::Value) -> Option<String> {
 fn emit(refs: &References, format: Format, output: &mut dyn Output) -> std::io::Result<()> {
     match format {
         Format::Text => output.emit(&(), &mut |w: &mut dyn Write| {
-            writeln!(w, "Base: {}", refs.base.as_deref().unwrap_or(""))?;
+            // A missing base renders as the literal "None" to match
+            // Python's f-string (`f"Base: {ref.base}"` with
+            // ref.base = None). The Shell arm keeps the empty string
+            // since that's a shell variable value, not display text.
+            writeln!(w, "Base: {}", refs.base.as_deref().unwrap_or("None"))?;
             writeln!(w, "Head: {}", refs.head)
         }),
         Format::Shell => output.emit(&(), &mut |w: &mut dyn Write| {
@@ -635,6 +639,21 @@ mod tests {
         emit(&refs, Format::Text, &mut cap.output).unwrap();
         let stdout = cap.stdout();
         assert_eq!(stdout, "Base: b\nHead: h\n");
+    }
+
+    #[test]
+    fn emits_text_format_with_none_base() {
+        // A missing base (e.g. workflow_dispatch / schedule events)
+        // renders the literal "None", matching Python's f-string.
+        let refs = References {
+            base: None,
+            head: "HEAD".into(),
+            source: ReferencesSource::GithubEventOther,
+        };
+        let mut cap = Captured::human();
+        emit(&refs, Format::Text, &mut cap.output).unwrap();
+        let stdout = cap.stdout();
+        assert_eq!(stdout, "Base: None\nHead: HEAD\n");
     }
 
     #[test]

--- a/crates/mergify-ci/src/junit_process/command.rs
+++ b/crates/mergify-ci/src/junit_process/command.rs
@@ -100,11 +100,26 @@ pub async fn run(
         }
     };
 
-    if parsed.cases.is_empty() {
+    // Two distinct early exits, mirroring Python. When the files
+    // yield no suites at all the session/suite spans are absent, so
+    // "No spans found" is the right message. When suites parsed but
+    // hold zero test cases, the spans exist — the actual problem is
+    // a test step that never produced results.
+    if parsed.suite_names.is_empty() {
         write_early_exit(
             &mut report,
             "No spans found in the JUnit files",
             "Check that the JUnit XML files are not empty.",
+        );
+        emit(output, &report)?;
+        return Ok(ExitCode::GenericError);
+    }
+
+    if parsed.cases.is_empty() {
+        write_early_exit(
+            &mut report,
+            "No test cases found in the JUnit files",
+            "Check that your test step ran successfully before this step.",
         );
         emit(output, &report)?;
         return Ok(ExitCode::GenericError);
@@ -1207,13 +1222,15 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn testsuite_without_cases_short_circuits_with_no_spans_error() {
+        async fn testsuite_without_cases_short_circuits_with_no_test_cases_error() {
             // A `<testsuites>` wrapping an empty `<testsuite>` is
             // valid XML and gets past the parser (the parser only
             // rejects bare `<testsuites/>` with zero suites), but
-            // produces zero TestCase records. The orchestrator must
-            // bail out with a specific error before reaching the
-            // quarantine + upload layers.
+            // produces zero TestCase records. Because suites *were*
+            // parsed, the orchestrator must report "No test cases
+            // found" (the test step ran but emitted nothing), not
+            // the "No spans found" message reserved for files with
+            // no suites at all.
             let tmp = tempfile::tempdir().unwrap();
             let file = write_xml(
                 &tmp,
@@ -1246,9 +1263,14 @@ mod tests {
             assert_eq!(code, ExitCode::GenericError);
             let stdout = String::from_utf8(cap.stdout.lock().unwrap().clone()).unwrap();
             assert!(
-                stdout.contains("No spans found in the JUnit files"),
+                stdout.contains("No test cases found in the JUnit files"),
                 "{stdout}"
             );
+            assert!(
+                stdout.contains("Check that your test step ran successfully before this step."),
+                "{stdout}"
+            );
+            assert!(!stdout.contains("No spans found"), "{stdout}");
         }
     }
 }

--- a/crates/mergify-ci/src/scopes_detect/mod.rs
+++ b/crates/mergify-ci/src/scopes_detect/mod.rs
@@ -231,26 +231,27 @@ fn emit_scopes_listing(
     }
 
     // Push the "Scopes touched:" block to stdout (so a downstream
-    // pipe captures it) and the per-file dump to stderr — the
-    // primary signal for downstream tooling is the list of
-    // touched scopes.
+    // pipe captures it). Under ACTIONS_STEP_DEBUG each scope's
+    // matching files are listed (sorted) immediately under their
+    // scope name, interleaved on the same stream — matching
+    // Python's `click.echo` ordering so verbose CI logs read the
+    // same.
     output.emit(&(), &mut |w: &mut dyn Write| {
         writeln!(w, "Scopes touched:")?;
         for s in hit {
             writeln!(w, "- {s}")?;
-        }
-        Ok(())
-    })?;
-
-    if actions_debug {
-        for s in hit {
-            if let Some(files) = by_scope.get(s) {
-                for f in files {
-                    output.status(&format!("    {f}"))?;
+            if actions_debug {
+                if let Some(files) = by_scope.get(s) {
+                    let mut files: Vec<&String> = files.iter().collect();
+                    files.sort();
+                    for f in files {
+                        writeln!(w, "    {f}")?;
+                    }
                 }
             }
         }
-    }
+        Ok(())
+    })?;
     Ok(())
 }
 

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -1327,30 +1327,20 @@ fn render_stack_list_text(out: &mergify_stack::commands::list::StackListOutput, 
                 "  [{status_label}] #{num} {title} ({short}){conflict}",
                 title = entry.title,
             );
-            if verbose && !entry.ci_checks.is_empty() {
-                let checks = entry
-                    .ci_checks
-                    .iter()
-                    .map(|c| format!("{} {}", c.status, c.name))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                println!("    CI: {checks}");
-            } else if entry.ci_status != "unknown" {
-                println!("    CI: {}", entry.ci_status);
-            }
-            if verbose && !entry.reviews.is_empty() {
-                let reviewers = entry
-                    .reviews
-                    .iter()
-                    .map(|r| format!("{} {}", r.state, r.user))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                println!("    Review: {reviewers}");
-            } else if entry.review_status != "unknown" {
-                println!("    Review: {}", entry.review_status);
+            // CI + review render on a single 5-space-indented line
+            // joined by " | ", matching Python's display_stack_list
+            // (a part is omitted entirely when its status is unknown).
+            let ci_display = format_ci_display(entry, verbose);
+            let review_display = format_review_display(entry, verbose);
+            let parts: Vec<&str> = [ci_display.as_str(), review_display.as_str()]
+                .into_iter()
+                .filter(|p| !p.is_empty())
+                .collect();
+            if !parts.is_empty() {
+                println!("     {}", parts.join(" | "));
             }
             if let Some(url) = &entry.pull_url {
-                println!("    {url}");
+                println!("     {url}");
             }
         } else {
             println!("  [{status_label}] {title} ({short})", title = entry.title);
@@ -1359,17 +1349,85 @@ fn render_stack_list_text(out: &mergify_stack::commands::list::StackListOutput, 
     }
 }
 
+/// Build the `CI: …` cell for a stack-list entry. Port of Python's
+/// `_format_ci_display`: empty when the status is unknown; in
+/// verbose mode with per-check data it lists each check with a
+/// status glyph, otherwise it shows the coarse status label.
+fn format_ci_display(
+    entry: &mergify_stack::commands::list::StackListEntry,
+    verbose: bool,
+) -> String {
+    if entry.ci_status == "unknown" {
+        return String::new();
+    }
+    if verbose && !entry.ci_checks.is_empty() {
+        let checks = entry
+            .ci_checks
+            .iter()
+            .map(|c| {
+                let glyph = match c.status.as_str() {
+                    "success" => "✓",
+                    "failure" => "✗",
+                    _ => "●",
+                };
+                format!("{glyph} {}", c.name)
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        return format!("CI: {checks}");
+    }
+    let text = match entry.ci_status.as_str() {
+        "passing" => "✓ passing",
+        "failing" => "✗ failing",
+        "pending" => "● pending",
+        other => other,
+    };
+    format!("CI: {text}")
+}
+
+/// Build the `Review: …` cell for a stack-list entry. Port of
+/// Python's `_format_review_display`.
+fn format_review_display(
+    entry: &mergify_stack::commands::list::StackListEntry,
+    verbose: bool,
+) -> String {
+    if entry.review_status == "unknown" {
+        return String::new();
+    }
+    if verbose && !entry.reviews.is_empty() {
+        let reviewers = entry
+            .reviews
+            .iter()
+            .map(|r| match r.state.as_str() {
+                "APPROVED" => format!("✓ {}", r.user),
+                "CHANGES_REQUESTED" => format!("✗ {}", r.user),
+                _ => r.user.clone(),
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        return format!("Review: {reviewers}");
+    }
+    let text = match entry.review_status.as_str() {
+        "approved" => "✓ approved",
+        "changes_requested" => "✗ changes requested",
+        "pending" => "● pending",
+        other => other,
+    };
+    format!("Review: {text}")
+}
+
 /// Install / upgrade the git hooks. Prints one human line per
 /// action performed, then a summary footer. Surfaces the same
 /// outcome ``mergify_cli/stack/setup.py`` used to print.
 fn run_stack_setup(force: bool) -> Result<(), mergify_core::CliError> {
     use mergify_stack::commands::setup::HookAction;
-    let logs = mergify_stack::commands::setup::install(&mergify_stack::commands::setup::Options {
-        repo_dir: None,
-        force,
-    })?;
+    let outcome =
+        mergify_stack::commands::setup::install(&mergify_stack::commands::setup::Options {
+            repo_dir: None,
+            force,
+        })?;
     let mut any_legacy_needs_force = false;
-    for log in &logs {
+    for log in &outcome.logs {
         for action in &log.actions {
             match action {
                 HookAction::ScriptInstalled | HookAction::ScriptUpdated => {
@@ -1394,6 +1452,9 @@ fn run_stack_setup(force: bool) -> Result<(), mergify_core::CliError> {
                 HookAction::ScriptUpToDate | HookAction::WrapperAlreadyInstalled => {}
             }
         }
+    }
+    if outcome.notes_display_ref_added {
+        println!("Added notes.displayRef = refs/notes/mergify/*");
     }
     if any_legacy_needs_force {
         println!("Some hooks are legacy. Run 'mergify stack hooks --setup --force' to migrate.");
@@ -1830,9 +1891,11 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                     },
                 )?;
                 match outcome {
-                    mergify_stack::commands::edit::Outcome::PausedAt { commit } => {
-                        let short = &commit.sha[..commit.sha.len().min(12)];
-                        println!("Editing commit: {short} {subject}", subject = commit.subject);
+                    mergify_stack::commands::edit::Outcome::PausedAt { .. } => {
+                        // The "Editing commit:" notice is printed by
+                        // edit::run before the rebase so it precedes
+                        // git's output; here we add the post-rebase
+                        // amend hint.
                         println!("Amend the commit, then run: git rebase --continue");
                     }
                     mergify_stack::commands::edit::Outcome::EmptyStack => {

--- a/crates/mergify-cli/tests/stack_sync.rs
+++ b/crates/mergify-cli/tests/stack_sync.rs
@@ -226,6 +226,93 @@ async fn sync_dry_run_lists_merged_commits() {
     assert!(stdout.contains("#42"), "stdout: {stdout}");
 }
 
+/// Real (non-dry-run) sync where the merged commit was
+/// squash-merged into trunk with an identical patch. Git's default
+/// `--no-reapply-cherry-picks` would silently omit it from the
+/// rebase todo, leaving the drop editor with no `pick` line to
+/// remove — the abort we guard against with `--reapply-cherry-picks`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sync_drops_squash_merged_commit_with_matching_patch() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let (work, commits) = build_stack_repo(2);
+    let local = work.path().join("local");
+    let a_sha = commits[0].0.clone();
+    let a_cid = commits[0].1.clone();
+
+    // Simulate the merge-queue squashing commit A onto trunk: a new
+    // commit on `main` that adds the *same* `a.txt` with the *same*
+    // content, so its patch-id matches commit A and git treats A as
+    // already-applied during the rebase.
+    run_in(&local, &["checkout", "-q", "main"]);
+    std::fs::write(local.join("a.txt"), "content A").unwrap();
+    run_in(&local, &["add", "a.txt"]);
+    run_in(&local, &["commit", "-q", "-m", "Commit A (squashed #42)"]);
+    run_in(&local, &["push", "-q", "origin", "main"]);
+    run_in(&local, &["checkout", "-q", "feature"]);
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/search/issues"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "items": [{"number": 42}],
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repos/myorg/myrepo/pulls/42"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "number": 42,
+            "title": "Commit A",
+            "state": "closed",
+            "merged_at": "2025-01-01T00:00:00Z",
+            "head": {"sha": a_sha, "ref": format!("stack/tester/feature/feat-a--{}", &a_cid[1..9])},
+            "base": {"ref": "main"},
+            "html_url": "https://github.com/myorg/myrepo/pull/42",
+        })))
+        .mount(&server)
+        .await;
+
+    let output = run_mergify(
+        &local,
+        &server.uri(),
+        &[
+            "stack",
+            "sync",
+            "--trunk",
+            "origin/main",
+            "--author",
+            "tester",
+            "--branch-prefix",
+            "stack/tester",
+            "--repo",
+            "myorg/myrepo",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    // Commit A is gone; only commit B remains, rebased onto the new
+    // trunk tip (which now carries the squashed a.txt).
+    let ahead = capture(&local, &["rev-list", "--count", "origin/main..HEAD"]);
+    assert_eq!(ahead, "1", "exactly commit B should remain on the stack");
+    let a_reachable = isolated_git()
+        .arg("-C")
+        .arg(&local)
+        .args(["merge-base", "--is-ancestor", &a_sha, "HEAD"])
+        .status()
+        .unwrap()
+        .success();
+    assert!(!a_reachable, "the squash-merged commit A should be dropped");
+    let head_subject = capture(&local, &["log", "-1", "--format=%s"]);
+    assert_eq!(head_subject, "Commit B");
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn sync_rejects_auto_generated_branch_names() {
     // Create a repo whose current branch matches the

--- a/crates/mergify-freeze/src/list.rs
+++ b/crates/mergify-freeze/src/list.rs
@@ -132,10 +132,10 @@ fn row_for(freeze: &ScheduledFreeze, now: DateTime<Utc>) -> [String; 6] {
 fn format_conditions(matching: &[String], exclude: &[String]) -> String {
     let mut out = matching.join(", ");
     if !exclude.is_empty() {
-        if !out.is_empty() {
-            out.push(' ');
-        }
-        out.push_str("(exclude: ");
+        // Python always prefixes " (exclude: …)" with a leading
+        // space (`conditions += f" (exclude: …)"`), so an
+        // exclude-only cell keeps the leading space too.
+        out.push_str(" (exclude: ");
         out.push_str(&exclude.join(", "));
         out.push(')');
     }
@@ -466,10 +466,11 @@ mod tests {
 
     #[test]
     fn format_conditions_exclude_only() {
-        // Edge case the Python format produces a leading space-free
-        // `(exclude: …)`. Mirror that.
+        // Python emits a leading space before `(exclude: …)` even
+        // when there are no matching conditions (`conditions += f"
+        // (exclude: …)"` on an empty string). Mirror that.
         let m: Vec<String> = vec![];
         let e = vec!["label=hotfix".to_string()];
-        assert_eq!(format_conditions(&m, &e), "(exclude: label=hotfix)");
+        assert_eq!(format_conditions(&m, &e), " (exclude: label=hotfix)");
     }
 }

--- a/crates/mergify-queue/src/pause.rs
+++ b/crates/mergify-queue/src/pause.rs
@@ -1,9 +1,9 @@
 //! `mergify queue pause` — pause the merge queue for a repository.
 //!
 //! PUTs ``{"reason": "..."}`` to
-//! ``/v1/repos/<repo>/merge-queue/pause``. Prints a "Queue paused"
-//! confirmation with the reason (and the raw pause timestamp if
-//! the API returned one).
+//! ``/v1/repos/<repo>/merge-queue/pause``. Prints a "⚠  Queue
+//! paused" confirmation with the reason (and a coarse relative
+//! "since" delta if the API returned a pause timestamp).
 //!
 //! Confirmation flow:
 //!
@@ -16,9 +16,11 @@
 use std::io::IsTerminal;
 use std::io::Write;
 
+use chrono::Utc;
 use mergify_core::CliError;
 use mergify_core::CommandContext;
 use mergify_core::Output;
+use mergify_tui::relative_time;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -142,11 +144,14 @@ fn confirm(skip: bool, is_tty: bool, repository: &str) -> Result<(), CliError> {
 fn emit_confirmation(output: &mut dyn Output, response: &PauseResponse) -> std::io::Result<()> {
     output.emit(&(), &mut |w: &mut dyn Write| {
         match &response.reason {
-            Some(r) => write!(w, "Queue paused: \"{r}\"")?,
-            None => write!(w, "Queue paused")?,
+            Some(r) => write!(w, "⚠  Queue paused: \"{r}\"")?,
+            None => write!(w, "⚠  Queue paused")?,
         }
         if let Some(ts) = &response.paused_at {
-            write!(w, " (since {ts})")?;
+            let rel = relative_time(ts, Utc::now(), false);
+            if !rel.is_empty() {
+                write!(w, " (since {rel})")?;
+            }
         }
         writeln!(w)
     })
@@ -247,8 +252,12 @@ mod tests {
         .unwrap();
 
         let stdout = cap.stdout();
-        assert!(stdout.contains("Queue paused"), "got: {stdout:?}");
+        assert!(stdout.contains("⚠  Queue paused"), "got: {stdout:?}");
         assert!(stdout.contains("deploy freeze"), "got: {stdout:?}");
-        assert!(stdout.contains("2026-04-23"), "got: {stdout:?}");
+        // `paused_at` renders as a coarse relative delta (e.g.
+        // "5m ago"), not the raw RFC-3339 timestamp.
+        assert!(stdout.contains("(since "), "got: {stdout:?}");
+        assert!(stdout.contains(" ago)"), "got: {stdout:?}");
+        assert!(!stdout.contains("2026-04-23"), "got: {stdout:?}");
     }
 }

--- a/crates/mergify-queue/src/show.rs
+++ b/crates/mergify-queue/src/show.rs
@@ -262,14 +262,32 @@ fn print_checks_section(
 }
 
 fn print_checks_table(w: &mut dyn Write, theme: &Theme, checks: &[Check]) -> std::io::Result<()> {
-    let name_width = checks
+    // First column carries the `  Check` header, so its width is the
+    // wider of the padded check names and the header label itself
+    // (mirrors rich's auto-sizing of the "  Check" column).
+    const HEADER_CHECK: &str = "  Check";
+    let name_col_width = checks
         .iter()
-        .map(|c| c.name.chars().count())
+        .map(|c| 2 + c.name.chars().count())
         .max()
-        .unwrap_or(0);
+        .unwrap_or(0)
+        .max(HEADER_CHECK.chars().count());
+
+    // Header row: `Check` / `Status`, dim, matching Python's
+    // `Table(show_header=True)` column titles.
+    let header_pad = name_col_width.saturating_sub(HEADER_CHECK.chars().count());
+    writeln!(
+        w,
+        "{D}{check}{spaces}  Status{R}",
+        D = theme.dim,
+        check = HEADER_CHECK,
+        spaces = " ".repeat(header_pad),
+        R = theme.reset,
+    )?;
+
     for check in checks {
         let glyph = check_state_glyph(theme, &check.state);
-        let pad = name_width.saturating_sub(check.name.chars().count());
+        let pad = name_col_width.saturating_sub(2 + check.name.chars().count());
         writeln!(
             w,
             "  {D}{name}{spaces}{R}  {S}{icon} {state}{R}",
@@ -591,6 +609,9 @@ mod tests {
         .unwrap();
 
         let stdout = cap.stdout();
+        // Verbose table: header row labels both columns.
+        assert!(stdout.contains("Check"), "got: {stdout:?}");
+        assert!(stdout.contains("Status"), "got: {stdout:?}");
         // Verbose table: every check name appears as its own row.
         assert!(stdout.contains("tests"), "got: {stdout:?}");
         assert!(stdout.contains("linters"), "got: {stdout:?}");

--- a/crates/mergify-queue/src/unpause.rs
+++ b/crates/mergify-queue/src/unpause.rs
@@ -32,7 +32,7 @@ pub async fn run(opts: UnpauseOptions<'_>, output: &mut dyn Output) -> Result<()
 
     match client.delete_if_exists(&path).await? {
         DeleteOutcome::Deleted => {
-            emit_resumed(output)?;
+            emit_unpaused(output)?;
             Ok(())
         }
         DeleteOutcome::NotFound => Err(CliError::MergifyApi(
@@ -41,8 +41,10 @@ pub async fn run(opts: UnpauseOptions<'_>, output: &mut dyn Output) -> Result<()
     }
 }
 
-fn emit_resumed(output: &mut dyn Output) -> std::io::Result<()> {
-    output.emit(&(), &mut |w: &mut dyn Write| writeln!(w, "Queue resumed."))
+fn emit_unpaused(output: &mut dyn Output) -> std::io::Result<()> {
+    output.emit(&(), &mut |w: &mut dyn Write| {
+        writeln!(w, "Queue unpaused successfully.")
+    })
 }
 
 #[cfg(test)]
@@ -82,7 +84,10 @@ mod tests {
         .unwrap();
 
         let stdout = cap.stdout();
-        assert!(stdout.contains("Queue resumed"), "got: {stdout:?}");
+        assert!(
+            stdout.contains("Queue unpaused successfully."),
+            "got: {stdout:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/mergify-stack/src/commands/drop.rs
+++ b/crates/mergify-stack/src/commands/drop.rs
@@ -102,7 +102,7 @@ pub fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
 
     let shas: Vec<String> = resolved.iter().map(|c| c.sha.clone()).collect();
     let editor = build_sequence_editor(opts.mergify_binary, &shas);
-    spawn_rebase(&repo_dir, &base, Some(&editor))?;
+    spawn_rebase(&repo_dir, &base, Some(&editor), false)?;
     Ok(Outcome::Dropped { plan })
 }
 

--- a/crates/mergify-stack/src/commands/edit.rs
+++ b/crates/mergify-stack/src/commands/edit.rs
@@ -87,6 +87,16 @@ pub fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
     }
 
     let target = match_commit(commit_prefix, &commits)?;
+    // Print the editing notice *before* spawning the rebase so it
+    // precedes git's interactive-rebase output, matching Python's
+    // ordering (`console.print` then `_run_edit_rebase`). The
+    // "Amend the commit…" hint is printed by the caller after the
+    // rebase pauses.
+    let short = &target.sha[..target.sha.len().min(12)];
+    println!(
+        "Editing commit: {short} {subject}",
+        subject = target.subject
+    );
     let editor = build_sequence_editor(opts.mergify_binary, &target.sha);
     spawn_rebase(&repo_dir, &base, Some(&editor))?;
 

--- a/crates/mergify-stack/src/commands/edit.rs
+++ b/crates/mergify-stack/src/commands/edit.rs
@@ -77,7 +77,7 @@ pub fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
     let base = run_git_capture(Some(&repo_dir), &["merge-base", &trunk.refspec(), "HEAD"])?;
 
     let Some(commit_prefix) = opts.commit_prefix else {
-        spawn_rebase(&repo_dir, &base, None)?;
+        spawn_rebase(&repo_dir, &base, None, false)?;
         return Ok(Outcome::InteractiveCompleted);
     };
 
@@ -98,7 +98,7 @@ pub fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         subject = target.subject
     );
     let editor = build_sequence_editor(opts.mergify_binary, &target.sha);
-    spawn_rebase(&repo_dir, &base, Some(&editor))?;
+    spawn_rebase(&repo_dir, &base, Some(&editor), false)?;
 
     Ok(Outcome::PausedAt { commit: target })
 }

--- a/crates/mergify-stack/src/commands/fixup.rs
+++ b/crates/mergify-stack/src/commands/fixup.rs
@@ -115,7 +115,7 @@ pub fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
 
     let shas: Vec<String> = resolved.iter().map(|c| c.sha.clone()).collect();
     let editor = build_sequence_editor(opts.mergify_binary, &shas);
-    spawn_rebase(&repo_dir, &base, Some(&editor))?;
+    spawn_rebase(&repo_dir, &base, Some(&editor), false)?;
     Ok(Outcome::Squashed { plan })
 }
 

--- a/crates/mergify-stack/src/commands/move_cmd.rs
+++ b/crates/mergify-stack/src/commands/move_cmd.rs
@@ -235,5 +235,5 @@ fn spawn_reorder_rebase(
     let bin = shell_quote(&mergify_binary.to_string_lossy());
     let shas = shell_quote(&ordered_shas.join(","));
     let editor = format!("{bin} _internal rebase-todo-rewrite --action reorder --shas {shas}");
-    spawn_rebase(repo_dir, base, Some(&editor))
+    spawn_rebase(repo_dir, base, Some(&editor), false)
 }

--- a/crates/mergify-stack/src/commands/reorder.rs
+++ b/crates/mergify-stack/src/commands/reorder.rs
@@ -160,5 +160,5 @@ fn spawn_reorder_rebase(
     let bin = shell_quote(&mergify_binary.to_string_lossy());
     let shas = shell_quote(&ordered_shas.join(","));
     let editor = format!("{bin} _internal rebase-todo-rewrite --action reorder --shas {shas}");
-    spawn_rebase(repo_dir, base, Some(&editor))
+    spawn_rebase(repo_dir, base, Some(&editor), false)
 }

--- a/crates/mergify-stack/src/commands/reword.rs
+++ b/crates/mergify-stack/src/commands/reword.rs
@@ -110,7 +110,7 @@ pub fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
     } else {
         build_sequence_editor_reword(opts.mergify_binary, &target.sha)
     };
-    spawn_rebase(&repo_dir, &base, Some(&editor))?;
+    spawn_rebase(&repo_dir, &base, Some(&editor), false)?;
     Ok(Outcome::Reworded { plan })
 }
 

--- a/crates/mergify-stack/src/commands/setup.rs
+++ b/crates/mergify-stack/src/commands/setup.rs
@@ -87,6 +87,16 @@ pub struct InstallLog {
     pub actions: Vec<HookAction>,
 }
 
+/// Outcome of an `install` run: the per-hook action log plus
+/// whether the local `notes.displayRef` config was added this run
+/// (so the caller can echo Python's `Added notes.displayRef = …`
+/// confirmation).
+#[derive(Debug, Clone)]
+pub struct InstallOutcome {
+    pub logs: Vec<InstallLog>,
+    pub notes_display_ref_added: bool,
+}
+
 pub struct Options<'a> {
     pub repo_dir: Option<&'a Path>,
     pub force: bool,
@@ -122,7 +132,7 @@ pub fn status(repo_dir: Option<&Path>) -> Result<HooksStatus, CliError> {
 
 /// Install or upgrade every managed hook. Returns a per-hook
 /// action log so callers can render the right messages.
-pub fn install(opts: &Options<'_>) -> Result<Vec<InstallLog>, CliError> {
+pub fn install(opts: &Options<'_>) -> Result<InstallOutcome, CliError> {
     let hooks_dir = resolve_hooks_dir(opts.repo_dir)?;
     let managed_dir = hooks_dir.join("mergify-hooks");
     fs::create_dir_all(&managed_dir).map_err(|e| {
@@ -142,8 +152,11 @@ pub fn install(opts: &Options<'_>) -> Result<Vec<InstallLog>, CliError> {
         });
     }
 
-    ensure_notes_display_ref(opts.repo_dir)?;
-    Ok(logs)
+    let notes_display_ref_added = ensure_notes_display_ref(opts.repo_dir)?;
+    Ok(InstallOutcome {
+        logs,
+        notes_display_ref_added,
+    })
 }
 
 fn install_single_hook(
@@ -190,7 +203,11 @@ fn install_single_hook(
     Ok(())
 }
 
-fn ensure_notes_display_ref(repo_dir: Option<&Path>) -> Result<(), CliError> {
+/// Ensure `git log` surfaces mergify notes by adding the local
+/// `notes.displayRef = refs/notes/mergify/*` config. Returns `true`
+/// when the config was added this run, `false` when it was already
+/// present.
+fn ensure_notes_display_ref(repo_dir: Option<&Path>) -> Result<bool, CliError> {
     let desired = "refs/notes/mergify/*";
     let current = run_git_capture(
         repo_dir,
@@ -198,13 +215,13 @@ fn ensure_notes_display_ref(repo_dir: Option<&Path>) -> Result<(), CliError> {
     )
     .unwrap_or_default();
     if current.lines().any(|l| l == desired) {
-        return Ok(());
+        return Ok(false);
     }
     run_git_capture(
         repo_dir,
         &["config", "--local", "--add", "notes.displayRef", desired],
     )?;
-    Ok(())
+    Ok(true)
 }
 
 fn wrapper_status(path: &Path, hook: &str) -> WrapperStatus {
@@ -334,12 +351,13 @@ mod tests {
     #[test]
     fn install_writes_wrappers_and_scripts() {
         let dir = init_repo();
-        let logs = install(&Options {
+        let outcome = install(&Options {
             repo_dir: Some(dir.path()),
             force: false,
         })
         .unwrap();
-        assert_eq!(logs.len(), HOOK_NAMES.len());
+        assert_eq!(outcome.logs.len(), HOOK_NAMES.len());
+        assert!(outcome.notes_display_ref_added);
         let s = status(Some(dir.path())).unwrap();
         for h in &s.git_hooks {
             assert_eq!(h.wrapper_status, WrapperStatus::Installed);
@@ -362,8 +380,10 @@ mod tests {
         })
         .unwrap();
         // Second run should report up-to-date scripts and already-
-        // installed wrappers across the board.
-        for log in &second {
+        // installed wrappers across the board, and not re-add the
+        // notes.displayRef config.
+        assert!(!second.notes_display_ref_added);
+        for log in &second.logs {
             assert!(log.actions.iter().any(|a| matches!(
                 a,
                 HookAction::ScriptUpToDate | HookAction::WrapperAlreadyInstalled
@@ -383,12 +403,16 @@ mod tests {
         )
         .unwrap();
 
-        let logs = install(&Options {
+        let outcome = install(&Options {
             repo_dir: Some(dir.path()),
             force: false,
         })
         .unwrap();
-        let commit_msg = logs.iter().find(|l| l.hook_name == "commit-msg").unwrap();
+        let commit_msg = outcome
+            .logs
+            .iter()
+            .find(|l| l.hook_name == "commit-msg")
+            .unwrap();
         assert!(
             commit_msg
                 .actions
@@ -397,12 +421,16 @@ mod tests {
         );
 
         // With --force, the legacy wrapper is migrated.
-        let logs = install(&Options {
+        let outcome = install(&Options {
             repo_dir: Some(dir.path()),
             force: true,
         })
         .unwrap();
-        let commit_msg = logs.iter().find(|l| l.hook_name == "commit-msg").unwrap();
+        let commit_msg = outcome
+            .logs
+            .iter()
+            .find(|l| l.hook_name == "commit-msg")
+            .unwrap();
         assert!(
             commit_msg
                 .actions

--- a/crates/mergify-stack/src/commands/squash.rs
+++ b/crates/mergify-stack/src/commands/squash.rs
@@ -226,5 +226,5 @@ fn spawn_squash_rebase(
         editor.push_str(" --command ");
         editor.push_str(&shell_quote(cmd));
     }
-    spawn_rebase(repo_dir, base, Some(&editor))
+    spawn_rebase(repo_dir, base, Some(&editor), false)
 }

--- a/crates/mergify-stack/src/commands/sync.rs
+++ b/crates/mergify-stack/src/commands/sync.rs
@@ -131,7 +131,10 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         let merged_shas: Vec<String> = status.merged.iter().map(|m| m.commit_sha.clone()).collect();
         let editor = build_drop_editor(opts.mergify_binary, &merged_shas);
         let trunk_ref_owned = trunk_ref.clone();
-        spawn_rebase(&repo_dir, &trunk_ref_owned, Some(&editor))?;
+        // Trunk already carries the squash-merged equivalents of the
+        // commits we're dropping, so they must stay in the todo for
+        // the drop editor to find them — see `spawn_rebase`.
+        spawn_rebase(&repo_dir, &trunk_ref_owned, Some(&editor), true)?;
     }
     Ok(Outcome::Synced {
         status,

--- a/crates/mergify-stack/src/git.rs
+++ b/crates/mergify-stack/src/git.rs
@@ -90,13 +90,29 @@ pub fn resolve_repo_toplevel(repo_dir: Option<&Path>) -> Result<PathBuf, CliErro
 /// to dispatch back into the rebase-todo rewriter without
 /// spawning a real interactive editor (or falling through to
 /// it when the caller wants the user in the loop).
+///
+/// `reapply_cherry_picks` maps to git's `--reapply-cherry-picks`;
+/// set it when the editor drops commits by SHA against a base
+/// that already contains their squash-merged equivalents.
 pub fn spawn_rebase(
     repo_dir: &Path,
     base: &str,
     sequence_editor: Option<&str>,
+    reapply_cherry_picks: bool,
 ) -> Result<(), CliError> {
     let mut cmd = git_cmd(Some(repo_dir));
-    cmd.args(["rebase", "-i", base]);
+    cmd.arg("rebase").arg("-i");
+    if reapply_cherry_picks {
+        // Keep commits whose patch-id already matches the base in
+        // the rebase todo. Git's default (`--no-reapply-cherry-picks`)
+        // silently omits them, which breaks callers that hand the
+        // rebase-todo rewriter an explicit drop list: the dropped
+        // SHAs would have no `pick` line left and the rewrite aborts.
+        // Letting them through keeps the drop editor the sole
+        // authority on what the rebase removes.
+        cmd.arg("--reapply-cherry-picks");
+    }
+    cmd.arg(base);
     if let Some(editor) = sequence_editor {
         cmd.env("GIT_SEQUENCE_EDITOR", editor);
     }


### PR DESCRIPTION
`stack sync` (and the `stack push` rebase that reuses it) ran `git rebase -i <trunk>` with git's default --no-reapply-cherry-picks, which omits commits whose patch-id already matches trunk. After a squash-merge those omitted commits are exactly the ones the drop editor is told to remove, so it finds no `pick` line and aborts the rebase — breaking sync whenever the stack holds merged commits.

Pass --reapply-cherry-picks in the merged-drop case so the squash-merged commits stay in the todo and the drop editor stays the sole authority on what the rebase removes. The other spawn_rebase callers keep git's default.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #1620