### PR TITLE
feat(install): support Windows in install.sh

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,14 +111,15 @@ jobs:
   # sha256 verification, the `install -m 0755` step, and the final
   # `--version` exec.
   #
-  # Linux + macOS only (Windows users go through a separate
-  # PowerShell installer, TBD).
+  # Windows runs the same POSIX `install.sh` under git-bash
+  # (`shell: bash`), pulling the `.zip` asset and `mergify.exe`
+  # instead of the `.tar.gz` + `mergify` the Unix legs use.
   install-script-smoke:
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-15]
+        os: [ubuntu-24.04, macos-15, windows-2025]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6.0.3
@@ -148,24 +149,59 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # `sha256sum` (Linux, git-bash) or `shasum -a 256` (macOS) —
+          # same fallback install.sh uses; git-bash ships no `shasum`.
+          sha256sums() {
+              if command -v sha256sum > /dev/null 2>&1; then sha256sum "$@"
+              else shasum -a 256 "$@"; fi
+          }
           target=$(rustc -vV | awk '/^host:/ {print $2}')
           echo "Building fixture for target: ${target}"
+          # Mirror what install.sh derives from the triple: Windows
+          # ships a `.zip` holding `mergify.exe`, everything else a
+          # `.tar.gz` holding `mergify`.
+          case "${target}" in
+              *windows*) ext="zip";    bin="mergify.exe" ;;
+              *)         ext="tar.gz"; bin="mergify"     ;;
+          esac
+          asset="mergify-2099.1.1.1-${target}.${ext}"
           mkdir -p fixture/release
           # install.sh resolves the version from latest-release.json (fixture
           # mode) before building the per-version asset name.
           echo '{"tag_name":"2099.1.1.1"}' > fixture/release/latest-release.json
-          tar -C target/release -czf "fixture/release/mergify-2099.1.1.1-${target}.tar.gz" mergify
-          (cd fixture/release && shasum -a 256 "mergify-2099.1.1.1-${target}.tar.gz" > SHA256SUMS)
+          if [ "${ext}" = "zip" ]; then
+              # Pack with python's zipfile rather than betting on a
+              # `zip` binary in git-bash; python is already required
+              # below for the fixture server. Resolve the interpreter
+              # name the same way the serve step does (`python3` on
+              # Unix, `python` on the Windows runner).
+              py=python3; command -v "$py" > /dev/null 2>&1 || py=python
+              ( cd target/release \
+                && "$py" -m zipfile -c "${OLDPWD}/fixture/release/${asset}" "${bin}" )
+          else
+              tar -C target/release -czf "fixture/release/${asset}" "${bin}"
+          fi
+          # Normalise to the canonical "HASH␣␣filename" form the
+          # release pipeline emits on Linux. git-bash's `sha256sum`
+          # tags binary files with a `*` marker (`HASH *file`), which
+          # would break install.sh's `$2 == asset` lookup and its
+          # two-space line-shape check.
+          ( cd fixture/release \
+            && hash=$(sha256sums "${asset}" | awk '{print $1}') \
+            && printf '%s  %s\n' "${hash}" "${asset}" > SHA256SUMS )
           ls -la fixture/release
 
       - name: Serve fixture
         shell: bash
         run: |
           cd fixture/release
-          # `python3 -m http.server` is preinstalled on both runners.
-          # Bind to localhost only; the runner is ephemeral but
-          # there's no point exposing the fixture.
-          python3 -m http.server 8765 --bind 127.0.0.1 > /tmp/server.log 2>&1 &
+          # `python3` on the Unix runners, `python` on the Windows
+          # runner (it ships no `python3` shim). The http.server
+          # module is in the stdlib on all of them. Bind to localhost
+          # only; the runner is ephemeral but there's no point
+          # exposing the fixture.
+          py=python3; command -v "$py" > /dev/null 2>&1 || py=python
+          "$py" -m http.server 8765 --bind 127.0.0.1 > /tmp/server.log 2>&1 &
           echo $! > /tmp/server.pid
           # Wait for the server to actually accept connections.
           for _ in $(seq 1 50); do
@@ -182,8 +218,13 @@ jobs:
           ./install.sh
           # `install.sh` runs `--version` itself, but pin it here
           # too so a future refactor that drops the post-install
-          # smoke from the script still trips this job.
-          /tmp/mergify-install/mergify --version
+          # smoke from the script still trips this job. The binary
+          # is `mergify.exe` on Windows.
+          case "$(rustc -vV | awk '/^host:/ {print $2}')" in
+              *windows*) bin=mergify.exe ;;
+              *)         bin=mergify     ;;
+          esac
+          "/tmp/mergify-install/${bin}" --version
 
       # Negative paths: corrupted SHA256SUMS must fail closed, not
       # silently install a tampered binary. Tests both the
@@ -196,7 +237,8 @@ jobs:
         run: |
           set -euo pipefail
           target=$(rustc -vV | awk '/^host:/ {print $2}')
-          asset="mergify-2099.1.1.1-${target}.tar.gz"
+          case "${target}" in *windows*) ext=zip ;; *) ext=tar.gz ;; esac
+          asset="mergify-2099.1.1.1-${target}.${ext}"
           # Keep a clean copy so the malformed test below can write
           # its own bad version without losing the original.
           cp fixture/release/SHA256SUMS fixture/release/SHA256SUMS.orig

--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,9 @@ detect_target() {
     case "${os}" in
         Linux)  os_part="unknown-linux-gnu" ;;
         Darwin) os_part="apple-darwin"      ;;
+        # git-bash, MSYS2 and Cygwin all report a `*_NT-*` kernel
+        # name from `uname -s`; they run a POSIX shell on Windows.
+        MINGW*|MSYS*|CYGWIN*) os_part="pc-windows-msvc" ;;
         *) die "unsupported OS '${os}' — see https://github.com/${REPO}/releases for available assets" ;;
     esac
     case "${arch}" in
@@ -47,6 +50,13 @@ detect_target() {
         arm64|aarch64) arch_part="aarch64" ;;
         *) die "unsupported architecture '${arch}'" ;;
     esac
+    # We only publish an x86_64 Windows binary, so reject other
+    # Windows arches up front instead of 404ing on an asset that
+    # was never built. x86_64 git-bash runs fine on ARM Windows
+    # under emulation, so this rarely bites in practice.
+    if [ "${os_part}" = "pc-windows-msvc" ] && [ "${arch_part}" != "x86_64" ]; then
+        die "unsupported architecture '${arch}' on Windows — only x86_64 is published"
+    fi
     printf '%s-%s' "${arch_part}" "${os_part}"
 }
 
@@ -65,7 +75,6 @@ sha256_check() {
 
 main() {
     command -v curl > /dev/null 2>&1 || die "curl is required"
-    command -v tar  > /dev/null 2>&1 || die "tar is required"
 
     # Resolve VERSION to the actual tag so we can embed it in the
     # asset filename. When MERGIFY_BASE_URL is set (fixture mode used
@@ -91,7 +100,25 @@ main() {
     BASE_URL="${MERGIFY_BASE_URL:-https://github.com/${REPO}/releases/download/${VERSION}}"
 
     target=$(detect_target)
-    asset="mergify-${VERSION}-${target}.tar.gz"
+    # Windows releases ship a `.zip` holding `mergify.exe`; every
+    # other target ships a `.tar.gz` holding `mergify`. Branch on the
+    # triple the same way the release workflow does so the names line
+    # up bit-for-bit with what it published.
+    case "${target}" in
+        *windows*) ext="zip";    bin="mergify.exe" ;;
+        *)         ext="tar.gz"; bin="mergify"     ;;
+    esac
+
+    # Need the matching extractor available. `tar` is everywhere we
+    # ship a tarball; `unzip` is the portable choice on the POSIX
+    # shells that run on Windows (git-bash, MSYS2, Cygwin).
+    case "${ext}" in
+        zip) command -v unzip > /dev/null 2>&1 \
+                || die "unzip is required to install the Windows binary" ;;
+        *)   command -v tar   > /dev/null 2>&1 || die "tar is required" ;;
+    esac
+
+    asset="mergify-${VERSION}-${target}.${ext}"
     url="${BASE_URL}/${asset}"
     sums_url="${BASE_URL}/SHA256SUMS"
 
@@ -127,15 +154,20 @@ main() {
         || die "checksum verification failed for ${asset}"
     cd - > /dev/null
 
-    tar -xzf "${tmp}/${asset}" -C "${tmp}"
+    case "${ext}" in
+        zip) unzip -oq "${tmp}/${asset}" -d "${tmp}" ;;
+        *)   tar -xzf "${tmp}/${asset}" -C "${tmp}"  ;;
+    esac
 
     mkdir -p "${INSTALL_DIR}"
     # `install -m 0755` is in coreutils on Linux and BSD install on
-    # macOS; both honour `-m`. Avoids a separate chmod step.
-    install -m 0755 "${tmp}/mergify" "${INSTALL_DIR}/mergify"
+    # macOS; both honour `-m`. Avoids a separate chmod step. On
+    # Windows git-bash the mode is cosmetic (the exec bit is
+    # meaningless there) but `install` still copies the file.
+    install -m 0755 "${tmp}/${bin}" "${INSTALL_DIR}/${bin}"
 
-    printf '\nmergify installed to %s/mergify\n' "${INSTALL_DIR}"
-    "${INSTALL_DIR}/mergify" --version
+    printf '\nmergify installed to %s/%s\n' "${INSTALL_DIR}" "${bin}"
+    "${INSTALL_DIR}/${bin}" --version
 
     case ":${PATH}:" in
         *":${INSTALL_DIR}:"*) ;;


### PR DESCRIPTION
`install.sh` bailed on any OS that wasn't Linux or macOS, so the
one-liner was unusable from the POSIX shells that run on Windows
(git-bash, MSYS2, Cygwin) even though we publish an
`x86_64-pc-windows-msvc` release asset.

Detect those shells in `detect_target` (`uname -s` reports a `*_NT-*`
kernel name) and map them to `pc-windows-msvc`, rejecting non-x86_64
Windows up front since that's the only Windows binary we publish. The
Windows asset is a `.zip` holding `mergify.exe` rather than the
`.tar.gz` + `mergify` every other target ships, so thread the
extension and binary name off the triple, branch extraction between
`unzip` and `tar`, and make the extractor preflight per-target. The
checksum verification stays fail-closed for both formats.

Extend the `install-script-smoke` CI job to a `windows-2025` runner
that exercises the same POSIX script under git-bash against a `.zip`
fixture, including the tampered-SHA256SUMS negative cases.

Note: `mergify self-update` (the self-update-smoke job) is still
Linux+macOS only and may have the same Windows gap; out of scope here.