### PR TITLE
fix(cargo): raise MSRV to 1.88 to match let-chain usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ members = ["crates/*"]
 
 [workspace.package]
 edition = "2024"
-# MSRV: the minimum supported toolchain. Set to the rustc that
-# ships edition 2024, so the project works on any stable from
-# early 2025 onwards. CI uses whatever stable is current.
-rust-version = "1.85"
+# MSRV: minimum supported toolchain. 1.88 is the floor — the code
+# uses let-chains (`if let Some(x) = … && cond`), stabilized in Rust
+# 1.88. The msrv CI job pins this exact version; move both together.
+rust-version = "1.88"
 license = "Apache-2.0"
 repository = "https://github.com/Mergifyio/mergify-cli"
 authors = ["Mergify Team <hello@mergify.com>"]

--- a/crates/mergify-ci/src/detector.rs
+++ b/crates/mergify-ci/src/detector.rs
@@ -386,10 +386,10 @@ pub fn get_head_sha() -> Option<String> {
 }
 
 fn get_github_actions_head_sha() -> Option<String> {
-    if env::var("GITHUB_EVENT_NAME").as_deref() == Ok("pull_request") {
-        if let Some(sha) = read_github_event_pull_request_head_sha() {
-            return Some(sha);
-        }
+    if env::var("GITHUB_EVENT_NAME").as_deref() == Ok("pull_request")
+        && let Some(sha) = read_github_event_pull_request_head_sha()
+    {
+        return Some(sha);
     }
     non_empty_env("GITHUB_SHA")
 }

--- a/crates/mergify-ci/src/git_refs.rs
+++ b/crates/mergify-ci/src/git_refs.rs
@@ -151,10 +151,10 @@ pub fn detect(
     output: &mut dyn Output,
     notes_reader: NotesReader<'_>,
 ) -> Result<References, CliError> {
-    if env::var("BUILDKITE").as_deref() == Ok("true") {
-        if let Some(refs) = detect_from_buildkite(notes_reader) {
-            return Ok(refs);
-        }
+    if env::var("BUILDKITE").as_deref() == Ok("true")
+        && let Some(refs) = detect_from_buildkite(notes_reader)
+    {
+        return Ok(refs);
     }
 
     let Some((event_name, event)) = load_event() else {
@@ -195,16 +195,15 @@ fn detect_from_buildkite(notes_reader: NotesReader<'_>) -> Option<References> {
         .ok()
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "HEAD".to_string());
-    if let Ok(branch) = env::var("BUILDKITE_BRANCH") {
-        if !branch.is_empty() {
-            if let Some(base) = notes_reader(&branch, &commit) {
-                return Some(References {
-                    base: Some(base),
-                    head: commit,
-                    source: ReferencesSource::MergeQueue,
-                });
-            }
-        }
+    if let Ok(branch) = env::var("BUILDKITE_BRANCH")
+        && !branch.is_empty()
+        && let Some(base) = notes_reader(&branch, &commit)
+    {
+        return Some(References {
+            base: Some(base),
+            head: commit,
+            source: ReferencesSource::MergeQueue,
+        });
     }
     let base_branch = env::var("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
         .ok()
@@ -227,18 +226,16 @@ fn detect_from_pull_request_event(
         .and_then(|pr| pr.head.as_ref())
         .map_or_else(|| "HEAD".to_string(), |r| r.sha.clone());
 
-    if let Some(pr) = &event.pull_request {
-        if let Some(head_ref) = &pr.head {
-            if let Some(branch) = head_ref.r#ref.as_deref() {
-                if let Some(base) = notes_reader(branch, &head_ref.sha) {
-                    return Ok(Some(References {
-                        base: Some(base),
-                        head,
-                        source: ReferencesSource::MergeQueue,
-                    }));
-                }
-            }
-        }
+    if let Some(pr) = &event.pull_request
+        && let Some(head_ref) = &pr.head
+        && let Some(branch) = head_ref.r#ref.as_deref()
+        && let Some(base) = notes_reader(branch, &head_ref.sha)
+    {
+        return Ok(Some(References {
+            base: Some(base),
+            head,
+            source: ReferencesSource::MergeQueue,
+        }));
     }
 
     if let Some(meta) = extract_from_event(event, output)? {
@@ -249,24 +246,24 @@ fn detect_from_pull_request_event(
         }));
     }
 
-    if let Some(pr) = &event.pull_request {
-        if let Some(base) = &pr.base {
-            return Ok(Some(References {
-                base: Some(base.sha.clone()),
-                head,
-                source: ReferencesSource::GithubEventPullRequest,
-            }));
-        }
+    if let Some(pr) = &event.pull_request
+        && let Some(base) = &pr.base
+    {
+        return Ok(Some(References {
+            base: Some(base.sha.clone()),
+            head,
+            source: ReferencesSource::GithubEventPullRequest,
+        }));
     }
 
-    if let Some(repo) = &event.repository {
-        if let Some(default_branch) = &repo.default_branch {
-            return Ok(Some(References {
-                base: Some(default_branch.clone()),
-                head,
-                source: ReferencesSource::GithubEventPullRequest,
-            }));
-        }
+    if let Some(repo) = &event.repository
+        && let Some(default_branch) = &repo.default_branch
+    {
+        return Ok(Some(References {
+            base: Some(default_branch.clone()),
+            head,
+            source: ReferencesSource::GithubEventPullRequest,
+        }));
     }
 
     Ok(None)

--- a/crates/mergify-ci/src/junit_process/command.rs
+++ b/crates/mergify-ci/src/junit_process/command.rs
@@ -195,12 +195,13 @@ pub async fn run(
     // non-zero but the JUnit report has no failures, the runner
     // probably crashed — fail loudly so the user knows the report
     // is incomplete.
-    if let Some(exit_code) = test_exit_code {
-        if exit_code != 0 && nb_failures == 0 {
-            write_silent_failure(&mut report, exit_code);
-            emit(output, &report)?;
-            return Ok(ExitCode::GenericError);
-        }
+    if let Some(exit_code) = test_exit_code
+        && exit_code != 0
+        && nb_failures == 0
+    {
+        write_silent_failure(&mut report, exit_code);
+        emit(output, &report)?;
+        return Ok(ExitCode::GenericError);
     }
 
     // ── Verdict.

--- a/crates/mergify-ci/src/junit_process/junit.rs
+++ b/crates/mergify-ci/src/junit_process/junit.rs
@@ -423,18 +423,18 @@ impl ParserState {
                 self.failure_captured = false;
             }
             b"failure" | b"error" => {
-                if let Some(tc) = self.in_progress.as_mut() {
-                    if !self.failure_captured {
-                        tc.status = if name == b"failure" {
-                            TestStatus::Failed
-                        } else {
-                            TestStatus::Errored
-                        };
-                        tc.failure = read_failure(e)?;
-                        self.in_failure = true;
-                        self.failure_captured = true;
-                        self.failure_text_buf.clear();
-                    }
+                if let Some(tc) = self.in_progress.as_mut()
+                    && !self.failure_captured
+                {
+                    tc.status = if name == b"failure" {
+                        TestStatus::Failed
+                    } else {
+                        TestStatus::Errored
+                    };
+                    tc.failure = read_failure(e)?;
+                    self.in_failure = true;
+                    self.failure_captured = true;
+                    self.failure_text_buf.clear();
                 }
             }
             b"skipped" => {
@@ -490,23 +490,23 @@ impl ParserState {
                 self.output.push(tc);
             }
             b"skipped" => {
-                if let Some(tc) = self.in_progress.as_mut() {
-                    if !self.failure_captured {
-                        tc.status = TestStatus::Skipped;
-                    }
+                if let Some(tc) = self.in_progress.as_mut()
+                    && !self.failure_captured
+                {
+                    tc.status = TestStatus::Skipped;
                 }
             }
             b"failure" | b"error" => {
-                if let Some(tc) = self.in_progress.as_mut() {
-                    if !self.failure_captured {
-                        tc.status = if name == b"failure" {
-                            TestStatus::Failed
-                        } else {
-                            TestStatus::Errored
-                        };
-                        tc.failure = read_failure(e)?;
-                        self.failure_captured = true;
-                    }
+                if let Some(tc) = self.in_progress.as_mut()
+                    && !self.failure_captured
+                {
+                    tc.status = if name == b"failure" {
+                        TestStatus::Failed
+                    } else {
+                        TestStatus::Errored
+                    };
+                    tc.failure = read_failure(e)?;
+                    self.failure_captured = true;
                 }
             }
             _ if !self.saw_valid_root => {
@@ -537,10 +537,10 @@ impl ParserState {
                 // close keeps the wire format identical to
                 // Python's `(child.text or "").strip()`.
                 let trimmed = self.failure_text_buf.trim();
-                if !trimmed.is_empty() {
-                    if let Some(tc) = self.in_progress.as_mut() {
-                        tc.failure.stacktrace = Some(trimmed.to_string());
-                    }
+                if !trimmed.is_empty()
+                    && let Some(tc) = self.in_progress.as_mut()
+                {
+                    tc.failure.stacktrace = Some(trimmed.to_string());
                 }
                 self.failure_text_buf.clear();
                 self.in_failure = false;

--- a/crates/mergify-ci/src/scopes_detect/mod.rs
+++ b/crates/mergify-ci/src/scopes_detect/mod.rs
@@ -240,13 +240,11 @@ fn emit_scopes_listing(
         writeln!(w, "Scopes touched:")?;
         for s in hit {
             writeln!(w, "- {s}")?;
-            if actions_debug {
-                if let Some(files) = by_scope.get(s) {
-                    let mut files: Vec<&String> = files.iter().collect();
-                    files.sort();
-                    for f in files {
-                        writeln!(w, "    {f}")?;
-                    }
+            if actions_debug && let Some(files) = by_scope.get(s) {
+                let mut files: Vec<&String> = files.iter().collect();
+                files.sort();
+                for f in files {
+                    writeln!(w, "    {f}")?;
                 }
             }
         }

--- a/crates/mergify-ci/src/scopes_detect/outputs.rs
+++ b/crates/mergify-ci/src/scopes_detect/outputs.rs
@@ -179,14 +179,14 @@ pub fn maybe_write_buildkite_annotation(
                 continue;
             }
         };
-        if let Some(mut stdin) = child.stdin.take() {
-            if let Err(e) = stdin.write_all(md.as_bytes()) {
-                eprintln!(
-                    "warning: failed to pipe markdown to buildkite-agent annotate \
+        if let Some(mut stdin) = child.stdin.take()
+            && let Err(e) = stdin.write_all(md.as_bytes())
+        {
+            eprintln!(
+                "warning: failed to pipe markdown to buildkite-agent annotate \
                      ({scope_label} scope): {e}",
-                );
-                // fall through to wait() so the child is reaped
-            }
+            );
+            // fall through to wait() so the child is reaped
         }
         let output = match child.wait_with_output() {
             Ok(o) => o,

--- a/crates/mergify-core/src/auth.rs
+++ b/crates/mergify-core/src/auth.rs
@@ -41,10 +41,10 @@ pub fn resolve_token(explicit: Option<&str>) -> Result<String, CliError> {
             return Ok(value);
         }
     }
-    if let Ok(token) = gh_auth_token() {
-        if !token.is_empty() {
-            return Ok(token);
-        }
+    if let Ok(token) = gh_auth_token()
+        && !token.is_empty()
+    {
+        return Ok(token);
     }
     Err(CliError::Configuration(
         "please set the 'MERGIFY_TOKEN' or 'GITHUB_TOKEN' environment variable, \

--- a/crates/mergify-stack/src/commands/note.rs
+++ b/crates/mergify-stack/src/commands/note.rs
@@ -236,7 +236,8 @@ fn read_note_from_editor() -> Result<String, CliError> {
     let status = invoke_editor(&editor, path.to_string_lossy().as_ref())?;
     if !status.success() {
         return Err(CliError::Generic(format!(
-            "editor {editor:?} exited with status {status:?}"
+            "editor {} exited with status {status:?}",
+            editor.display()
         )));
     }
 

--- a/crates/mergify-stack/src/git.rs
+++ b/crates/mergify-stack/src/git.rs
@@ -227,10 +227,10 @@ pub fn compute_base_commit_sha(
     trunk_ref: &str,
     dest_branch: &str,
 ) -> Result<String, CliError> {
-    if let Ok(sha) = run_git_capture(Some(repo_dir), &["merge-base", "--fork-point", trunk_ref]) {
-        if !sha.is_empty() {
-            return Ok(sha);
-        }
+    if let Ok(sha) = run_git_capture(Some(repo_dir), &["merge-base", "--fork-point", trunk_ref])
+        && !sha.is_empty()
+    {
+        return Ok(sha);
     }
     let sha = run_git_capture(Some(repo_dir), &["merge-base", trunk_ref, "HEAD"])?;
     if sha.is_empty() {

--- a/crates/mergify-stack/src/progress.rs
+++ b/crates/mergify-stack/src/progress.rs
@@ -523,14 +523,15 @@ fn render_row(
             &format!("{glyph_style}{status}{reset}", reset = theme.reset),
             1,
         );
-        if let Some(detail) = row.detail.as_deref() {
-            if !detail.is_empty() && out.contains(detail) {
-                out = out.replacen(
-                    detail,
-                    &format!("{dim}{detail}{reset}", dim = theme.dim, reset = theme.reset),
-                    1,
-                );
-            }
+        if let Some(detail) = row.detail.as_deref()
+            && !detail.is_empty()
+            && out.contains(detail)
+        {
+            out = out.replacen(
+                detail,
+                &format!("{dim}{detail}{reset}", dim = theme.dim, reset = theme.reset),
+                1,
+            );
         }
     }
     out

--- a/crates/mergify-stack/src/rebase_todo.rs
+++ b/crates/mergify-stack/src/rebase_todo.rs
@@ -364,12 +364,12 @@ fn rewrite_squash(
         out.push_str(rest);
         out.push_str(term_to_emit);
 
-        if let Some((after_sha, command)) = exec_set {
-            if sha_matches(sha, after_sha) {
-                out.push_str("exec ");
-                out.push_str(command);
-                out.push_str(term_to_emit);
-            }
+        if let Some((after_sha, command)) = exec_set
+            && sha_matches(sha, after_sha)
+        {
+            out.push_str("exec ");
+            out.push_str(command);
+            out.push_str(term_to_emit);
         }
     }
     out.push_str(&other_lines);

--- a/crates/mergify-stack/src/stack_context.rs
+++ b/crates/mergify-stack/src/stack_context.rs
@@ -173,12 +173,12 @@ pub fn resolve_repo(
 /// for local wiremock servers) without the coercion getting in
 /// the way.
 pub fn resolve_github_server(repo_dir: Option<&Path>) -> Result<Url, CliError> {
-    if let Ok(raw) = std::env::var("MERGIFY_GITHUB_SERVER") {
-        if !raw.is_empty() {
-            return Url::parse(&raw).map_err(|e| {
-                CliError::InvalidState(format!("invalid MERGIFY_GITHUB_SERVER '{raw}': {e}"))
-            });
-        }
+    if let Ok(raw) = std::env::var("MERGIFY_GITHUB_SERVER")
+        && !raw.is_empty()
+    {
+        return Url::parse(&raw).map_err(|e| {
+            CliError::InvalidState(format!("invalid MERGIFY_GITHUB_SERVER '{raw}': {e}"))
+        });
     }
     let configured = run_git_capture(repo_dir, &["config", "--get", "mergify-cli.github-server"])
         .unwrap_or_default();


### PR DESCRIPTION
The workspace declares rust-version = "1.85", but the code uses
let-chains (`if let … && …`) — stabilized in Rust 1.88 — in
revision_history.rs, notes_push.rs, and approvals.rs. Building on
1.85–1.87 fails deep in compilation with E0658, so the declared
floor was a misleading contract.

Raise the floor to the honest minimum. Cargo now rejects older
toolchains up front ("requires rustc 1.88") instead of failing
mid-build. Prebuilt wheels are unaffected — no rustc is involved.

Raising the floor unlocks two clippy suggestions previously gated
below 1.85, applied here so the bump lands clippy-clean: collapsing
nested `if let { if … }` into let-chains (clippy::collapsible_if),
and `OsStr::display()` (stable since 1.87) instead of `{:?}` on the
editor path in `stack note` (clippy::unnecessary_debug_formatting).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>