### PR TITLE
feat(stack): stream push progress with live in-place rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,6 +1306,7 @@ dependencies = [
  "serde_json",
  "temp-env",
  "tempfile",
+ "terminal_size",
  "tokio",
  "url",
  "wiremock",
@@ -2212,6 +2213,16 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -2372,14 +2372,14 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                     },
                 )
                 .await?;
-                let log_lines = match outcome {
-                    mergify_stack::commands::push::Outcome::DryRun { log_lines, .. }
-                    | mergify_stack::commands::push::Outcome::Pushed { log_lines, .. } => {
-                        log_lines
+                // Dry-run buffers its plan and prints it here; a real
+                // push streams progress live from `push::run` as each
+                // step completes, so its transcript must not be
+                // re-printed.
+                if let mergify_stack::commands::push::Outcome::DryRun { log_lines, .. } = outcome {
+                    for line in log_lines {
+                        println!("{line}");
                     }
-                };
-                for line in log_lines {
-                    println!("{line}");
                 }
                 Ok(mergify_core::ExitCode::Success)
             }

--- a/crates/mergify-stack/Cargo.toml
+++ b/crates/mergify-stack/Cargo.toml
@@ -16,6 +16,10 @@ regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.14"
+# `stack push` live progress: query the terminal width so each
+# in-place row is truncated to one physical line (multi-line
+# cursor-up redraw breaks if a row wraps).
+terminal_size = "0.4"
 tokio = { version = "1", default-features = false, features = ["time"] }
 url = "2"
 

--- a/crates/mergify-stack/src/commands/push.rs
+++ b/crates/mergify-stack/src/commands/push.rs
@@ -44,6 +44,7 @@ use crate::local_commits;
 use crate::notes_push::{self, PushEntry};
 use crate::plan::{self, PlannedChange, PlannedChanges, PlannerOpts};
 use crate::pr_upsert::{self, PrUpsertInput, StaleBase};
+use crate::progress::{Mark, Progress};
 use crate::rebase_log;
 use crate::remote_changes;
 use crate::replay;
@@ -141,22 +142,36 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         format!("{prefix}/{dest_branch}", prefix = opts.branch_prefix)
     };
 
-    // Pre-push: trunk fetch + notes fetch. Both are required
-    // before merge-base / push can run.
+    // The pre-flight — trunk + notes fetch, the PR search, the rebase
+    // decision — is several network round-trips with nothing to show,
+    // the stretch that used to look frozen. Drive one spinner row
+    // through it, then clear it so the live block (or the dry-run
+    // plan) starts fresh below.
+    let mut prog = Progress::new();
+    let pf = prog.add(None, "", "fetching trunk");
+
+    // The two git fetches are synchronous, so the spinner can't tick
+    // across them, but the label still says what is happening.
+    prog.activate(pf, "fetching trunk");
     run_git_silent(Some(&repo_dir), &["fetch", remote, base_branch])?;
     let notes_ref_fetched = notes_push::fetch_notes_ref(Some(&repo_dir), remote)?;
 
     let trunk_ref = format!("{remote}/{base_branch}");
     let base_commit_sha = compute_base_commit_sha(&repo_dir, &trunk_ref, &dest_branch)?;
 
-    let remote_changes_data = remote_changes::get_remote_changes(
-        opts.client,
-        opts.user,
-        opts.repo,
-        &stack_prefix,
-        opts.author,
-    )
-    .await?;
+    let remote_changes_data = prog
+        .run(
+            pf,
+            "reading pull requests",
+            remote_changes::get_remote_changes(
+                opts.client,
+                opts.user,
+                opts.repo,
+                &stack_prefix,
+                opts.author,
+            ),
+        )
+        .await?;
     let local = local_commits::read(&repo_dir, &base_commit_sha, "HEAD")?;
 
     let planner_opts = PlannerOpts {
@@ -167,19 +182,24 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
     };
     let mut planned = plan::plan(&local, remote_changes_data.clone(), planner_opts)?;
 
-    let rebase_decision = approvals::decide_rebase(
-        opts.client,
-        opts.user,
-        opts.repo,
-        &PlannedAsChanges(&planned).into(),
-        opts.skip_rebase,
-        opts.force_rebase,
-    )
-    .await?;
-
-    let mut log_lines: Vec<String> = vec!["Stacked pull request plan:".into()];
+    let rebase_decision = prog
+        .run(
+            pf,
+            "checking rebase",
+            approvals::decide_rebase(
+                opts.client,
+                opts.user,
+                opts.repo,
+                &PlannedAsChanges(&planned).into(),
+                opts.skip_rebase,
+                opts.force_rebase,
+            ),
+        )
+        .await?;
+    prog.clear_block();
 
     if opts.dry_run {
+        let mut log_lines: Vec<String> = vec!["Stacked pull request plan:".into()];
         let commits_behind = git_count_behind(&repo_dir, &trunk_ref)?;
         log_lines.extend(rebase_log::rebase_dry_run(
             &dest_branch,
@@ -201,7 +221,11 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         });
     }
 
-    // Real-push path.
+    // Real-push path. `prog` (created above for the pre-flight) now
+    // drives the live per-PR rows. Live streaming replaces the old
+    // buffered plan-then-result transcript so a slow link never looks
+    // frozen and PRs aren't listed twice; off a TTY it degrades to
+    // one plain line per step (see [`crate::progress`]).
     if rebase_decision.should_rebase {
         let sync_opts = sync_cmd::Options {
             repo_dir: Some(&repo_dir),
@@ -219,7 +243,7 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
             sync_cmd::Outcome::Synced { dropped_count, .. } => dropped_count,
             sync_cmd::Outcome::DryRun(_) => 0,
         };
-        log_lines.push(rebase_log::rebase_performed(
+        prog.note(rebase_log::rebase_performed(
             &dest_branch,
             remote,
             base_branch,
@@ -232,13 +256,8 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         let local2 = local_commits::read(&repo_dir, &new_base, "HEAD")?;
         planned = plan::plan(&local2, remote_changes_data, planner_opts)?;
     } else if let Some(line) = rebase_log::rebase_skipped(&dest_branch, &rebase_decision) {
-        log_lines.push(line);
+        prog.note(line);
     }
-
-    // Plan preview (what will happen) — emitted before the push so
-    // the order matches Python's `display_plan`. `planned` is now
-    // final (re-planned above if a rebase ran).
-    push_plan_preview(&mut log_lines, &planned, opts.create_as_draft);
 
     // Pre-push: optional change-type detection for the
     // revision-history comment. Order matters — must happen
@@ -261,7 +280,7 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         if let Err(e) =
             change_type::fetch_old_pr_heads(Some(&repo_dir), remote, &updated_pr_numbers)
         {
-            log_lines.push(format!(
+            prog.note(format!(
                 "Could not fetch old PR heads; revision-history \
                  change types will fall back to 'unknown': {e}",
             ));
@@ -329,6 +348,12 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
             }
         })
         .collect();
+    if !push_entries.is_empty() {
+        prog.note(format!(
+            "Pushing {n} branch(es) to `{remote}`…",
+            n = push_entries.len(),
+        ));
+    }
     notes_push::push_branches(
         Some(&repo_dir),
         remote,
@@ -337,30 +362,53 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         notes_ref_fetched,
     )?;
 
+    // One live row per planned change, in stack order. Create/Update
+    // start `queued` and spin while their upsert is in flight; the
+    // skip variants resolve immediately. `row_idx[i]` maps each local
+    // back to its row for the upsert loop below.
+    let mut row_idx: Vec<Option<usize>> = Vec::with_capacity(planned.locals.len());
+    for p in &planned.locals {
+        let number = pull_number(p.change.pull.as_ref());
+        let url = pull_url(p.change.pull.as_ref());
+        let title = p.change.title.clone();
+        match p.change.action {
+            Action::Create | Action::Update => {
+                row_idx.push(Some(prog.add(number, title, "queued")));
+            }
+            Action::SkipMerged => {
+                prog.add_resolved(number, title, Mark::Noop, "merged", url);
+                row_idx.push(None);
+            }
+            Action::SkipUpToDate => {
+                prog.add_resolved(number, title, Mark::Noop, "up-to-date", url);
+                row_idx.push(None);
+            }
+            Action::SkipCreate | Action::SkipNextOnly => {
+                prog.add_resolved(number, title, Mark::Noop, "skipped", url);
+                row_idx.push(None);
+            }
+        }
+    }
+
     // Sequential per-PR upsert so each Depends-On has access to
     // the predecessor's freshly-known PR number. Python uses
     // asyncio fan-out + Event coordination; sequential is fine
     // for typical stack sizes.
     let mut upserted: Vec<Value> = Vec::new();
     let mut last_pull_number: Option<u64> = None;
-    for entry in &mut planned.locals {
+    for (i, entry) in planned.locals.iter_mut().enumerate() {
         let action = entry.change.action;
         if !matches!(action, Action::Create | Action::Update) {
             // Skip-* still carries an existing pull number
             // forward as a potential predecessor for downstream
             // Depends-On chaining. Mirrors Python's
             // `_build_change_tasks` carry-forward semantics.
-            if let Some(n) = entry
-                .change
-                .pull
-                .as_ref()
-                .and_then(|v| v.get("number"))
-                .and_then(Value::as_u64)
-            {
+            if let Some(n) = pull_number(entry.change.pull.as_ref()) {
                 last_pull_number = Some(n);
             }
             continue;
         }
+        let idx = row_idx[i].expect("create/update rows are always added");
 
         let input = PrUpsertInput {
             action,
@@ -373,26 +421,35 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
             create_as_draft: opts.create_as_draft,
             keep_pull_request_title_and_body: opts.keep_pull_request_title_and_body,
         };
-        let pull = pr_upsert::create_or_update_pr(opts.client, opts.user, opts.repo, input).await?;
-        if let Some(n) = pull.get("number").and_then(Value::as_u64) {
+        let active = if matches!(action, Action::Create) {
+            "creating"
+        } else {
+            "updating"
+        };
+        let pull = prog
+            .run(
+                idx,
+                active,
+                pr_upsert::create_or_update_pr(opts.client, opts.user, opts.repo, input),
+            )
+            .await?;
+        let number = pull.get("number").and_then(Value::as_u64);
+        if let Some(n) = number {
             last_pull_number = Some(n);
         }
+        let url = pull
+            .get("html_url")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        prog.set_pr(idx, number, url);
+        let done_word = if matches!(action, Action::Create) {
+            "created"
+        } else {
+            "updated"
+        };
+        prog.resolve(idx, Mark::Done, Some(done_word));
         entry.change.pull = Some(pull.clone());
         upserted.push(pull);
-    }
-
-    // Per-PR outcome lines — every local change (not just
-    // create/update) so skip/up-to-date/merged rows show too, now
-    // with the freshly-known PR URLs. Mirrors Python's
-    // post-`gather` log loop.
-    log_lines.push("Updating and/or creating stacked pull requests:".into());
-    for p in &planned.locals {
-        log_lines.push(crate::changes::format_local_change_log(
-            &p.change,
-            &p.dest_branch,
-            false,
-            opts.create_as_draft,
-        ));
     }
 
     // Stack comments (only when stack has > 1 PR — the upserter
@@ -405,90 +462,106 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         .collect();
     let total_pulls = entries.len();
     if total_pulls > 1 {
-        for p in &planned.locals {
-            let Some(pull) = p.change.pull.as_ref() else {
-                continue;
-            };
-            if pull.get("merged_at").is_some_and(|v| !v.is_null()) {
-                continue;
+        let cidx = prog.add(None, "", "queued");
+        prog.run(cidx, "updating stack comments", async {
+            for p in &planned.locals {
+                let Some(pull) = p.change.pull.as_ref() else {
+                    continue;
+                };
+                if pull.get("merged_at").is_some_and(|v| !v.is_null()) {
+                    continue;
+                }
+                let Some(number) = pull.get("number").and_then(Value::as_u64) else {
+                    continue;
+                };
+                comment_upsert::update_stack_comment_for_pull(
+                    opts.client,
+                    opts.user,
+                    opts.repo,
+                    number,
+                    &entries,
+                    &dest_branch,
+                    total_pulls,
+                )
+                .await?;
             }
-            let Some(number) = pull.get("number").and_then(Value::as_u64) else {
-                continue;
-            };
-            comment_upsert::update_stack_comment_for_pull(
-                opts.client,
-                opts.user,
-                opts.repo,
-                number,
-                &entries,
-                &dest_branch,
-                total_pulls,
-            )
-            .await?;
-        }
+            Ok::<(), CliError>(())
+        })
+        .await?;
+        prog.resolve(cidx, Mark::Done, Some("stack comments updated"));
     }
-    log_lines.push("Comments updated.".into());
 
     // Revision-history comments — only for Updates, and only
     // when revision_history is enabled.
     if opts.revision_history {
-        let now = Utc::now();
-        for p in &planned.locals {
-            if !matches!(p.change.action, Action::Update) {
-                continue;
-            }
-            let Some(pull) = p.change.pull.as_ref() else {
-                continue;
-            };
-            let Some(number) = pull.get("number").and_then(Value::as_u64) else {
-                continue;
-            };
-            let Some(old_sha) = pull.pointer("/head/sha").and_then(Value::as_str) else {
-                continue;
-            };
+        let has_updates = planned
+            .locals
+            .iter()
+            .any(|p| matches!(p.change.action, Action::Update) && p.change.pull.is_some());
+        if has_updates {
+            let ridx = prog.add(None, "", "queued");
+            prog.run(ridx, "updating revision history", async {
+                let now = Utc::now();
+                for p in &planned.locals {
+                    if !matches!(p.change.action, Action::Update) {
+                        continue;
+                    }
+                    let Some(pull) = p.change.pull.as_ref() else {
+                        continue;
+                    };
+                    let Some(number) = pull.get("number").and_then(Value::as_u64) else {
+                        continue;
+                    };
+                    let Some(old_sha) = pull.pointer("/head/sha").and_then(Value::as_str) else {
+                        continue;
+                    };
 
-            let ct = change_types
-                .get(&p.change.change_id)
-                .copied()
-                .unwrap_or(ChangeType::Unknown);
+                    let ct = change_types
+                        .get(&p.change.change_id)
+                        .copied()
+                        .unwrap_or(ChangeType::Unknown);
 
-            // Replay only when the change is content (not rebase
-            // or unknown) — for rebase/unknown the
-            // revision-history table renders without a compare
-            // URL anyway.
-            let replay_sha = if matches!(ct, ChangeType::Content) {
-                replay::replay_for_revision(
-                    opts.client,
-                    Some(&repo_dir),
-                    opts.user,
-                    opts.repo,
-                    old_sha,
-                    &p.change.commit_sha,
-                )
-                .await
-            } else {
-                None
-            };
+                    // Replay only when the change is content (not
+                    // rebase or unknown) — for rebase/unknown the
+                    // revision-history table renders without a
+                    // compare URL anyway.
+                    let replay_sha = if matches!(ct, ChangeType::Content) {
+                        replay::replay_for_revision(
+                            opts.client,
+                            Some(&repo_dir),
+                            opts.user,
+                            opts.repo,
+                            old_sha,
+                            &p.change.commit_sha,
+                        )
+                        .await
+                    } else {
+                        None
+                    };
 
-            let input = RevisionInput {
-                pull_number: number,
-                old_sha,
-                new_sha: &p.change.commit_sha,
-                change_type: ct,
-                reason: &p.change.note,
-                replay_sha: replay_sha.as_deref(),
-                timestamp: now,
-            };
-            comment_upsert::update_revision_history_for_pull(
-                opts.client,
-                opts.user,
-                opts.repo,
-                opts.github_server,
-                &input,
-            )
+                    let input = RevisionInput {
+                        pull_number: number,
+                        old_sha,
+                        new_sha: &p.change.commit_sha,
+                        change_type: ct,
+                        reason: &p.change.note,
+                        replay_sha: replay_sha.as_deref(),
+                        timestamp: now,
+                    };
+                    comment_upsert::update_revision_history_for_pull(
+                        opts.client,
+                        opts.user,
+                        opts.repo,
+                        opts.github_server,
+                        &input,
+                    )
+                    .await?;
+                }
+                Ok::<(), CliError>(())
+            })
             .await?;
+            prog.resolve(ridx, Mark::Done, Some("revision history updated"));
         }
-        log_lines.push("Revision history updated.".into());
     }
 
     // Orphan-branch teardown — last so we don't yank the rug out
@@ -498,11 +571,28 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         let Some(head_ref) = orphan.pointer("/head/ref").and_then(Value::as_str) else {
             continue;
         };
-        pr_upsert::delete_orphan_branch(opts.client, opts.user, opts.repo, head_ref).await?;
-        log_lines.push(crate::changes::format_orphan_change_log(orphan, false));
+        let number = orphan.get("number").and_then(Value::as_u64);
+        let title = orphan
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("<unknown>")
+            .to_string();
+        let url = orphan
+            .get("html_url")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let oidx = prog.add(number, title, "queued");
+        prog.set_pr(oidx, None, url);
+        prog.run(
+            oidx,
+            "deleting",
+            pr_upsert::delete_orphan_branch(opts.client, opts.user, opts.repo, head_ref),
+        )
+        .await?;
+        prog.resolve(oidx, Mark::Noop, Some("deleted"));
     }
 
-    log_lines.push("Finished.".into());
+    let log_lines = prog.finish("Finished.");
 
     Ok(Outcome::Pushed {
         planned,
@@ -527,6 +617,19 @@ fn push_plan_preview(log: &mut Vec<String>, planned: &PlannedChanges, create_as_
     for orphan in &planned.orphans {
         log.push(crate::changes::format_orphan_change_log(orphan, true));
     }
+}
+
+/// PR number from a pull payload, if present.
+fn pull_number(pull: Option<&Value>) -> Option<u64> {
+    pull?.get("number").and_then(Value::as_u64)
+}
+
+/// PR `html_url` from a pull payload, if present.
+fn pull_url(pull: Option<&Value>) -> Option<String> {
+    pull?
+        .get("html_url")
+        .and_then(Value::as_str)
+        .map(str::to_string)
 }
 
 /// Build a `StackEntry` from a `PlannedChange` — pulls every

--- a/crates/mergify-stack/src/lib.rs
+++ b/crates/mergify-stack/src/lib.rs
@@ -86,6 +86,7 @@ pub mod notes_push;
 pub mod plan;
 pub mod plan_display;
 pub mod pr_upsert;
+pub mod progress;
 pub mod push_helpers;
 pub mod rebase_log;
 pub mod rebase_todo;

--- a/crates/mergify-stack/src/progress.rs
+++ b/crates/mergify-stack/src/progress.rs
@@ -1,0 +1,476 @@
+//! Live, in-place progress display for `stack push`.
+//!
+//! `stack push` runs a sequence of slow network steps — git push,
+//! one PR upsert per stacked commit, stack comments, revision
+//! history. Done silently it looks frozen, especially on a slow
+//! link. [`Progress`] renders one row per step and rewrites those
+//! rows in place (spinner → ✓) as each completes, so the terminal
+//! always shows what is happening *now*.
+//!
+//! On anything that is not an interactive terminal (a pipe, CI,
+//! a redirect) it degrades to plain streaming: each row is printed
+//! once, when it resolves, with no cursor control or color. Tests
+//! and scripts therefore see deterministic line-per-step output.
+//!
+//! The full rendered text is also collected into a transcript
+//! (returned by [`Progress::finish`]) so callers can keep the
+//! buffered-lines contract the dry-run path still uses.
+
+use std::fmt::Write as _;
+use std::io::{IsTerminal, Write};
+use std::time::Duration;
+
+/// Braille spinner frames; each is one display column wide.
+const FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// How a finished row reads — drives both its glyph and color.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Mark {
+    /// The step did real work (push/create/update): green `✓`.
+    Done,
+    /// The step was a no-op (skipped/up-to-date/merged/deleted):
+    /// dim `·`.
+    Noop,
+}
+
+#[derive(Clone, Copy)]
+enum State {
+    Pending,
+    Active,
+    Resolved(Mark),
+}
+
+struct Row {
+    /// PR number, once known. A freshly-created PR has none until
+    /// its POST returns — the row fills the number in on resolve.
+    number: Option<u64>,
+    /// Long, truncatable middle. Empty for non-PR steps whose text
+    /// lives entirely in `word`.
+    title: String,
+    /// Trailing status word ("queued" / "updating" / "updated").
+    word: String,
+    url: Option<String>,
+    state: State,
+}
+
+pub struct Progress {
+    interactive: bool,
+    color: bool,
+    width: usize,
+    frame: usize,
+    rows: Vec<Row>,
+    /// Physical lines written by the last redraw, so the next one
+    /// knows how far up to move the cursor.
+    drawn: usize,
+    transcript: Vec<String>,
+}
+
+impl Progress {
+    /// Detect the output mode from stdout. Interactive (cursor
+    /// redraw + spinner + color) only on a real terminal whose
+    /// width we can read and with `NO_COLOR` unset.
+    #[must_use]
+    pub fn new() -> Self {
+        let stdout = std::io::stdout();
+        let (interactive, width) = match terminal_size::terminal_size() {
+            Some((terminal_size::Width(w), _)) if stdout.is_terminal() => (true, w as usize),
+            _ => (false, 0),
+        };
+        let color = interactive && std::env::var_os("NO_COLOR").is_none();
+        Self::with_mode(interactive, color, width)
+    }
+
+    fn with_mode(interactive: bool, color: bool, width: usize) -> Self {
+        Self {
+            interactive,
+            color,
+            width: width.max(20),
+            frame: 0,
+            rows: Vec::new(),
+            drawn: 0,
+            transcript: Vec::new(),
+        }
+    }
+
+    /// Print a standalone line above or below the live block (the
+    /// header, the rebase note, the final summary). Only safe
+    /// before the first row is added or after [`finish`]; never
+    /// interleave with a live block.
+    pub fn note(&mut self, line: impl Into<String>) {
+        let line = line.into();
+        println!("{line}");
+        self.transcript.push(line);
+    }
+
+    /// Add a step that will run: a PR row (`title` set) or a plain
+    /// status step (`title` empty, text in `word`). Starts
+    /// `Pending`; interactive mode draws it immediately so the user
+    /// sees the whole plan up front.
+    pub fn add(
+        &mut self,
+        number: Option<u64>,
+        title: impl Into<String>,
+        word: impl Into<String>,
+    ) -> usize {
+        self.rows.push(Row {
+            number,
+            title: title.into(),
+            word: word.into(),
+            url: None,
+            state: State::Pending,
+        });
+        self.redraw();
+        self.rows.len() - 1
+    }
+
+    /// Add an already-finished row (a skip/up-to-date/merged commit
+    /// that needs no network call). Records the transcript and, in
+    /// plain mode, prints it.
+    pub fn add_resolved(
+        &mut self,
+        number: Option<u64>,
+        title: impl Into<String>,
+        mark: Mark,
+        word: impl Into<String>,
+        url: Option<String>,
+    ) {
+        let idx = self.add(number, title, word);
+        self.rows[idx].url = url;
+        self.resolve(idx, mark, None);
+    }
+
+    /// Mark a row active (spinner glyph) without awaiting anything —
+    /// for a step whose work is synchronous and so can't be polled.
+    pub fn activate(&mut self, idx: usize, word: impl Into<String>) {
+        self.rows[idx].word = word.into();
+        self.rows[idx].state = State::Active;
+        self.redraw();
+    }
+
+    /// Drop the current rows and start a fresh block on the next
+    /// draw. Interactive mode erases the live block first, so a
+    /// transient phase (e.g. the pre-flight spinner) disappears
+    /// before unrelated output — a child process's stdout, or the
+    /// next block — takes its place.
+    pub fn clear_block(&mut self) {
+        if self.interactive && self.drawn > 0 {
+            let mut out = std::io::stdout().lock();
+            let _ = write!(out, "\r\x1b[{}A\x1b[0J", self.drawn);
+            let _ = out.flush();
+        }
+        self.rows.clear();
+        self.drawn = 0;
+    }
+
+    /// Mark a row active and spin it while `fut` runs, redrawing on
+    /// a fixed cadence so the spinner animates even across a single
+    /// slow request. In plain mode this just awaits `fut`.
+    pub async fn run<F: std::future::Future>(
+        &mut self,
+        idx: usize,
+        active_word: impl Into<String>,
+        fut: F,
+    ) -> F::Output {
+        self.activate(idx, active_word);
+
+        if !self.interactive {
+            return fut.await;
+        }
+        let mut fut = std::pin::pin!(fut);
+        loop {
+            match tokio::time::timeout(Duration::from_millis(90), fut.as_mut()).await {
+                Ok(out) => return out,
+                Err(_elapsed) => {
+                    self.frame = (self.frame + 1) % FRAMES.len();
+                    self.redraw();
+                }
+            }
+        }
+    }
+
+    /// Resolve a row to its terminal state. `word` replaces the
+    /// trailing word when given (e.g. "updating" → "updated").
+    pub fn resolve(&mut self, idx: usize, mark: Mark, word: Option<&str>) {
+        let row = &mut self.rows[idx];
+        if let Some(w) = word {
+            row.word = w.to_string();
+        }
+        row.state = State::Resolved(mark);
+        let line = render_row(row, self.frame, usize::MAX, false);
+        self.transcript.push(line.clone());
+        if self.interactive {
+            self.redraw();
+        } else {
+            println!("{line}");
+        }
+    }
+
+    /// Fill in the number/url of a row whose PR was just created.
+    pub fn set_pr(&mut self, idx: usize, number: Option<u64>, url: Option<String>) {
+        let row = &mut self.rows[idx];
+        if number.is_some() {
+            row.number = number;
+        }
+        if url.is_some() {
+            row.url = url;
+        }
+    }
+
+    /// Print the closing line and hand back the full transcript.
+    #[must_use]
+    pub fn finish(mut self, line: impl Into<String>) -> Vec<String> {
+        self.note(line);
+        self.transcript
+    }
+
+    fn redraw(&mut self) {
+        if !self.interactive {
+            return;
+        }
+        if let Some((terminal_size::Width(w), _)) = terminal_size::terminal_size() {
+            self.width = (w as usize).max(20);
+        }
+        let mut buf = String::new();
+        if self.drawn > 0 {
+            let _ = write!(buf, "\x1b[{}A", self.drawn);
+        }
+        for row in &self.rows {
+            buf.push_str("\r\x1b[2K");
+            buf.push_str(&render_row(row, self.frame, self.width, self.color));
+            buf.push('\n');
+        }
+        self.drawn = self.rows.len();
+        let mut out = std::io::stdout().lock();
+        let _ = out.write_all(buf.as_bytes());
+        let _ = out.flush();
+    }
+}
+
+impl Default for Progress {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+const DIM: &str = "\x1b[2m";
+const GREEN: &str = "\x1b[32m";
+const CYAN: &str = "\x1b[36m";
+const RESET: &str = "\x1b[0m";
+
+/// Render one row to a single line, truncating the title so the
+/// visible text fits `width` (use `usize::MAX` for no limit, e.g.
+/// the transcript). Color wraps only the fixed-width glyph and
+/// trailing word, so the width budget is computed on plain text.
+fn render_row(row: &Row, frame: usize, width: usize, color: bool) -> String {
+    let (glyph, glyph_color) = match row.state {
+        State::Pending => ("◦", DIM),
+        State::Active => (FRAMES[frame % FRAMES.len()], CYAN),
+        State::Resolved(Mark::Done) => ("✓", GREEN),
+        State::Resolved(Mark::Noop) => ("·", DIM),
+    };
+    let number = row.number.map_or_else(String::new, |n| format!("#{n}"));
+
+    // Fixed (non-title) segments, joined later by single spaces.
+    let mut head = vec![glyph.to_string()];
+    if !number.is_empty() {
+        head.push(number);
+    }
+    let mut tail = vec![row.word.clone()];
+    if let Some(url) = &row.url {
+        tail.push(url.clone());
+    }
+
+    // Budget the title against everything else already on the line.
+    // +2 leading indent, +1 space between every segment.
+    let fixed: usize = head.iter().chain(&tail).map(|s| s.chars().count()).sum::<usize>()
+        + head.len()
+        + tail.len() // one space before each segment (incl. the title slot)
+        + 2; // leading indent
+    let title = if row.title.is_empty() {
+        String::new()
+    } else {
+        truncate(&row.title, width.saturating_sub(fixed))
+    };
+
+    let glyph_seg = if color {
+        format!("{glyph_color}{glyph}{RESET}")
+    } else {
+        head[0].clone()
+    };
+    let word = tail[0].clone();
+    let word_seg = if color {
+        format!("{DIM}{word}{RESET}")
+    } else {
+        word
+    };
+
+    let mut out = String::from("  ");
+    out.push_str(&glyph_seg);
+    if head.len() > 1 {
+        out.push(' ');
+        out.push_str(&head[1]);
+    }
+    if !title.is_empty() {
+        out.push(' ');
+        out.push_str(&title);
+    }
+    out.push(' ');
+    out.push_str(&word_seg);
+    if let Some(url) = &row.url {
+        out.push(' ');
+        out.push_str(url);
+    }
+    out
+}
+
+/// Truncate to at most `max` display columns, with a trailing `…`
+/// when shortened. Returns empty if there is no room.
+fn truncate(s: &str, max: usize) -> String {
+    let len = s.chars().count();
+    if len <= max {
+        return s.to_string();
+    }
+    if max == 0 {
+        return String::new();
+    }
+    if max == 1 {
+        return "…".to_string();
+    }
+    let kept: String = s.chars().take(max - 1).collect();
+    format!("{kept}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(number: Option<u64>, title: &str, word: &str, state: State, url: Option<&str>) -> Row {
+        Row {
+            number,
+            title: title.to_string(),
+            word: word.to_string(),
+            url: url.map(str::to_string),
+            state,
+        }
+    }
+
+    #[test]
+    fn resolved_row_renders_glyph_number_title_word_url() {
+        let r = row(
+            Some(1618),
+            "fix(stack): restore prefix-match",
+            "updated",
+            State::Resolved(Mark::Done),
+            Some("https://example/pull/1618"),
+        );
+        let line = render_row(&r, 0, usize::MAX, false);
+        assert_eq!(
+            line,
+            "  ✓ #1618 fix(stack): restore prefix-match updated https://example/pull/1618"
+        );
+    }
+
+    #[test]
+    fn pending_row_uses_hollow_glyph_and_no_url_when_absent() {
+        let r = row(Some(7), "title", "queued", State::Pending, None);
+        assert_eq!(render_row(&r, 0, usize::MAX, false), "  ◦ #7 title queued");
+    }
+
+    #[test]
+    fn active_row_shows_current_spinner_frame() {
+        let r = row(Some(7), "t", "updating", State::Active, None);
+        let line = render_row(&r, 2, usize::MAX, false);
+        assert!(
+            line.starts_with(&format!("  {} ", FRAMES[2])),
+            "got: {line}"
+        );
+    }
+
+    #[test]
+    fn create_row_without_number_omits_the_hash() {
+        let r = row(None, "new thing", "creating", State::Active, None);
+        let line = render_row(&r, 0, usize::MAX, false);
+        assert!(!line.contains('#'), "got: {line}");
+        assert!(line.contains("new thing"), "got: {line}");
+    }
+
+    #[test]
+    fn title_is_truncated_to_fit_width_keeping_glyph_number_word() {
+        let r = row(
+            Some(42),
+            "a very long pull request title that will not fit",
+            "updated",
+            State::Resolved(Mark::Done),
+            None,
+        );
+        let line = render_row(&r, 0, 30, false);
+        assert!(
+            line.chars().count() <= 30,
+            "len {}: {line}",
+            line.chars().count()
+        );
+        assert!(line.contains('…'), "got: {line}");
+        assert!(line.contains("#42"), "got: {line}");
+        assert!(line.ends_with("updated"), "got: {line}");
+    }
+
+    #[test]
+    fn color_wraps_glyph_and_word_but_not_title() {
+        let r = row(
+            Some(1),
+            "plaintitle",
+            "updated",
+            State::Resolved(Mark::Done),
+            None,
+        );
+        let line = render_row(&r, 0, usize::MAX, true);
+        assert!(line.contains(GREEN), "glyph should be green: {line}");
+        assert!(line.contains("plaintitle"), "title stays plain: {line}");
+        assert!(
+            line.contains(&format!("{DIM}updated{RESET}")),
+            "word dim: {line}"
+        );
+    }
+
+    #[test]
+    fn noop_row_uses_dim_dot() {
+        let r = row(Some(9), "t", "merged", State::Resolved(Mark::Noop), None);
+        assert!(render_row(&r, 0, usize::MAX, false).starts_with("  · "));
+    }
+
+    #[test]
+    fn plain_mode_records_transcript_on_resolve_only() {
+        let mut p = Progress::with_mode(false, false, 80);
+        let idx = p.add(Some(5), "title", "queued");
+        assert!(p.transcript.is_empty(), "pending must not record");
+        p.resolve(idx, Mark::Done, Some("updated"));
+        assert_eq!(p.transcript, vec!["  ✓ #5 title updated".to_string()]);
+    }
+
+    #[test]
+    fn clear_block_resets_rows_and_draw_state() {
+        let mut p = Progress::with_mode(false, false, 80);
+        let _ = p.add(None, "", "fetching");
+        p.clear_block();
+        assert!(p.rows.is_empty());
+        assert_eq!(p.drawn, 0);
+        // A fresh row starts at index 0 again.
+        assert_eq!(p.add(Some(1), "t", "queued"), 0);
+    }
+
+    #[test]
+    fn set_pr_fills_number_for_a_created_row() {
+        let mut p = Progress::with_mode(false, false, 80);
+        let idx = p.add(None, "new pr", "queued");
+        p.set_pr(
+            idx,
+            Some(1630),
+            Some("https://example/pull/1630".to_string()),
+        );
+        p.resolve(idx, Mark::Done, Some("created"));
+        assert_eq!(
+            p.transcript,
+            vec!["  ✓ #1630 new pr created https://example/pull/1630".to_string()]
+        );
+    }
+}


### PR DESCRIPTION
`stack push` ran its pre-flight (trunk fetch, PR search, rebase decision), branch push, and per-PR upserts silently, then printed a buffered plan-then-result transcript at the end — so it looked frozen on a slow link and listed every PR twice.

Add a `progress` reporter that drives a spinner through the pre-flight, then renders one row per stacked PR and rewrites each in place (queued → spinner → ✓) as its GitHub call returns. The spinner animates during each request. Off a TTY it degrades to plain one-line-per-step streaming (no ANSI, `NO_COLOR` honored); rows truncate to terminal width so the cursor-up redraw never wraps on a long title.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #1630