### PR TITLE
feat(stack): stream push progress with live in-place rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,12 +1301,15 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "mergify-core",
+ "mergify-tui",
  "regex",
  "serde",
  "serde_json",
  "temp-env",
  "tempfile",
+ "terminal_size",
  "tokio",
+ "unicode-width",
  "url",
  "wiremock",
 ]
@@ -2217,6 +2220,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2397,6 +2410,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -2267,6 +2267,11 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                         trunk: (&trunk.0, &trunk.1),
                         dry_run: opts.dry_run,
                         mergify_binary: &mergify_binary,
+                        // Direct `stack sync` shows git's rebase output.
+                        quiet: false,
+                        // Standalone sync fetches everything itself.
+                        prefetched_remote_changes: None,
+                        skip_trunk_fetch: false,
                     },
                 )
                 .await?;
@@ -2372,14 +2377,14 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                     },
                 )
                 .await?;
-                let log_lines = match outcome {
-                    mergify_stack::commands::push::Outcome::DryRun { log_lines, .. }
-                    | mergify_stack::commands::push::Outcome::Pushed { log_lines, .. } => {
-                        log_lines
+                // Dry-run buffers its plan and prints it here; a real
+                // push streams progress live from `push::run` as each
+                // step completes, so its transcript must not be
+                // re-printed.
+                if let mergify_stack::commands::push::Outcome::DryRun { log_lines, .. } = outcome {
+                    for line in log_lines {
+                        println!("{line}");
                     }
-                };
-                for line in log_lines {
-                    println!("{line}");
                 }
                 Ok(mergify_core::ExitCode::Success)
             }

--- a/crates/mergify-stack/Cargo.toml
+++ b/crates/mergify-stack/Cargo.toml
@@ -12,11 +12,25 @@ publish = false
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 mergify-core = { path = "../mergify-core" }
+# `stack push` live progress reuses the shared TTY/`NO_COLOR`-aware
+# color palette instead of hand-rolling ANSI consts.
+mergify-tui = { path = "../mergify-tui" }
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.14"
-tokio = { version = "1", default-features = false, features = ["time"] }
+# `stack push` live progress: query the terminal width so each
+# in-place row is truncated to one physical line (multi-line
+# cursor-up redraw breaks if a row wraps).
+terminal_size = "0.4"
+# Measure CJK/emoji/wide glyphs at their real terminal column width so
+# the in-place redraw's truncation never lets a row wrap (a wrap
+# desyncs the cursor-up math and corrupts the live block).
+unicode-width = "0.2"
+# `rt` for `spawn_blocking` — runs the synchronous git fetch/push
+# off the async executor so the `stack push` progress spinner keeps
+# ticking smoothly across them.
+tokio = { version = "1", default-features = false, features = ["rt", "time"] }
 url = "2"
 
 [dev-dependencies]

--- a/crates/mergify-stack/src/commands/push.rs
+++ b/crates/mergify-stack/src/commands/push.rs
@@ -28,8 +28,10 @@
 //! a `tokio::sync::Notify` graph.
 
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::git::{resolve_repo_toplevel, run_git_capture, run_git_silent};
+use crate::git::{compute_base_commit_sha, resolve_repo_toplevel, run_git_capture, run_git_silent};
 
 use chrono::Utc;
 use mergify_core::{CliError, HttpClient};
@@ -44,6 +46,7 @@ use crate::local_commits;
 use crate::notes_push::{self, PushEntry};
 use crate::plan::{self, PlannedChange, PlannedChanges, PlannerOpts};
 use crate::pr_upsert::{self, PrUpsertInput, StaleBase};
+use crate::progress::{Mark, Progress};
 use crate::rebase_log;
 use crate::remote_changes;
 use crate::replay;
@@ -90,9 +93,11 @@ pub struct Options<'a> {
 }
 
 /// Outcome of [`run`]. `DryRun` carries the plan + the rebase
-/// decision (the things the CLI's dry-run path renders) so the
-/// caller can format the output. `Pushed` reports the per-PR
-/// results so a future test harness can assert on them.
+/// decision and the buffered `log_lines` the CLI's dry-run path
+/// prints. `Pushed` carries the final plan + rebase decision; the
+/// real-push path streams its per-PR results live (see
+/// [`crate::progress`]) rather than buffering them, so there is
+/// nothing further to return.
 #[derive(Debug)]
 pub enum Outcome {
     DryRun {
@@ -104,9 +109,6 @@ pub enum Outcome {
     Pushed {
         planned: PlannedChanges,
         rebase: RebaseDecision,
-        /// Per-PR upserted pull payloads (Create / Update only).
-        upserted: Vec<Value>,
-        log_lines: Vec<String>,
     },
 }
 
@@ -141,22 +143,56 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         format!("{prefix}/{dest_branch}", prefix = opts.branch_prefix)
     };
 
-    // Pre-push: trunk fetch + notes fetch. Both are required
-    // before merge-base / push can run.
-    run_git_silent(Some(&repo_dir), &["fetch", remote, base_branch])?;
-    let notes_ref_fetched = notes_push::fetch_notes_ref(Some(&repo_dir), remote)?;
+    // The pre-flight — trunk + notes fetch, the PR search, the rebase
+    // decision — is several network round-trips with nothing to show,
+    // the stretch that used to look frozen. Drive one spinner row
+    // through it, resolving to a kept summary line so it never blinks
+    // out, then seal so the live block (or the dry-run plan) starts
+    // fresh below.
+    let mut prog = Progress::new();
+    let pf = prog.add("fetching trunk");
+
+    // The trunk + notes fetch is synchronous git; run it on a
+    // blocking thread so the spinner keeps ticking smoothly across it.
+    let notes_ref_fetched = {
+        let repo = repo_dir.clone();
+        let remote = remote.to_string();
+        let base = base_branch.to_string();
+        prog.run(
+            pf,
+            "fetching trunk",
+            spawn_git_blocking("git fetch", move || -> Result<bool, CliError> {
+                run_git_silent(Some(&repo), &["fetch", &remote, &base])?;
+                notes_push::fetch_notes_ref(Some(&repo), &remote)
+            }),
+        )
+        .await?
+    };
 
     let trunk_ref = format!("{remote}/{base_branch}");
     let base_commit_sha = compute_base_commit_sha(&repo_dir, &trunk_ref, &dest_branch)?;
 
-    let remote_changes_data = remote_changes::get_remote_changes(
+    // `get_remote_changes` fetches each PR sequentially. Publish the
+    // number it's on into a shared cell; the spinner's tick loop reads
+    // it each frame so the label tracks each pull (owner/repo#id)
+    // while the glyph keeps spinning smoothly.
+    let reading = Arc::new(AtomicU64::new(0));
+    let reading_writer = Arc::clone(&reading);
+    let fetch_pulls = remote_changes::get_remote_changes_reporting(
         opts.client,
         opts.user,
         opts.repo,
         &stack_prefix,
         opts.author,
-    )
-    .await?;
+        move |number| reading_writer.store(number, Ordering::Relaxed),
+    );
+    let (owner, repo_name) = (opts.user, opts.repo);
+    let remote_changes_data = prog
+        .run_reporting(pf, "reading pull requests", fetch_pulls, move || {
+            let n = reading.load(Ordering::Relaxed);
+            (n != 0).then(|| format!("reading {owner}/{repo_name}#{n}"))
+        })
+        .await?;
     let local = local_commits::read(&repo_dir, &base_commit_sha, "HEAD")?;
 
     let planner_opts = PlannerOpts {
@@ -167,19 +203,29 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
     };
     let mut planned = plan::plan(&local, remote_changes_data.clone(), planner_opts)?;
 
-    let rebase_decision = approvals::decide_rebase(
-        opts.client,
-        opts.user,
-        opts.repo,
-        &PlannedAsChanges(&planned).into(),
-        opts.skip_rebase,
-        opts.force_rebase,
-    )
-    .await?;
-
-    let mut log_lines: Vec<String> = vec!["Stacked pull request plan:".into()];
+    let rebase_decision = prog
+        .run(
+            pf,
+            "checking rebase",
+            approvals::decide_rebase(
+                opts.client,
+                opts.user,
+                opts.repo,
+                &PlannedAsChanges(&planned).into(),
+                opts.skip_rebase,
+                opts.force_rebase,
+            ),
+        )
+        .await?;
+    // Resolve the pre-flight spinner to a kept summary line (not
+    // erased — no blank gap) and seal it so the rebase's own git
+    // output, and the live blocks below, start fresh underneath.
+    let pre_flight_summary = format!("read {n} pull request(s)", n = remote_changes_data.len());
+    prog.resolve(pf, Mark::Done, Some(&pre_flight_summary));
+    prog.seal();
 
     if opts.dry_run {
+        let mut log_lines: Vec<String> = vec!["Stacked pull request plan:".into()];
         let commits_behind = git_count_behind(&repo_dir, &trunk_ref)?;
         log_lines.extend(rebase_log::rebase_dry_run(
             &dest_branch,
@@ -201,7 +247,11 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         });
     }
 
-    // Real-push path.
+    // Real-push path. `prog` (created above for the pre-flight) now
+    // drives the live per-PR rows. Live streaming replaces the old
+    // buffered plan-then-result transcript so a slow link never looks
+    // frozen and PRs aren't listed twice; off a TTY it degrades to
+    // one plain line per step (see [`crate::progress`]).
     if rebase_decision.should_rebase {
         let sync_opts = sync_cmd::Options {
             repo_dir: Some(&repo_dir),
@@ -213,58 +263,91 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
             trunk: opts.trunk,
             dry_run: false,
             mergify_binary: opts.mergify_binary,
+            quiet: true,
+            // The pre-flight already fetched the trunk and the remote
+            // PRs; hand them through so the rebase doesn't repeat the
+            // search + per-PR GETs.
+            prefetched_remote_changes: Some(remote_changes_data.clone()),
+            skip_trunk_fetch: true,
         };
-        let outcome = sync_cmd::run(&sync_opts).await?;
+        // Drive the rebase under a spinner — it re-reads the remote
+        // PRs, fetches trunk, and rebases, which used to be a silent
+        // stall. `quiet` captures git's output so it can't corrupt
+        // the in-place redraw.
+        let ridx = prog.add("rebasing");
+        let outcome = prog
+            .run(
+                ridx,
+                format!("rebasing onto `{remote}/{base_branch}`"),
+                sync_cmd::run(&sync_opts),
+            )
+            .await?;
         let dropped = match outcome {
             sync_cmd::Outcome::Synced { dropped_count, .. } => dropped_count,
             sync_cmd::Outcome::DryRun(_) => 0,
         };
-        log_lines.push(rebase_log::rebase_performed(
-            &dest_branch,
-            remote,
-            base_branch,
-            dropped,
-            &rebase_decision,
-        ));
+        prog.resolve(
+            ridx,
+            Mark::Done,
+            Some(&rebase_log::rebase_performed(
+                &dest_branch,
+                remote,
+                base_branch,
+                dropped,
+                &rebase_decision,
+            )),
+        );
 
         // Rebase changed local SHAs — recompute base + re-plan.
         let new_base = compute_base_commit_sha(&repo_dir, &trunk_ref, &dest_branch)?;
         let local2 = local_commits::read(&repo_dir, &new_base, "HEAD")?;
         planned = plan::plan(&local2, remote_changes_data, planner_opts)?;
     } else if let Some(line) = rebase_log::rebase_skipped(&dest_branch, &rebase_decision) {
-        log_lines.push(line);
+        prog.add_resolved(Mark::Noop, line);
     }
 
-    // Plan preview (what will happen) — emitted before the push so
-    // the order matches Python's `display_plan`. `planned` is now
-    // final (re-planned above if a rebase ran).
-    push_plan_preview(&mut log_lines, &planned, opts.create_as_draft);
+    // Publishing spinner — covers change-type detection, base
+    // neutralization, and the push, so there's no silent gap between
+    // the rebase note and "pushed". Only when something is created or
+    // updated; a fully up-to-date stack has none of these.
+    let publishing = planned
+        .locals
+        .iter()
+        .any(|p| matches!(p.change.action, Action::Create | Action::Update))
+        .then(|| prog.add("preparing"));
 
-    // Pre-push: optional change-type detection for the
-    // revision-history comment. Order matters — must happen
-    // before `push_branches` overwrites the remote refs.
+    // Pre-push change-type detection for the revision-history comment,
+    // before `push_branches` overwrites the remote refs. The old-PR-
+    // head fetch is network git, so run it on a blocking thread under
+    // the spinner. A failure only downgrades change types to
+    // 'unknown', so defer the warning past the live block rather than
+    // corrupt it with a mid-block print.
     let mut change_types: std::collections::HashMap<String, ChangeType> =
         std::collections::HashMap::new();
+    let mut deferred_notes: Vec<String> = Vec::new();
     if opts.revision_history {
         let updated_pr_numbers: Vec<u64> = planned
             .locals
             .iter()
             .filter(|p| matches!(p.change.action, Action::Update))
-            .filter_map(|p| {
-                p.change
-                    .pull
-                    .as_ref()
-                    .and_then(|v| v.get("number"))
-                    .and_then(Value::as_u64)
-            })
+            .filter_map(|p| pull_number(p.change.pull.as_ref()))
             .collect();
-        if let Err(e) =
-            change_type::fetch_old_pr_heads(Some(&repo_dir), remote, &updated_pr_numbers)
-        {
-            log_lines.push(format!(
-                "Could not fetch old PR heads; revision-history \
-                 change types will fall back to 'unknown': {e}",
-            ));
+        if !updated_pr_numbers.is_empty() {
+            let repo = repo_dir.clone();
+            let remote = remote.to_string();
+            let numbers = updated_pr_numbers;
+            let fetch = spawn_git_blocking("change-type fetch", move || {
+                change_type::fetch_old_pr_heads(Some(&repo), &remote, &numbers)
+            });
+            let fetched = prog
+                .run_optional(publishing, "analyzing changes", fetch)
+                .await;
+            if let Err(e) = fetched {
+                deferred_notes.push(format!(
+                    "Could not fetch old PR heads; revision-history \
+                     change types will fall back to 'unknown': {e}",
+                ));
+            }
         }
         for entry in &planned.locals {
             if !matches!(entry.change.action, Action::Update) {
@@ -303,7 +386,14 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
             })
         })
         .collect();
-    pr_upsert::neutralize_stale_bases(opts.client, opts.user, opts.repo, &stale_bases, base_branch)
+    let neutralize = pr_upsert::neutralize_stale_bases(
+        opts.client,
+        opts.user,
+        opts.repo,
+        &stale_bases,
+        base_branch,
+    );
+    prog.run_optional(publishing, "preparing branches", neutralize)
         .await?;
 
     // The actual push.
@@ -329,38 +419,87 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
             }
         })
         .collect();
-    notes_push::push_branches(
-        Some(&repo_dir),
-        remote,
-        &push_entries,
-        opts.no_verify,
-        notes_ref_fetched,
-    )?;
+    let pushed = push_entries.len();
+    {
+        // Synchronous git push on a blocking thread so the spinner
+        // keeps ticking across the network round-trip.
+        let repo = repo_dir.clone();
+        let remote_owned = remote.to_string();
+        let no_verify = opts.no_verify;
+        let push = spawn_git_blocking("git push", move || {
+            notes_push::push_branches(
+                Some(&repo),
+                &remote_owned,
+                &push_entries,
+                no_verify,
+                notes_ref_fetched,
+            )
+        });
+        prog.run_optional(publishing, format!("pushing {pushed} branch(es)"), push)
+            .await?;
+    }
+    if let Some(idx) = publishing {
+        prog.resolve(
+            idx,
+            Mark::Done,
+            Some(&format!("pushed {pushed} branch(es)")),
+        );
+    }
+
+    // One live row per planned change, in stack order. Create/Update
+    // start `queued` and spin while their upsert is in flight; the
+    // skip variants resolve immediately. `row_idx[i]` maps each local
+    // back to its row for the upsert loop below.
+    let mut row_idx: Vec<Option<usize>> = Vec::with_capacity(planned.locals.len());
+    for p in &planned.locals {
+        let url = pull_url(p.change.pull.as_ref());
+        let title = p.change.title.clone();
+        match p.change.action {
+            Action::Create | Action::Update => {
+                // Dim SHA transition shown beside the status: the old
+                // PR-head short SHA → the new commit short SHA for an
+                // update, just the new short SHA for a create.
+                let new7 = short_sha(&p.change.commit_sha);
+                let detail = match p.change.action {
+                    Action::Update => pull_head_short_sha(p.change.pull.as_ref())
+                        .map(|old7| format!("{old7}→{new7}")),
+                    _ => Some(new7),
+                };
+                row_idx.push(Some(prog.add_pr(title, "queued", detail, None)));
+            }
+            Action::SkipMerged => {
+                prog.add_resolved_pr(title, Mark::Merged, "merged", url);
+                row_idx.push(None);
+            }
+            Action::SkipUpToDate => {
+                prog.add_resolved_pr(title, Mark::Noop, "up-to-date", url);
+                row_idx.push(None);
+            }
+            Action::SkipCreate | Action::SkipNextOnly => {
+                prog.add_resolved_pr(title, Mark::Noop, "skipped", url);
+                row_idx.push(None);
+            }
+        }
+    }
 
     // Sequential per-PR upsert so each Depends-On has access to
     // the predecessor's freshly-known PR number. Python uses
     // asyncio fan-out + Event coordination; sequential is fine
     // for typical stack sizes.
-    let mut upserted: Vec<Value> = Vec::new();
     let mut last_pull_number: Option<u64> = None;
-    for entry in &mut planned.locals {
+    for (i, entry) in planned.locals.iter_mut().enumerate() {
         let action = entry.change.action;
         if !matches!(action, Action::Create | Action::Update) {
             // Skip-* still carries an existing pull number
             // forward as a potential predecessor for downstream
             // Depends-On chaining. Mirrors Python's
             // `_build_change_tasks` carry-forward semantics.
-            if let Some(n) = entry
-                .change
-                .pull
-                .as_ref()
-                .and_then(|v| v.get("number"))
-                .and_then(Value::as_u64)
-            {
+            if let Some(n) = pull_number(entry.change.pull.as_ref()) {
                 last_pull_number = Some(n);
             }
             continue;
         }
+        let idx = row_idx[i].expect("create/update rows are always added");
 
         let input = PrUpsertInput {
             action,
@@ -373,26 +512,34 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
             create_as_draft: opts.create_as_draft,
             keep_pull_request_title_and_body: opts.keep_pull_request_title_and_body,
         };
-        let pull = pr_upsert::create_or_update_pr(opts.client, opts.user, opts.repo, input).await?;
-        if let Some(n) = pull.get("number").and_then(Value::as_u64) {
+        let active = if matches!(action, Action::Create) {
+            "creating"
+        } else {
+            "updating"
+        };
+        let pull = prog
+            .run(
+                idx,
+                active,
+                pr_upsert::create_or_update_pr(opts.client, opts.user, opts.repo, input),
+            )
+            .await?;
+        let number = pull.get("number").and_then(Value::as_u64);
+        if let Some(n) = number {
             last_pull_number = Some(n);
         }
-        entry.change.pull = Some(pull.clone());
-        upserted.push(pull);
-    }
-
-    // Per-PR outcome lines — every local change (not just
-    // create/update) so skip/up-to-date/merged rows show too, now
-    // with the freshly-known PR URLs. Mirrors Python's
-    // post-`gather` log loop.
-    log_lines.push("Updating and/or creating stacked pull requests:".into());
-    for p in &planned.locals {
-        log_lines.push(crate::changes::format_local_change_log(
-            &p.change,
-            &p.dest_branch,
-            false,
-            opts.create_as_draft,
-        ));
+        let url = pull
+            .get("html_url")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        prog.set_url(idx, url);
+        let done_word = if matches!(action, Action::Create) {
+            "created"
+        } else {
+            "updated"
+        };
+        prog.resolve(idx, Mark::Done, Some(done_word));
+        entry.change.pull = Some(pull);
     }
 
     // Stack comments (only when stack has > 1 PR — the upserter
@@ -405,90 +552,106 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         .collect();
     let total_pulls = entries.len();
     if total_pulls > 1 {
-        for p in &planned.locals {
-            let Some(pull) = p.change.pull.as_ref() else {
-                continue;
-            };
-            if pull.get("merged_at").is_some_and(|v| !v.is_null()) {
-                continue;
+        let cidx = prog.add("queued");
+        prog.run(cidx, "updating stack comments", async {
+            for p in &planned.locals {
+                let Some(pull) = p.change.pull.as_ref() else {
+                    continue;
+                };
+                if pull.get("merged_at").is_some_and(|v| !v.is_null()) {
+                    continue;
+                }
+                let Some(number) = pull.get("number").and_then(Value::as_u64) else {
+                    continue;
+                };
+                comment_upsert::update_stack_comment_for_pull(
+                    opts.client,
+                    opts.user,
+                    opts.repo,
+                    number,
+                    &entries,
+                    &dest_branch,
+                    total_pulls,
+                )
+                .await?;
             }
-            let Some(number) = pull.get("number").and_then(Value::as_u64) else {
-                continue;
-            };
-            comment_upsert::update_stack_comment_for_pull(
-                opts.client,
-                opts.user,
-                opts.repo,
-                number,
-                &entries,
-                &dest_branch,
-                total_pulls,
-            )
-            .await?;
-        }
+            Ok::<(), CliError>(())
+        })
+        .await?;
+        prog.resolve(cidx, Mark::Done, Some("stack comments updated"));
     }
-    log_lines.push("Comments updated.".into());
 
     // Revision-history comments — only for Updates, and only
     // when revision_history is enabled.
     if opts.revision_history {
-        let now = Utc::now();
-        for p in &planned.locals {
-            if !matches!(p.change.action, Action::Update) {
-                continue;
-            }
-            let Some(pull) = p.change.pull.as_ref() else {
-                continue;
-            };
-            let Some(number) = pull.get("number").and_then(Value::as_u64) else {
-                continue;
-            };
-            let Some(old_sha) = pull.pointer("/head/sha").and_then(Value::as_str) else {
-                continue;
-            };
+        let has_updates = planned
+            .locals
+            .iter()
+            .any(|p| matches!(p.change.action, Action::Update) && p.change.pull.is_some());
+        if has_updates {
+            let ridx = prog.add("queued");
+            prog.run(ridx, "updating revision history", async {
+                let now = Utc::now();
+                for p in &planned.locals {
+                    if !matches!(p.change.action, Action::Update) {
+                        continue;
+                    }
+                    let Some(pull) = p.change.pull.as_ref() else {
+                        continue;
+                    };
+                    let Some(number) = pull.get("number").and_then(Value::as_u64) else {
+                        continue;
+                    };
+                    let Some(old_sha) = pull.pointer("/head/sha").and_then(Value::as_str) else {
+                        continue;
+                    };
 
-            let ct = change_types
-                .get(&p.change.change_id)
-                .copied()
-                .unwrap_or(ChangeType::Unknown);
+                    let ct = change_types
+                        .get(&p.change.change_id)
+                        .copied()
+                        .unwrap_or(ChangeType::Unknown);
 
-            // Replay only when the change is content (not rebase
-            // or unknown) — for rebase/unknown the
-            // revision-history table renders without a compare
-            // URL anyway.
-            let replay_sha = if matches!(ct, ChangeType::Content) {
-                replay::replay_for_revision(
-                    opts.client,
-                    Some(&repo_dir),
-                    opts.user,
-                    opts.repo,
-                    old_sha,
-                    &p.change.commit_sha,
-                )
-                .await
-            } else {
-                None
-            };
+                    // Replay only when the change is content (not
+                    // rebase or unknown) — for rebase/unknown the
+                    // revision-history table renders without a
+                    // compare URL anyway.
+                    let replay_sha = if matches!(ct, ChangeType::Content) {
+                        replay::replay_for_revision(
+                            opts.client,
+                            Some(&repo_dir),
+                            opts.user,
+                            opts.repo,
+                            old_sha,
+                            &p.change.commit_sha,
+                        )
+                        .await
+                    } else {
+                        None
+                    };
 
-            let input = RevisionInput {
-                pull_number: number,
-                old_sha,
-                new_sha: &p.change.commit_sha,
-                change_type: ct,
-                reason: &p.change.note,
-                replay_sha: replay_sha.as_deref(),
-                timestamp: now,
-            };
-            comment_upsert::update_revision_history_for_pull(
-                opts.client,
-                opts.user,
-                opts.repo,
-                opts.github_server,
-                &input,
-            )
+                    let input = RevisionInput {
+                        pull_number: number,
+                        old_sha,
+                        new_sha: &p.change.commit_sha,
+                        change_type: ct,
+                        reason: &p.change.note,
+                        replay_sha: replay_sha.as_deref(),
+                        timestamp: now,
+                    };
+                    comment_upsert::update_revision_history_for_pull(
+                        opts.client,
+                        opts.user,
+                        opts.repo,
+                        opts.github_server,
+                        &input,
+                    )
+                    .await?;
+                }
+                Ok::<(), CliError>(())
+            })
             .await?;
+            prog.resolve(ridx, Mark::Done, Some("revision history updated"));
         }
-        log_lines.push("Revision history updated.".into());
     }
 
     // Orphan-branch teardown — last so we don't yank the rug out
@@ -498,17 +661,37 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         let Some(head_ref) = orphan.pointer("/head/ref").and_then(Value::as_str) else {
             continue;
         };
-        pr_upsert::delete_orphan_branch(opts.client, opts.user, opts.repo, head_ref).await?;
-        log_lines.push(crate::changes::format_orphan_change_log(orphan, false));
+        let title = orphan
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("<unknown>")
+            .to_string();
+        let url = orphan
+            .get("html_url")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let oidx = prog.add_pr(title, "queued", None, None);
+        prog.set_url(oidx, url);
+        prog.run(
+            oidx,
+            "deleting",
+            pr_upsert::delete_orphan_branch(opts.client, opts.user, opts.repo, head_ref),
+        )
+        .await?;
+        prog.resolve(oidx, Mark::Noop, Some("deleted"));
     }
 
-    log_lines.push("Finished.".into());
+    // Warnings stashed during the live block (a mid-block print would
+    // corrupt the in-place redraw) surface now, after the last row.
+    for note in deferred_notes {
+        prog.note(note);
+    }
+    // Real-push streams live; the buffered transcript is unused.
+    let _ = prog.finish("Finished.");
 
     Ok(Outcome::Pushed {
         planned,
         rebase: rebase_decision,
-        upserted,
-        log_lines,
     })
 }
 
@@ -527,6 +710,48 @@ fn push_plan_preview(log: &mut Vec<String>, planned: &PlannedChanges, create_as_
     for orphan in &planned.orphans {
         log.push(crate::changes::format_orphan_change_log(orphan, true));
     }
+}
+
+/// PR number from a pull payload, if present.
+fn pull_number(pull: Option<&Value>) -> Option<u64> {
+    pull?.get("number").and_then(Value::as_u64)
+}
+
+/// First 7 chars of a SHA — the conventional short form shown in
+/// the progress detail.
+fn short_sha(sha: &str) -> String {
+    sha.chars().take(7).collect()
+}
+
+/// Short head SHA of a PR payload, if present.
+fn pull_head_short_sha(pull: Option<&Value>) -> Option<String> {
+    pull?
+        .pointer("/head/sha")
+        .and_then(Value::as_str)
+        .map(short_sha)
+}
+
+/// Run a synchronous git operation on a blocking thread, mapping a
+/// task-join panic into a `CliError`. Collapses the
+/// `spawn_blocking(...).await.map_err(...)?` boilerplate the push
+/// flow repeats for each off-executor git step (`label` names the
+/// step in the panic message).
+async fn spawn_git_blocking<T, F>(label: &str, f: F) -> Result<T, CliError>
+where
+    F: FnOnce() -> Result<T, CliError> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| CliError::Generic(format!("{label} task panicked: {e}")))?
+}
+
+/// PR `html_url` from a pull payload, if present.
+fn pull_url(pull: Option<&Value>) -> Option<String> {
+    pull?
+        .get("html_url")
+        .and_then(Value::as_str)
+        .map(str::to_string)
 }
 
 /// Build a `StackEntry` from a `PlannedChange` — pulls every
@@ -574,28 +799,6 @@ impl<'a> From<PlannedAsChanges<'a>> for crate::changes::Changes {
             orphans: p.0.orphans.clone(),
         }
     }
-}
-
-fn compute_base_commit_sha(
-    repo_dir: &Path,
-    trunk_ref: &str,
-    dest_branch: &str,
-) -> Result<String, CliError> {
-    // `--fork-point` is the precise answer when the reflog has
-    // history; falls back to plain merge-base for fresh clones /
-    // CI sandboxes. Same tolerance as `commands::sync`.
-    if let Ok(sha) = run_git_capture(Some(repo_dir), &["merge-base", "--fork-point", trunk_ref]) {
-        if !sha.is_empty() {
-            return Ok(sha);
-        }
-    }
-    let sha = run_git_capture(Some(repo_dir), &["merge-base", trunk_ref, "HEAD"])?;
-    if sha.is_empty() {
-        return Err(CliError::StackNotFound(format!(
-            "common commit between `{trunk_ref}` and `{dest_branch}` branches not found",
-        )));
-    }
-    Ok(sha)
 }
 
 fn git_count_behind(repo_dir: &Path, trunk_ref: &str) -> Result<u32, CliError> {

--- a/crates/mergify-stack/src/commands/sync.rs
+++ b/crates/mergify-stack/src/commands/sync.rs
@@ -25,7 +25,8 @@ use mergify_core::CliError;
 use mergify_core::HttpClient;
 
 use crate::git::{
-    resolve_repo_toplevel, run_git_capture, run_git_silent, shell_quote, spawn_rebase,
+    compute_base_commit_sha, resolve_repo_toplevel, run_git_silent, shell_quote, spawn_rebase,
+    spawn_rebase_captured,
 };
 use crate::local_commits;
 use crate::remote_changes;
@@ -56,6 +57,18 @@ pub struct Options<'a> {
     pub trunk: (&'a str, &'a str),
     pub dry_run: bool,
     pub mergify_binary: &'a Path,
+    /// Capture the rebase's git output instead of letting it reach
+    /// the terminal — set by `stack push`, which drives the rebase
+    /// under a progress spinner that owns the terminal.
+    pub quiet: bool,
+    /// Remote changes already fetched by the caller (the `stack push`
+    /// pre-flight). When `Some`, `run` reuses them instead of
+    /// re-running the search + per-PR GETs that `get_remote_changes`
+    /// does. `None` for the standalone `stack sync` command.
+    pub prefetched_remote_changes: Option<Vec<remote_changes::RemoteChange>>,
+    /// Skip the `git fetch <remote> <base>` pre-rebase. Set by
+    /// `stack push`, whose pre-flight already fetched the trunk.
+    pub skip_trunk_fetch: bool,
 }
 
 pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
@@ -81,29 +94,21 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
     };
 
     let trunk_ref = format!("{remote}/{base_branch}");
-    let base_commit_sha =
-        match run_git_capture(Some(&repo_dir), &["merge-base", "--fork-point", &trunk_ref]) {
-            Ok(sha) if !sha.is_empty() => sha,
-            // `--fork-point` falls back to the plain merge-base when
-            // there's no reflog history (CI sandboxes, freshly cloned
-            // repos). Match Python's "any non-empty result is fine"
-            // tolerance.
-            _ => run_git_capture(Some(&repo_dir), &["merge-base", &trunk_ref, "HEAD"])?,
-        };
-    if base_commit_sha.is_empty() {
-        return Err(CliError::StackNotFound(format!(
-            "common commit between `{trunk_ref}` and `{dest_branch}` branches not found"
-        )));
-    }
+    let base_commit_sha = compute_base_commit_sha(&repo_dir, &trunk_ref, &dest_branch)?;
 
-    let remote_changes = remote_changes::get_remote_changes(
-        opts.client,
-        opts.user,
-        opts.repo,
-        &stack_prefix,
-        opts.author,
-    )
-    .await?;
+    let remote_changes = match &opts.prefetched_remote_changes {
+        Some(changes) => changes.clone(),
+        None => {
+            remote_changes::get_remote_changes(
+                opts.client,
+                opts.user,
+                opts.repo,
+                &stack_prefix,
+                opts.author,
+            )
+            .await?
+        }
+    };
 
     let local = local_commits::read(&repo_dir, &base_commit_sha, "HEAD")?;
     let status = sync_status::classify(
@@ -118,12 +123,27 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
     }
 
     // Real sync.
-    run_git_silent(Some(&repo_dir), &["fetch", remote, base_branch])?;
+    if !opts.skip_trunk_fetch {
+        run_git_silent(Some(&repo_dir), &["fetch", remote, base_branch])?;
+    }
     let dropped_count = status.merged.len();
     if status.up_to_date() || status.all_merged() {
         // Either nothing to drop, or every commit got merged.
         // Both cases collapse to a plain pull --rebase.
-        run_git_silent(Some(&repo_dir), &["pull", "--rebase", remote, base_branch])?;
+        run_git_silent(Some(&repo_dir), &["pull", "--rebase", remote, base_branch]).map_err(
+            // A failed `pull --rebase` is almost always a conflict;
+            // give the same recovery guidance and Conflict exit code as
+            // `spawn_rebase` rather than a bare stderr. (`run_git_silent`
+            // only ever returns `Generic`, so map unconditionally.)
+            |_| {
+                CliError::Conflict(
+                    "rebase failed — there may be conflicts\n\
+                     Resolve conflicts then run: git rebase --continue\n\
+                     Or abort the rebase with: git rebase --abort"
+                        .to_string(),
+                )
+            },
+        )?;
     } else {
         // Mixed case: drop merged commits in a single
         // `git rebase -i`, dispatched through the existing
@@ -134,7 +154,11 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         // Trunk already carries the squash-merged equivalents of the
         // commits we're dropping, so they must stay in the todo for
         // the drop editor to find them — see `spawn_rebase`.
-        spawn_rebase(&repo_dir, &trunk_ref_owned, Some(&editor), true)?;
+        if opts.quiet {
+            spawn_rebase_captured(&repo_dir, &trunk_ref_owned, Some(&editor), true)?;
+        } else {
+            spawn_rebase(&repo_dir, &trunk_ref_owned, Some(&editor), true)?;
+        }
     }
     Ok(Outcome::Synced {
         status,

--- a/crates/mergify-stack/src/git.rs
+++ b/crates/mergify-stack/src/git.rs
@@ -8,6 +8,7 @@
 //! captured stderr" mapping so the per-command modules don't have
 //! to maintain their own slight variations of each helper.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -94,11 +95,38 @@ pub fn resolve_repo_toplevel(repo_dir: Option<&Path>) -> Result<PathBuf, CliErro
 /// `reapply_cherry_picks` maps to git's `--reapply-cherry-picks`;
 /// set it when the editor drops commits by SHA against a base
 /// that already contains their squash-merged equivalents.
+///
+/// Inherits the terminal — git's rebase progress prints live. Use
+/// [`spawn_rebase_captured`] when a progress spinner owns the
+/// terminal and git's output would corrupt the in-place redraw.
 pub fn spawn_rebase(
     repo_dir: &Path,
     base: &str,
     sequence_editor: Option<&str>,
     reapply_cherry_picks: bool,
+) -> Result<(), CliError> {
+    spawn_rebase_inner(repo_dir, base, sequence_editor, reapply_cherry_picks, false)
+}
+
+/// Like [`spawn_rebase`] but captures git's output instead of
+/// letting it reach the terminal — for spinner-driven rebases. On
+/// success the output is discarded; on failure it's flushed to the
+/// real streams first so a conflict is never swallowed.
+pub fn spawn_rebase_captured(
+    repo_dir: &Path,
+    base: &str,
+    sequence_editor: Option<&str>,
+    reapply_cherry_picks: bool,
+) -> Result<(), CliError> {
+    spawn_rebase_inner(repo_dir, base, sequence_editor, reapply_cherry_picks, true)
+}
+
+fn spawn_rebase_inner(
+    repo_dir: &Path,
+    base: &str,
+    sequence_editor: Option<&str>,
+    reapply_cherry_picks: bool,
+    capture: bool,
 ) -> Result<(), CliError> {
     let mut cmd = git_cmd(Some(repo_dir));
     cmd.arg("rebase").arg("-i");
@@ -116,22 +144,101 @@ pub fn spawn_rebase(
     if let Some(editor) = sequence_editor {
         cmd.env("GIT_SEQUENCE_EDITOR", editor);
     }
-    let status = cmd
-        .status()
-        .map_err(|e| CliError::Generic(format!("failed to spawn `git rebase -i`: {e}")))?;
-    if !status.success() {
-        // A non-zero `git rebase -i` almost always means conflicts.
-        // Surface the recovery steps and map to the dedicated
-        // Conflict exit code (4) so scripts can branch on it — same
-        // contract as the Python `run_scripted_rebase`.
-        return Err(CliError::Conflict(
-            "rebase failed — there may be conflicts\n\
-             Resolve conflicts then run: git rebase --continue\n\
-             Or abort the rebase with: git rebase --abort"
-                .to_string(),
-        ));
+
+    let (success, stderr) = if capture {
+        // Null stdin so a mid-rebase prompt (e.g. an unexpected
+        // interactive editor invocation) fails fast instead of
+        // blocking invisibly behind the progress spinner that owns
+        // the terminal.
+        cmd.stdin(std::process::Stdio::null());
+        let output = cmd
+            .output()
+            .map_err(|e| CliError::Generic(format!("failed to spawn `git rebase -i`: {e}")))?;
+        if !output.status.success() {
+            // The spinner suppressed git's output, so replay it now
+            // that we've hit a failure and the user needs to see it.
+            let _ = std::io::stdout().write_all(&output.stdout);
+            let _ = std::io::stderr().write_all(&output.stderr);
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        (output.status.success(), stderr)
+    } else {
+        let success = cmd
+            .status()
+            .map_err(|e| CliError::Generic(format!("failed to spawn `git rebase -i`: {e}")))?
+            .success();
+        (success, String::new())
+    };
+
+    if !success {
+        if rebase_in_progress(repo_dir) {
+            // An interrupted rebase left a `rebase-merge`/`rebase-apply`
+            // state dir — this is the conflict case. Surface the
+            // recovery steps and map to the dedicated Conflict exit
+            // code (4) so scripts can branch on it — same contract as
+            // the Python `run_scripted_rebase`.
+            return Err(CliError::Conflict(
+                "rebase failed — there may be conflicts\n\
+                 Resolve conflicts then run: git rebase --continue\n\
+                 Or abort the rebase with: git rebase --abort"
+                    .to_string(),
+            ));
+        }
+        // No rebase in progress: git failed before/while starting
+        // (bad base, todo-editor error, …). The continue/abort advice
+        // would be misleading, so report the failure plainly.
+        return Err(CliError::Generic(if stderr.is_empty() {
+            "git rebase failed".to_string()
+        } else {
+            format!("git rebase failed: {stderr}")
+        }));
     }
     Ok(())
+}
+
+/// Whether an interrupted rebase left a state directory under the
+/// repo's git dir. Distinguishes a real conflict (recoverable with
+/// `--continue`/`--abort`) from a rebase that failed before it
+/// started, which has no such state.
+fn rebase_in_progress(repo_dir: &Path) -> bool {
+    let git_dir = run_git_capture(Some(repo_dir), &["rev-parse", "--git-dir"])
+        .map_or_else(|_| repo_dir.join(".git"), PathBuf::from);
+    // `git rev-parse --git-dir` may return a path relative to
+    // `repo_dir`; resolve it against the repo so the existence check
+    // works regardless of the process CWD.
+    let git_dir = if git_dir.is_absolute() {
+        git_dir
+    } else {
+        repo_dir.join(git_dir)
+    };
+    git_dir.join("rebase-merge").exists() || git_dir.join("rebase-apply").exists()
+}
+
+/// Base commit SHA of the stack: the merge-base between the trunk
+/// ref and `HEAD`.
+///
+/// `--fork-point` is the precise answer when the reflog has history;
+/// falls back to a plain merge-base for fresh clones / CI sandboxes
+/// where the reflog is empty. An empty result from both is a
+/// [`CliError::StackNotFound`] — the branch shares no history with
+/// the trunk.
+pub fn compute_base_commit_sha(
+    repo_dir: &Path,
+    trunk_ref: &str,
+    dest_branch: &str,
+) -> Result<String, CliError> {
+    if let Ok(sha) = run_git_capture(Some(repo_dir), &["merge-base", "--fork-point", trunk_ref]) {
+        if !sha.is_empty() {
+            return Ok(sha);
+        }
+    }
+    let sha = run_git_capture(Some(repo_dir), &["merge-base", trunk_ref, "HEAD"])?;
+    if sha.is_empty() {
+        return Err(CliError::StackNotFound(format!(
+            "common commit between `{trunk_ref}` and `{dest_branch}` branches not found",
+        )));
+    }
+    Ok(sha)
 }
 
 /// POSIX shell single-quote a value so it survives substitution
@@ -171,11 +278,136 @@ mod tests {
         dir
     }
 
+    fn capture(path: &Path, args: &[&str]) -> String {
+        run_git_capture(Some(path), args).unwrap()
+    }
+
+    /// A repo whose trunk already carries the squash-merged
+    /// equivalent of a stacked commit. Returns `(dir, [base_sha,
+    /// reapplied_sha, kept_sha])`:
+    ///
+    /// - `main` has `root` then `feat` (the squash-merge landing).
+    /// - `feature` branches off `root`, re-adds the same patch as
+    ///   `feat` (so its patch-id matches what's now on `main`), then
+    ///   adds a distinct `extra` commit on top.
+    ///
+    /// Rebasing `feature` onto `main` therefore needs
+    /// `--reapply-cherry-picks` to keep the cherry-picked commit in
+    /// the todo, or the drop editor has nothing to drop.
+    fn squash_merged_repo() -> (TempDir, String, String, String) {
+        let dir = init_repo();
+        let p = dir.path().to_path_buf();
+        let root = capture(&p, &["rev-parse", "HEAD"]);
+
+        // The patch that gets both squash-merged to main and
+        // re-created on the feature branch.
+        std::fs::write(p.join("feat.txt"), "feature\n").unwrap();
+        run(&p, &["add", "feat.txt"]);
+        run(&p, &["commit", "-q", "-m", "feat"]);
+
+        // Feature branch off root: re-apply the same patch, then a
+        // distinct commit.
+        run(&p, &["checkout", "-q", "-b", "feature", &root]);
+        std::fs::write(p.join("feat.txt"), "feature\n").unwrap();
+        run(&p, &["add", "feat.txt"]);
+        run(&p, &["commit", "-q", "-m", "feat (reapplied)"]);
+        let reapplied = capture(&p, &["rev-parse", "HEAD"]);
+        std::fs::write(p.join("extra.txt"), "extra\n").unwrap();
+        run(&p, &["add", "extra.txt"]);
+        run(&p, &["commit", "-q", "-m", "extra"]);
+        let kept = capture(&p, &["rev-parse", "HEAD"]);
+
+        (dir, root, reapplied, kept)
+    }
+
     #[test]
     fn run_git_capture_returns_trimmed_stdout() {
         let dir = init_repo();
         let out = run_git_capture(Some(dir.path()), &["rev-parse", "HEAD"]).unwrap();
         assert_eq!(out.len(), 40, "SHA1 hex without trailing newline");
+    }
+
+    /// Build a sequence editor that copies the rebase todo it's
+    /// handed to `todo_copy`, then deletes the reapplied commit's
+    /// line so the rebase can complete. Lets a test both assert on
+    /// the todo git produced AND drive the drop.
+    fn capturing_drop_editor(todo_copy: &Path) -> String {
+        // `$1` is the todo path git passes to the editor.
+        let copy = todo_copy.to_string_lossy();
+        format!("sh -c 'cp \"$1\" \"{copy}\"; sed -i.bak \"/feat (reapplied)/d\" \"$1\"' --")
+    }
+
+    #[test]
+    fn captured_rebase_drops_squash_merged_commit_via_reapply_cherry_picks() {
+        // Regression guard for `--reapply-cherry-picks` on the
+        // captured (quiet) rebase path. The flag forces git to keep
+        // the cherry-picked (already-on-trunk) commit in the todo so
+        // the drop editor has a line to remove; the test asserts the
+        // todo contained that line and the commit was dropped while
+        // the distinct `extra` commit survived.
+        let (dir, _root, _reapplied, kept) = squash_merged_repo();
+        let p = dir.path();
+        let todo = p.join("captured-todo");
+        let editor = capturing_drop_editor(&todo);
+
+        spawn_rebase_captured(p, "main", Some(&editor), true).unwrap();
+
+        let todo_text = std::fs::read_to_string(&todo).unwrap();
+        assert!(
+            todo_text.contains("feat (reapplied)"),
+            "--reapply-cherry-picks must keep the cherry-picked commit \
+             in the todo, else there's nothing to drop:\n{todo_text}"
+        );
+        let subjects = capture(p, &["log", "--format=%s", "main..HEAD"]);
+        assert!(
+            subjects.contains("extra"),
+            "kept commit survives: {subjects}"
+        );
+        assert!(
+            !subjects.contains("feat (reapplied)"),
+            "squash-merged commit dropped: {subjects}"
+        );
+        assert_ne!(capture(p, &["rev-parse", "HEAD"]), kept);
+    }
+
+    #[test]
+    fn captured_rebase_without_reapply_omits_cherry_picked_from_todo() {
+        // The negative side of the guard: dropping
+        // `--reapply-cherry-picks` makes git silently omit the
+        // already-on-trunk commit from the todo — so a drop editor
+        // keyed on it would find nothing. This is exactly the
+        // regression the positive test catches.
+        let (dir, _root, _reapplied, _kept) = squash_merged_repo();
+        let p = dir.path();
+        let todo = p.join("captured-todo");
+        let editor = capturing_drop_editor(&todo);
+
+        spawn_rebase_captured(p, "main", Some(&editor), false).unwrap();
+
+        let todo_text = std::fs::read_to_string(&todo).unwrap();
+        assert!(
+            !todo_text.contains("feat (reapplied)"),
+            "without --reapply-cherry-picks the cherry-picked commit \
+             must be absent from the todo:\n{todo_text}"
+        );
+    }
+
+    #[test]
+    fn rebase_failure_without_conflict_is_generic_not_conflict() {
+        // A rebase that fails before it starts (here: an
+        // unresolvable base) must not hand back the conflict
+        // continue/abort advice — there is no rebase in progress to
+        // continue.
+        let dir = init_repo();
+        let err = spawn_rebase_captured(dir.path(), "no-such-base", None, false).unwrap_err();
+        match err {
+            CliError::Generic(msg) => {
+                assert!(msg.contains("rebase failed"), "got: {msg}");
+            }
+            other => panic!("expected Generic, got: {other:?}"),
+        }
+        // No rebase state dir was left behind.
+        assert!(!rebase_in_progress(dir.path()));
     }
 
     #[test]

--- a/crates/mergify-stack/src/lib.rs
+++ b/crates/mergify-stack/src/lib.rs
@@ -86,6 +86,7 @@ pub mod notes_push;
 pub mod plan;
 pub mod plan_display;
 pub mod pr_upsert;
+pub mod progress;
 pub mod push_helpers;
 pub mod rebase_log;
 pub mod rebase_todo;

--- a/crates/mergify-stack/src/progress.rs
+++ b/crates/mergify-stack/src/progress.rs
@@ -1,0 +1,899 @@
+//! Live, in-place progress display for `stack push`.
+//!
+//! `stack push` runs a sequence of slow network steps — git push,
+//! one PR upsert per stacked commit, stack comments, revision
+//! history. Done silently it looks frozen, especially on a slow
+//! link. [`Progress`] renders one row per step and rewrites those
+//! rows in place (spinner → ✓) as each completes, so the terminal
+//! always shows what is happening *now*.
+//!
+//! On anything that is not an interactive terminal (a pipe, CI,
+//! a redirect) it degrades to plain streaming: each row is printed
+//! once, when it resolves, with no cursor control or color. Tests
+//! and scripts therefore see deterministic line-per-step output.
+//!
+//! The same plain-streaming fallback also kicks in mid-flight when
+//! the live block would grow taller than the viewport (see
+//! [`Progress::would_overflow`]): a block taller than the terminal
+//! can't be redrawn with a single cursor-up without corrupting
+//! scrollback, so we flush what's resolved as permanent lines and
+//! stream the rest.
+//!
+//! The full rendered text is also collected into a transcript
+//! (returned by [`Progress::finish`]) so callers can keep the
+//! buffered-lines contract the dry-run path still uses.
+
+use std::fmt::Write as _;
+use std::io::{IsTerminal, Write};
+use std::time::Duration;
+
+use mergify_tui::Theme;
+use unicode_width::UnicodeWidthChar;
+
+/// Braille spinner frames; each is one display column wide.
+const FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Glyph advance cadence — fast enough to read as smooth motion.
+const SPIN_INTERVAL: Duration = Duration::from_millis(80);
+
+/// How a finished row reads — drives both its glyph and color.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Mark {
+    /// The step did real work (push/create/update): green `✓`.
+    Done,
+    /// The step was a no-op (skipped/up-to-date/deleted): dim `·`.
+    Noop,
+    /// The commit was already merged on the trunk: magenta `·`,
+    /// matching GitHub's merged badge. A distinct variant rather
+    /// than a string-compare on the status word so the producer's
+    /// `SkipMerged` semantics drive the color directly.
+    Merged,
+}
+
+/// Whether a row is a bare status step or a per-PR row. Explicit so
+/// a legitimately empty PR title can't be mistaken for a step row
+/// (which would mis-indent it and drop it from column alignment).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RowKind {
+    Step,
+    Pr,
+}
+
+#[derive(Clone, Copy)]
+enum State {
+    Pending,
+    Active,
+    Resolved(Mark),
+}
+
+struct Row {
+    kind: RowKind,
+    /// Long, truncatable middle (PR rows only). Empty for step rows
+    /// whose text lives entirely in `word`.
+    title: String,
+    /// Trailing status word ("queued" / "updating" / "updated").
+    word: String,
+    /// Optional dim detail between the status tag and the url — the
+    /// short SHA transition (`old7→new7` for an update, `new7` for a
+    /// create). `None` leaves the segment out entirely.
+    detail: Option<String>,
+    /// PR URL, once known (a freshly-created PR has none until its
+    /// POST returns). It already carries the PR number, so the row
+    /// doesn't repeat it.
+    url: Option<String>,
+    state: State,
+}
+
+pub struct Progress {
+    interactive: bool,
+    theme: Theme,
+    width: usize,
+    /// Terminal height in rows. A live block taller than this can't
+    /// be redrawn with a single cursor-up, so we fall back to plain
+    /// streaming before it overflows.
+    height: usize,
+    frame: usize,
+    rows: Vec<Row>,
+    /// Physical lines written by the last redraw, so the next one
+    /// knows how far up to move the cursor.
+    drawn: usize,
+    /// Cached `(status_w, url_w, detail_w)` PR-column widths.
+    /// Recomputed only when a row is added or its word/url/detail
+    /// changes — not on every redraw frame. `detail_w` keeps the SHA
+    /// detail a padded column so titles line up even when some rows
+    /// carry a detail and others don't.
+    cols: Option<(usize, usize, usize)>,
+    transcript: Vec<String>,
+}
+
+impl Progress {
+    /// Detect the output mode from stdout. Interactive (cursor
+    /// redraw + spinner) only on a real terminal whose size we can
+    /// read. Color is delegated to [`Theme::detect`] (TTY-and-
+    /// `NO_COLOR`-aware, suppressed under tests).
+    #[must_use]
+    pub fn new() -> Self {
+        let stdout = std::io::stdout();
+        let (interactive, width, height) = match terminal_size::terminal_size() {
+            Some((terminal_size::Width(w), terminal_size::Height(h))) if stdout.is_terminal() => {
+                (true, w as usize, h as usize)
+            }
+            _ => (false, 0, 0),
+        };
+        // Color follows interactivity: only an interactive terminal
+        // (one whose size we could read) gets ANSI. A TTY whose size
+        // probe failed streams plain, so it must stay plain — don't
+        // let `Theme::detect` (which keys only on is_terminal) leak
+        // color into that fallback.
+        let theme = if interactive {
+            Theme::detect()
+        } else {
+            Theme::new(false)
+        };
+        Self::with_mode(interactive, theme, width, height)
+    }
+
+    fn with_mode(interactive: bool, theme: Theme, width: usize, height: usize) -> Self {
+        Self {
+            interactive,
+            theme,
+            width: width.max(20),
+            height: height.max(1),
+            frame: 0,
+            rows: Vec::new(),
+            drawn: 0,
+            cols: None,
+            transcript: Vec::new(),
+        }
+    }
+
+    /// Print a standalone line above or below the live block (the
+    /// header, the rebase note, the final summary). Only safe
+    /// before the first row is added or after [`finish`]; never
+    /// interleave with a live block.
+    pub fn note(&mut self, line: impl Into<String>) {
+        let line = line.into();
+        println!("{line}");
+        self.transcript.push(line);
+    }
+
+    /// Add a plain status step (text in `word`, no PR title). Starts
+    /// `Pending`; interactive mode draws it immediately so the user
+    /// sees the whole plan up front.
+    pub fn add(&mut self, word: impl Into<String>) -> usize {
+        self.push_row(RowKind::Step, String::new(), word.into(), None, None);
+        self.rows.len() - 1
+    }
+
+    /// Add a PR row (truncatable `title`, optional dim SHA `detail`).
+    /// Starts `Pending`.
+    pub fn add_pr(
+        &mut self,
+        title: impl Into<String>,
+        word: impl Into<String>,
+        detail: Option<String>,
+        url: Option<String>,
+    ) -> usize {
+        self.push_row(RowKind::Pr, title.into(), word.into(), detail, url);
+        self.rows.len() - 1
+    }
+
+    fn push_row(
+        &mut self,
+        kind: RowKind,
+        title: String,
+        word: String,
+        detail: Option<String>,
+        url: Option<String>,
+    ) {
+        self.rows.push(Row {
+            kind,
+            title,
+            word,
+            detail,
+            url,
+            state: State::Pending,
+        });
+        self.recompute_cols();
+        // Adding a row may make the live block taller than the
+        // viewport; degrade to plain streaming before it overflows.
+        if self.interactive && self.would_overflow() {
+            self.degrade_to_streaming();
+        }
+        self.redraw();
+    }
+
+    /// Add an already-finished step row (a skip that needs no
+    /// network call).
+    pub fn add_resolved(&mut self, mark: Mark, word: impl Into<String>) {
+        let idx = self.add(word);
+        self.resolve(idx, mark, None);
+    }
+
+    /// Add an already-finished PR row (a skip/up-to-date/merged
+    /// commit that needs no network call).
+    pub fn add_resolved_pr(
+        &mut self,
+        title: impl Into<String>,
+        mark: Mark,
+        word: impl Into<String>,
+        url: Option<String>,
+    ) {
+        let idx = self.add_pr(title, word, None, url);
+        self.resolve(idx, mark, None);
+    }
+
+    /// Mark a row active (spinner glyph) and relabel it, without
+    /// awaiting. The frame is advanced only by the tick loop in
+    /// [`Progress::run`], so the glyph stays put here — use this for
+    /// a synchronous step that can't be polled.
+    pub fn activate(&mut self, idx: usize, word: impl Into<String>) {
+        self.rows[idx].word = word.into();
+        self.rows[idx].state = State::Active;
+        self.recompute_cols();
+        self.redraw();
+    }
+
+    /// Finalize the rows drawn so far as permanent scrollback and
+    /// start a fresh block on the next draw. Call before emitting
+    /// output the reporter doesn't control (a child process's
+    /// stdout) so the next redraw won't move the cursor back up over
+    /// it. Prints nothing — the resolved lines stay on screen, so
+    /// the spinner never blinks out to a blank gap.
+    pub fn seal(&mut self) {
+        self.rows.clear();
+        self.cols = None;
+        self.drawn = 0;
+    }
+
+    /// Mark a row active and spin it smoothly while `fut` runs,
+    /// advancing the glyph on a fixed cadence regardless of when the
+    /// work makes progress. In plain mode this just awaits `fut`.
+    pub async fn run<F: std::future::Future>(
+        &mut self,
+        idx: usize,
+        active_word: impl Into<String>,
+        fut: F,
+    ) -> F::Output {
+        self.run_reporting(idx, active_word, fut, || None).await
+    }
+
+    /// Run `fut` under row `opt_idx` when `Some`, else just await it.
+    /// Collapses the repeated `if let Some(idx) = … { run } else {
+    /// await }` branch at the call sites that only conditionally
+    /// have a row to attach the work to.
+    pub async fn run_optional<F: std::future::Future>(
+        &mut self,
+        opt_idx: Option<usize>,
+        active_word: impl Into<String>,
+        fut: F,
+    ) -> F::Output {
+        if let Some(idx) = opt_idx {
+            self.run(idx, active_word, fut).await
+        } else {
+            fut.await
+        }
+    }
+
+    /// Like [`Progress::run`], but re-reads `label` on every tick so
+    /// a step can relabel itself mid-flight (e.g. the pull number the
+    /// fetch loop is currently on) while the glyph keeps spinning
+    /// smoothly. `label` returns `None` to leave the label untouched.
+    pub async fn run_reporting<F, L>(
+        &mut self,
+        idx: usize,
+        active_word: impl Into<String>,
+        fut: F,
+        mut label: L,
+    ) -> F::Output
+    where
+        F: std::future::Future,
+        L: FnMut() -> Option<String>,
+    {
+        self.activate(idx, active_word);
+
+        if !self.interactive {
+            return fut.await;
+        }
+        let mut fut = std::pin::pin!(fut);
+        loop {
+            match tokio::time::timeout(SPIN_INTERVAL, fut.as_mut()).await {
+                Ok(out) => return out,
+                Err(_elapsed) => {
+                    if let Some(word) = label() {
+                        self.rows[idx].word = word;
+                        self.recompute_cols();
+                    }
+                    self.frame = (self.frame + 1) % FRAMES.len();
+                    self.redraw();
+                }
+            }
+        }
+    }
+
+    /// Resolve a row to its terminal state. `word` replaces the
+    /// trailing word when given (e.g. "updating" → "updated").
+    pub fn resolve(&mut self, idx: usize, mark: Mark, word: Option<&str>) {
+        let row = &mut self.rows[idx];
+        if let Some(w) = word {
+            row.word = w.to_string();
+        }
+        row.state = State::Resolved(mark);
+        self.recompute_cols();
+        let line = render_row(
+            &self.rows[idx],
+            self.frame,
+            usize::MAX,
+            &Theme::new(false),
+            None,
+        );
+        self.transcript.push(line.clone());
+        if self.interactive {
+            self.redraw();
+        } else {
+            println!("{line}");
+        }
+    }
+
+    /// Fill in the url of a row whose PR was just created.
+    pub fn set_url(&mut self, idx: usize, url: Option<String>) {
+        if url.is_some() {
+            self.rows[idx].url = url;
+            self.recompute_cols();
+        }
+    }
+
+    /// Print the closing line and hand back the full transcript.
+    #[must_use]
+    pub fn finish(mut self, line: impl Into<String>) -> Vec<String> {
+        self.note(line);
+        self.transcript
+    }
+
+    /// True when the current row count would not fit in the
+    /// viewport, leaving a row for the cursor. A block this tall
+    /// can't be redrawn with a single cursor-up.
+    fn would_overflow(&self) -> bool {
+        self.rows.len() > self.height.saturating_sub(1)
+    }
+
+    /// Permanently flush the live block and switch to plain
+    /// streaming. Clears the current in-place block, reprints the
+    /// already-resolved rows as permanent scrollback lines, and
+    /// drops out of interactive mode so future resolves stream one
+    /// plain line each (no cursor-up — corruption-proof). Pending /
+    /// active rows are dropped from the block; they print when they
+    /// later resolve.
+    fn degrade_to_streaming(&mut self) {
+        let mut buf = String::new();
+        if self.drawn > 0 {
+            // Move to the top of the block and erase it, so the
+            // resolved rows reprint cleanly as permanent lines.
+            let _ = write!(buf, "\x1b[{}A\r\x1b[0J", self.drawn);
+        }
+        for row in &self.rows {
+            if matches!(row.state, State::Resolved(_)) {
+                buf.push_str(&render_row(
+                    row,
+                    self.frame,
+                    self.width,
+                    &self.theme,
+                    self.cols,
+                ));
+                buf.push('\n');
+            }
+        }
+        let mut out = std::io::stdout().lock();
+        let _ = out.write_all(buf.as_bytes());
+        let _ = out.flush();
+        self.interactive = false;
+        self.drawn = 0;
+    }
+
+    fn redraw(&mut self) {
+        if !self.interactive {
+            return;
+        }
+        if let Some((terminal_size::Width(w), terminal_size::Height(h))) =
+            terminal_size::terminal_size()
+        {
+            self.width = (w as usize).max(20);
+            self.height = (h as usize).max(1);
+        }
+        let cols = self.cols;
+        let mut buf = String::new();
+        if self.drawn > 0 {
+            let _ = write!(buf, "\x1b[{}A", self.drawn);
+        }
+        for row in &self.rows {
+            buf.push_str("\r\x1b[2K");
+            buf.push_str(&render_row(row, self.frame, self.width, &self.theme, cols));
+            buf.push('\n');
+        }
+        self.drawn = self.rows.len();
+        let mut out = std::io::stdout().lock();
+        let _ = out.write_all(buf.as_bytes());
+        let _ = out.flush();
+    }
+
+    /// Recompute and cache the widest `[status]` and url across the
+    /// current PR rows, so the live redraw can pad them to aligned
+    /// columns without re-measuring every frame. `None` when there
+    /// are no PR rows (nothing to align).
+    fn recompute_cols(&mut self) {
+        let mut status_w = 0;
+        let mut url_w = 0;
+        let mut detail_w = 0;
+        let mut any = false;
+        for r in self.rows.iter().filter(|r| r.kind == RowKind::Pr) {
+            any = true;
+            status_w = status_w.max(r.word.chars().count() + 2); // + "[]"
+            url_w = url_w.max(r.url.as_deref().map_or(0, |u| u.chars().count()));
+            detail_w = detail_w.max(r.detail.as_deref().map_or(0, |d| d.chars().count()));
+        }
+        self.cols = any.then_some((status_w, url_w, detail_w));
+    }
+}
+
+impl Default for Progress {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Render one row to a single line.
+///
+/// A step row is just `glyph + label`. A PR row is `glyph [status]
+/// detail  url  title`, where `detail` (the dim SHA transition) is
+/// omitted when absent. With `cols = Some((status_w, url_w))` the
+/// status and url are space-padded to those widths so rows line up
+/// under each other (the live view). With `cols = None` the fields
+/// are tab-separated instead — keeps the piped transcript
+/// `cut -f`-able, where streaming can't align anyway. The whole
+/// line is truncated (tab-aware, Unicode-width-aware) to `width` so
+/// the cursor-up redraw never wraps; pass `usize::MAX` for the
+/// un-truncated transcript. Only the glyph and the `[status]`/detail
+/// segments are colored, so the width budget is plain text.
+fn render_row(
+    row: &Row,
+    frame: usize,
+    width: usize,
+    theme: &Theme,
+    cols: Option<(usize, usize, usize)>,
+) -> String {
+    let (glyph, glyph_style) = match row.state {
+        State::Pending => ("◦", theme.dim),
+        State::Active => (FRAMES[frame % FRAMES.len()], theme.cyan),
+        State::Resolved(Mark::Done) => ("✓", theme.green),
+        State::Resolved(Mark::Noop) => ("·", theme.dim),
+        State::Resolved(Mark::Merged) => ("·", theme.magenta),
+    };
+
+    let status = format!("[{word}]", word = row.word);
+    // PR rows nest one level under the step they belong to (the push)
+    // — four spaces — while bare step rows stay at the top level with
+    // two.
+    let plain = match row.kind {
+        RowKind::Step => format!("  {glyph} {word}", word = row.word),
+        RowKind::Pr => {
+            // The url already carries the PR number, so the title
+            // field is just the title.
+            let url = row.url.as_deref().unwrap_or("");
+            let title = &row.title;
+            match cols {
+                // Aligned (live view): pad status, the SHA detail, and
+                // url to fixed columns so titles line up even across
+                // rows where some carry a detail and some don't. The
+                // detail column is dropped entirely when no row has one.
+                Some((status_w, url_w, detail_w)) => {
+                    if detail_w > 0 {
+                        let detail = row.detail.as_deref().unwrap_or("");
+                        format!(
+                            "    {glyph} {status:<status_w$}  {detail:<detail_w$}  {url:<url_w$}  {title}"
+                        )
+                    } else {
+                        format!("    {glyph} {status:<status_w$}  {url:<url_w$}  {title}")
+                    }
+                }
+                // Tab-separated (piped transcript): cut -f-able; no
+                // alignment since streaming can't align anyway.
+                None => match row.detail.as_deref() {
+                    Some(detail) => format!("    {glyph} {status}\t{detail}\t{url}\t{title}"),
+                    None => format!("    {glyph} {status}\t{url}\t{title}"),
+                },
+            }
+        }
+    };
+    let plain = truncate_display(&plain, width);
+
+    if !theme.enabled {
+        return plain;
+    }
+    // Color the glyph everywhere, and on PR rows the `[status]` tag
+    // (state color) and the SHA `detail` (dim). They sit ahead of the
+    // truncatable title, so first-match replaces are safe.
+    let mut out = plain.replacen(
+        glyph,
+        &format!("{glyph_style}{glyph}{reset}", reset = theme.reset),
+        1,
+    );
+    if row.kind == RowKind::Pr {
+        out = out.replacen(
+            &status,
+            &format!("{glyph_style}{status}{reset}", reset = theme.reset),
+            1,
+        );
+        if let Some(detail) = row.detail.as_deref() {
+            if !detail.is_empty() && out.contains(detail) {
+                out = out.replacen(
+                    detail,
+                    &format!("{dim}{detail}{reset}", dim = theme.dim, reset = theme.reset),
+                    1,
+                );
+            }
+        }
+    }
+    out
+}
+
+/// Display width of `s` in terminal columns: each tab expands to the
+/// next multiple of 8, and every other char counts at its Unicode
+/// display width (CJK/emoji are 2, combining marks 0).
+fn display_width(s: &str) -> usize {
+    s.chars().fold(0, |col, ch| {
+        if ch == '\t' {
+            (col / 8 + 1) * 8
+        } else {
+            col + UnicodeWidthChar::width(ch).unwrap_or(0)
+        }
+    })
+}
+
+/// Truncate `s` to at most `max` display columns (tab-aware,
+/// Unicode-width-aware), with a trailing `…` when shortened, so it
+/// occupies exactly one terminal line.
+fn truncate_display(s: &str, max: usize) -> String {
+    if display_width(s) <= max {
+        return s.to_string();
+    }
+    let budget = max.saturating_sub(1); // leave a column for the `…`
+    let mut col = 0;
+    let mut out = String::new();
+    for ch in s.chars() {
+        let next = if ch == '\t' {
+            (col / 8 + 1) * 8
+        } else {
+            col + UnicodeWidthChar::width(ch).unwrap_or(0)
+        };
+        if next > budget {
+            break;
+        }
+        out.push(ch);
+        col = next;
+    }
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pr_row(title: &str, word: &str, state: State, url: Option<&str>) -> Row {
+        Row {
+            kind: RowKind::Pr,
+            title: title.to_string(),
+            word: word.to_string(),
+            detail: None,
+            url: url.map(str::to_string),
+            state,
+        }
+    }
+
+    fn step_row(word: &str, state: State) -> Row {
+        Row {
+            kind: RowKind::Step,
+            title: String::new(),
+            word: word.to_string(),
+            detail: None,
+            url: None,
+            state,
+        }
+    }
+
+    fn plain() -> Theme {
+        Theme::new(false)
+    }
+
+    fn colored() -> Theme {
+        Theme::new(true)
+    }
+
+    #[test]
+    fn resolved_pr_row_is_tab_separated_status_url_title() {
+        let r = pr_row(
+            "fix(stack): restore prefix-match",
+            "updated",
+            State::Resolved(Mark::Done),
+            Some("https://example/pull/1618"),
+        );
+        assert_eq!(
+            render_row(&r, 0, usize::MAX, &plain(), None),
+            "    ✓ [updated]\thttps://example/pull/1618\tfix(stack): restore prefix-match"
+        );
+    }
+
+    #[test]
+    fn step_row_without_title_is_glyph_and_label_only() {
+        let r = step_row("fetching trunk", State::Active);
+        assert_eq!(
+            render_row(&r, 0, usize::MAX, &plain(), None),
+            format!("  {} fetching trunk", FRAMES[0])
+        );
+    }
+
+    #[test]
+    fn pending_pr_row_has_an_empty_url_field() {
+        let r = pr_row("title", "queued", State::Pending, None);
+        assert_eq!(
+            render_row(&r, 0, usize::MAX, &plain(), None),
+            "    ◦ [queued]\t\ttitle"
+        );
+    }
+
+    #[test]
+    fn empty_title_pr_row_stays_a_pr_row() {
+        // A legitimately empty PR title must not collapse into a
+        // step row (which would mis-indent and drop alignment).
+        let r = pr_row("", "queued", State::Pending, None);
+        let line = render_row(&r, 0, usize::MAX, &plain(), None);
+        assert!(line.starts_with("    ◦ [queued]"), "got: {line}");
+    }
+
+    #[test]
+    fn active_row_shows_current_spinner_frame() {
+        let r = pr_row("t", "updating", State::Active, None);
+        assert!(
+            render_row(&r, 2, usize::MAX, &plain(), None)
+                .starts_with(&format!("    {} ", FRAMES[2]))
+        );
+    }
+
+    #[test]
+    fn create_row_without_url_renders_just_the_title() {
+        let r = pr_row("new thing", "creating", State::Active, None);
+        let line = render_row(&r, 0, usize::MAX, &plain(), None);
+        assert!(!line.contains('#'), "got: {line}");
+        assert!(line.ends_with("new thing"), "got: {line}");
+    }
+
+    #[test]
+    fn detail_segment_renders_between_status_and_url() {
+        let mut r = pr_row("t", "updated", State::Resolved(Mark::Done), Some("u"));
+        r.detail = Some("old7→new7".to_string());
+        let line = render_row(&r, 0, usize::MAX, &plain(), None);
+        assert_eq!(line, "    ✓ [updated]\told7→new7\tu\tt");
+    }
+
+    #[test]
+    fn detail_segment_is_dimmed_when_colored() {
+        let mut r = pr_row("t", "created", State::Resolved(Mark::Done), None);
+        r.detail = Some("new1234".to_string());
+        let line = render_row(&r, 0, usize::MAX, &colored(), Some((9, 0, 7)));
+        let theme = colored();
+        assert!(
+            line.contains(&format!("{}new1234{}", theme.dim, theme.reset)),
+            "got: {line}"
+        );
+    }
+
+    #[test]
+    fn long_row_is_truncated_to_one_line() {
+        let r = pr_row(
+            "a very long pull request title that will not fit",
+            "updated",
+            State::Resolved(Mark::Done),
+            Some("https://example/pull/42"),
+        );
+        let line = render_row(&r, 0, 40, &plain(), None);
+        assert!(
+            display_width(&line) <= 40,
+            "width {}: {line}",
+            display_width(&line)
+        );
+        assert!(line.contains('…'), "got: {line}");
+    }
+
+    #[test]
+    fn color_wraps_glyph_and_status_tag_but_not_title() {
+        let r = pr_row("plaintitle", "updated", State::Resolved(Mark::Done), None);
+        let theme = colored();
+        let line = render_row(&r, 0, usize::MAX, &theme, None);
+        assert!(
+            line.starts_with(&format!("    {}✓{}", theme.green, theme.reset)),
+            "glyph green: {line}"
+        );
+        assert!(
+            line.contains(&format!("{}[updated]{}", theme.green, theme.reset)),
+            "status green: {line}"
+        );
+        assert!(line.contains("plaintitle"), "title plain: {line}");
+    }
+
+    #[test]
+    fn noop_row_uses_dim_dot() {
+        let r = pr_row("t", "skipped", State::Resolved(Mark::Noop), None);
+        assert!(render_row(&r, 0, usize::MAX, &plain(), None).starts_with("    · "));
+    }
+
+    #[test]
+    fn merged_mark_is_magenta_like_github() {
+        let r = pr_row("t", "merged", State::Resolved(Mark::Merged), None);
+        let theme = colored();
+        let line = render_row(&r, 0, usize::MAX, &theme, None);
+        // The merged glyph is the magenta dot.
+        assert!(
+            line.starts_with(&format!("    {}·{}", theme.magenta, theme.reset)),
+            "got: {line}"
+        );
+        assert!(
+            line.contains(&format!("{}[merged]{}", theme.magenta, theme.reset)),
+            "got: {line}"
+        );
+    }
+
+    #[test]
+    fn aligned_cols_line_up_titles_across_rows() {
+        // Different status widths and url lengths; the title column
+        // must still start at the same display column in both rows.
+        let a = pr_row(
+            "title-a",
+            "updated",
+            State::Resolved(Mark::Done),
+            Some("u1"),
+        );
+        let b = pr_row(
+            "title-b",
+            "up-to-date",
+            State::Resolved(Mark::Noop),
+            Some("longer-url"),
+        );
+        let cols = Some(("up-to-date".len() + 2, "longer-url".len(), 0));
+        let col_of = |s: &str, needle: &str| s[..s.find(needle).unwrap()].chars().count();
+        let la = render_row(&a, 0, usize::MAX, &plain(), cols);
+        let lb = render_row(&b, 0, usize::MAX, &plain(), cols);
+        assert_eq!(
+            col_of(&la, "title-a"),
+            col_of(&lb, "title-b"),
+            "a: {la:?}\nb: {lb:?}"
+        );
+    }
+
+    #[test]
+    fn aligned_cols_line_up_titles_with_mixed_detail() {
+        // One row carries a SHA detail, the other doesn't; the title
+        // column must still start at the same display column — the
+        // detail is a padded column, not an inline splice.
+        let with = {
+            let mut r = pr_row(
+                "title-a",
+                "updated",
+                State::Resolved(Mark::Done),
+                Some("u1"),
+            );
+            r.detail = Some("old7→new7".to_string());
+            r
+        };
+        let without = pr_row(
+            "title-b",
+            "up-to-date",
+            State::Resolved(Mark::Noop),
+            Some("u2"),
+        );
+        let cols = Some(("up-to-date".len() + 2, 2, "old7→new7".chars().count()));
+        let col_of = |s: &str, needle: &str| s[..s.find(needle).unwrap()].chars().count();
+        let la = render_row(&with, 0, usize::MAX, &plain(), cols);
+        let lb = render_row(&without, 0, usize::MAX, &plain(), cols);
+        assert_eq!(
+            col_of(&la, "title-a"),
+            col_of(&lb, "title-b"),
+            "a: {la:?}\nb: {lb:?}"
+        );
+    }
+
+    #[test]
+    fn display_width_expands_tabs_to_eight_column_stops() {
+        assert_eq!(display_width("ab\tc"), 9);
+        assert_eq!(display_width("\t"), 8);
+        assert_eq!(display_width("plain"), 5);
+    }
+
+    #[test]
+    fn display_width_counts_wide_glyphs_as_two_columns() {
+        // CJK ideographs are double-width; naive char-count would
+        // under-measure and let a too-wide line slip past truncation.
+        let cjk = "日本語"; // 3 chars, 6 columns
+        assert_eq!(cjk.chars().count(), 3);
+        assert_eq!(display_width(cjk), 6);
+        assert!(display_width(cjk) > cjk.chars().count());
+    }
+
+    #[test]
+    fn truncate_respects_wide_glyph_budget() {
+        let cjk = "日本語日本語日本語"; // 9 chars, 18 columns
+        let out = truncate_display(cjk, 8);
+        assert!(
+            display_width(&out) <= 8,
+            "width {}: {out}",
+            display_width(&out)
+        );
+    }
+
+    #[test]
+    fn plain_mode_records_transcript_on_resolve_only() {
+        let mut p = Progress::with_mode(false, plain(), 80, 24);
+        let idx = p.add_pr("title", "queued", None, None);
+        assert!(p.transcript.is_empty(), "pending must not record");
+        p.resolve(idx, Mark::Done, Some("updated"));
+        assert_eq!(p.transcript, vec!["    ✓ [updated]\t\ttitle".to_string()]);
+    }
+
+    #[test]
+    fn seal_resets_rows_and_draw_state() {
+        let mut p = Progress::with_mode(false, plain(), 80, 24);
+        let _ = p.add("fetching");
+        p.seal();
+        assert!(p.rows.is_empty());
+        assert_eq!(p.drawn, 0);
+        assert!(p.cols.is_none());
+        // A fresh row starts at index 0 again.
+        assert_eq!(p.add_pr("t", "queued", None, None), 0);
+    }
+
+    #[test]
+    fn set_url_fills_a_created_rows_url() {
+        let mut p = Progress::with_mode(false, plain(), 80, 24);
+        let idx = p.add_pr("new pr", "queued", None, None);
+        p.set_url(idx, Some("https://example/pull/1630".to_string()));
+        p.resolve(idx, Mark::Done, Some("created"));
+        assert_eq!(
+            p.transcript,
+            vec!["    ✓ [created]\thttps://example/pull/1630\tnew pr".to_string()]
+        );
+    }
+
+    #[test]
+    fn cols_cache_tracks_widest_row() {
+        let mut p = Progress::with_mode(false, plain(), 80, 24);
+        p.add_pr("a", "queued", None, Some("short".into()));
+        assert_eq!(p.cols, Some(("queued".len() + 2, "short".len(), 0)));
+        p.add_pr("b", "up-to-date", None, Some("longer-url".into()));
+        assert_eq!(
+            p.cols,
+            Some(("up-to-date".len() + 2, "longer-url".len(), 0))
+        );
+    }
+
+    #[test]
+    fn overflow_degrades_without_oversized_cursor_up() {
+        // A row count that exceeds a tiny forced height must trip the
+        // streaming fallback rather than emit a cursor-up larger than
+        // the viewport (which would corrupt scrollback).
+        let mut p = Progress::with_mode(true, plain(), 80, 3);
+        // height 3 ⇒ block may hold at most 2 rows before overflow.
+        p.add("a");
+        p.add("b");
+        assert!(p.interactive, "still fits");
+        p.add("c"); // would need 3 live rows in a 3-row terminal
+        assert!(!p.interactive, "must have degraded to streaming");
+        // drawn is reset on degrade, so no later cursor-up can exceed
+        // the viewport.
+        assert_eq!(p.drawn, 0);
+        assert!(
+            p.drawn < p.height,
+            "cursor-up ({}) must stay within height ({})",
+            p.drawn,
+            p.height
+        );
+    }
+}

--- a/crates/mergify-stack/src/remote_changes.rs
+++ b/crates/mergify-stack/src/remote_changes.rs
@@ -69,6 +69,21 @@ pub async fn get_remote_changes(
     stack_prefix: &str,
     author: &str,
 ) -> Result<Vec<RemoteChange>, CliError> {
+    get_remote_changes_reporting(client, user, repo, stack_prefix, author, |_| {}).await
+}
+
+/// Same as [`get_remote_changes`], but calls `on_pull` with each
+/// pull-request number just before fetching it — so a caller can
+/// surface per-pull progress through the otherwise-silent
+/// sequential fetch loop.
+pub async fn get_remote_changes_reporting(
+    client: &Client,
+    user: &str,
+    repo: &str,
+    stack_prefix: &str,
+    author: &str,
+    mut on_pull: impl FnMut(u64),
+) -> Result<Vec<RemoteChange>, CliError> {
     let q = format!("repo:{user}/{repo} author:{author} is:pull-request head:{stack_prefix}/");
     let search: SearchResponse = client
         .get_with_query(
@@ -87,6 +102,7 @@ pub async fn get_remote_changes(
     // each = a few seconds for the largest realistic stacks).
     let mut pulls: Vec<serde_json::Value> = Vec::with_capacity(search.items.len());
     for item in &search.items {
+        on_pull(item.number);
         let path = format!("/repos/{user}/{repo}/pulls/{number}", number = item.number);
         let pull: serde_json::Value = client.get(&path).await?;
         pulls.push(pull);


### PR DESCRIPTION
`stack push` ran its pre-flight (trunk fetch, PR search, rebase decision), branch push, and per-PR upserts silently, then printed a buffered plan-then-result transcript at the end — so it looked frozen on a slow link and listed every PR twice.

Add a `progress` reporter that keeps a spinner alive through every network phase: the pre-flight (the PR search reports each pull by number), the branch push, then one row per stacked PR rewritten in place (queued → spinner → ✓) as its upsert returns, then the stack-comment and revision-history passes. Off a TTY it degrades to plain one-line-per-step streaming (no ANSI, `NO_COLOR` honored); rows truncate to terminal width so the cursor-up redraw never wraps on a long title.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #1630