### PR TITLE
feat(cli): publish the exit-code contract in the CLI schema

### DIFF
--- a/crates/mergify-cli/src/cli_schema.rs
+++ b/crates/mergify-cli/src/cli_schema.rs
@@ -7,10 +7,18 @@
 //! every field is sourced from a clap getter that the derive macro
 //! populates from the Rust doc comments and `#[arg]`/`#[command]`
 //! attributes — there is no hand-maintained docs metadata.
+//!
+//! The exit-code contract rides alongside the command tree: the
+//! top-level `exitCodes` block is sourced from [`mergify_core::ExitCode`]
+//! (the single source of truth, compat-tested), so it can't drift from
+//! the binary either. The per-command "which code can this command
+//! return" mapping is *not* introspectable and stays in the compat-test
+//! harness — it deliberately doesn't live here.
 
 use std::collections::BTreeSet;
 
 use clap::CommandFactory;
+use mergify_core::ExitCode;
 use serde::Serialize;
 
 use crate::CliRoot;
@@ -41,7 +49,15 @@ pub struct CliSchema {
     schema_version: u32,
     generator: &'static str,
     cli: CliInfo,
+    exit_codes: Vec<ExitCodeNode>,
     command: CommandNode,
+}
+
+#[derive(Serialize)]
+struct ExitCodeNode {
+    code: u8,
+    name: &'static str,
+    description: &'static str,
 }
 
 #[derive(Serialize)]
@@ -112,6 +128,15 @@ pub fn build() -> CliSchema {
     // can't drift from `cli.name`.
     let command = command_node(&root, vec![root.get_name().to_string()], &BTreeSet::new());
 
+    let exit_codes = ExitCode::ALL
+        .iter()
+        .map(|code| ExitCodeNode {
+            code: code.as_u8(),
+            name: code.name(),
+            description: code.description(),
+        })
+        .collect();
+
     CliSchema {
         schema_version: SCHEMA_VERSION,
         generator: "mergify _internal dump-cli-schema",
@@ -120,6 +145,7 @@ pub fn build() -> CliSchema {
             version: crate::VERSION,
             about: root.get_about().map(ToString::to_string),
         },
+        exit_codes,
         command,
     }
 }

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -4216,6 +4216,17 @@ mod tests {
             std::collections::BTreeSet::from(["native"]),
             "expected only `native` stack subcommands",
         );
+
+        // The exit-code contract rides alongside the command tree,
+        // sourced from `mergify_core::ExitCode`. Pin the codes so a
+        // dropped or renumbered variant surfaces here.
+        let codes: Vec<u64> = v["exitCodes"]
+            .as_array()
+            .expect("exitCodes array")
+            .iter()
+            .map(|c| c["code"].as_u64().expect("code"))
+            .collect();
+        assert_eq!(codes, [0, 1, 3, 4, 5, 6, 7, 8]);
     }
 
     #[test]

--- a/crates/mergify-core/src/exit_code.rs
+++ b/crates/mergify-core/src/exit_code.rs
@@ -26,11 +26,61 @@ pub enum ExitCode {
 }
 
 impl ExitCode {
+    /// Every variant, in numeric order. The single source of truth for
+    /// enumerating exit codes — the published CLI schema reads this.
+    pub const ALL: [Self; 8] = [
+        Self::Success,
+        Self::GenericError,
+        Self::StackNotFound,
+        Self::Conflict,
+        Self::GitHubApiError,
+        Self::MergifyApiError,
+        Self::InvalidState,
+        Self::ConfigurationError,
+    ];
+
     /// Raw u8 value suitable for `std::process::exit` or
     /// `std::process::ExitCode::from`.
     #[must_use]
     pub const fn as_u8(self) -> u8 {
         self as u8
+    }
+
+    /// Stable identifier — the enum variant name.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Success => "Success",
+            Self::GenericError => "GenericError",
+            Self::StackNotFound => "StackNotFound",
+            Self::Conflict => "Conflict",
+            Self::GitHubApiError => "GitHubApiError",
+            Self::MergifyApiError => "MergifyApiError",
+            Self::InvalidState => "InvalidState",
+            Self::ConfigurationError => "ConfigurationError",
+        }
+    }
+
+    /// One-line meaning for the published reference. Mirrors the
+    /// `CliError` variant that produces each code.
+    #[must_use]
+    pub const fn description(self) -> &'static str {
+        match self {
+            Self::Success => "Command completed successfully.",
+            Self::GenericError => {
+                "Unclassified runtime failure (I/O error, bug, or captured panic)."
+            }
+            Self::StackNotFound => "Stack, branch, or commit not found.",
+            Self::Conflict => "Rebase or merge conflict.",
+            Self::GitHubApiError => "GitHub API request failed.",
+            Self::MergifyApiError => "Mergify API request failed.",
+            Self::InvalidState => {
+                "CLI invariant violated (e.g. command run outside a valid context)."
+            }
+            Self::ConfigurationError => {
+                "Configuration file missing, unparseable, or failing validation."
+            }
+        }
     }
 }
 
@@ -48,6 +98,8 @@ impl From<ExitCode> for ProcessExitCode {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use super::*;
 
     #[test]
@@ -68,17 +120,35 @@ mod tests {
     fn two_is_not_used() {
         // Code 2 is reserved for Click/clap CLI argument errors.
         // No variant may shadow it.
-        for code in [
-            ExitCode::Success,
-            ExitCode::GenericError,
-            ExitCode::StackNotFound,
-            ExitCode::Conflict,
-            ExitCode::GitHubApiError,
-            ExitCode::MergifyApiError,
-            ExitCode::InvalidState,
-            ExitCode::ConfigurationError,
-        ] {
+        for code in ExitCode::ALL {
             assert_ne!(code.as_u8(), 2, "{code:?} must not use code 2");
+        }
+    }
+
+    #[test]
+    fn all_is_complete_and_ordered() {
+        // `ALL` is hand-maintained; a forgotten variant would silently
+        // drop from the published schema. Pin its codes against the
+        // contract, and require strictly ascending order so a stray
+        // duplicate or reordering is caught here.
+        let codes: Vec<u8> = ExitCode::ALL.iter().map(|c| c.as_u8()).collect();
+        assert_eq!(codes, [0, 1, 3, 4, 5, 6, 7, 8]);
+        assert!(
+            codes.windows(2).all(|w| w[0] < w[1]),
+            "ALL must be strictly ascending",
+        );
+    }
+
+    #[test]
+    fn names_and_descriptions_are_present_and_unique() {
+        let names: BTreeSet<&str> = ExitCode::ALL.iter().map(|c| c.name()).collect();
+        assert_eq!(names.len(), ExitCode::ALL.len(), "names must be unique");
+        for code in ExitCode::ALL {
+            assert!(!code.name().is_empty(), "{code:?} name is empty");
+            assert!(
+                !code.description().is_empty(),
+                "{code:?} description is empty",
+            );
         }
     }
 


### PR DESCRIPTION
Add a top-level `exitCodes` block to the machine-readable schema: code,
name, and one-line meaning for every variant, sourced from
`mergify_core::ExitCode`. Descriptions mirror the `CliError` variant that
produces each code, and `ExitCode` grows `ALL`/`name`/`description` so the
block stays single-source and can't drift from the binary — the same
guarantee the command tree already has.

The per-command "which code can this command return" mapping stays in the
compat-test harness: it isn't introspectable from clap, so encoding it in
the schema would reintroduce the hand-maintained metadata the generator
deliberately avoids.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>