### PR TITLE
feat(stack): report "Already up to date." when push touches nothing

### DIFF
--- a/crates/mergify-stack/src/commands/push.rs
+++ b/crates/mergify-stack/src/commands/push.rs
@@ -687,7 +687,15 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         prog.note(note);
     }
     // Real-push streams live; the buffered transcript is unused.
-    let _ = prog.finish("Finished.");
+    // When nothing reached the remote — no branch pushed, no orphan
+    // deleted — the stack already matched GitHub. A preceding rebase
+    // only rewrote local refs, so it still reports as up to date.
+    let closing = if pushed == 0 && planned.orphans.is_empty() {
+        "Already up to date."
+    } else {
+        "Finished."
+    };
+    let _ = prog.finish(closing);
 
     Ok(Outcome::Pushed {
         planned,


### PR DESCRIPTION
The real-push closing line was always "Finished.", giving no signal
that a run made no remote change. When no branch was pushed and no
orphan was deleted, the closing line is now "Already up to date." A
preceding rebase only rewrites local refs, so it still reports as up
to date.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>