### PR TITLE
ci: harden the PR pipeline with MSRV, supply-chain, and lint gates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,13 @@ on:
       - main
       - devs/**
 
+# Cancel superseded runs on the same ref — a force-push or a new
+# commit makes the in-flight matrix obsolete, so don't keep runners
+# busy finishing it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   rust:
     timeout-minutes: 10
@@ -26,13 +33,63 @@ jobs:
         run: cargo fmt --all --check
 
       - name: cargo clippy
-        run: cargo clippy --all-targets --workspace -- -D warnings
+        run: cargo clippy --all-targets --all-features --workspace --locked -- -D warnings
 
       - name: cargo test
-        run: cargo test --workspace
+        run: cargo test --workspace --all-features --locked
 
       - name: cargo build --release
-        run: cargo build --release
+        run: cargo build --release --locked
+
+  # Verify the workspace compiles on the declared MSRV. The version
+  # is read from Cargo.toml so the floor stays a single source of
+  # truth — bump rust-version there and this job follows it. `--locked`
+  # makes the committed lockfile part of the contract.
+  msrv:
+    name: cargo check (MSRV)
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - name: Resolve MSRV from Cargo.toml
+        id: msrv
+        run: |
+          set -euo pipefail
+          msrv=$(grep -m1 '^rust-version' Cargo.toml | sed -E 's/.*"([0-9.]+)".*/\1/')
+          echo "Declared MSRV: ${msrv}"
+          echo "version=${msrv}" >> "${GITHUB_OUTPUT}"
+      - name: Install MSRV toolchain
+        run: |
+          rustup toolchain install "${{ steps.msrv.outputs.version }}" --profile minimal
+          rustup default "${{ steps.msrv.outputs.version }}"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: msrv
+      - name: cargo check --locked on MSRV
+        run: cargo check --workspace --all-targets --locked
+
+  # Supply-chain gate: RUSTSEC advisories, license policy, banned /
+  # duplicate crates, and source provenance. Policy lives in
+  # deny.toml; reproduce locally with `cargo deny check`.
+  cargo-deny:
+    name: cargo-deny
+    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories bans licenses sources
+
+  # Spellcheck source, comments, and docs. Allow-list of project
+  # nouns lives in _typos.toml; reproduce locally with `typos`.
+  typos:
+    name: typos
+    timeout-minutes: 5
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - uses: crate-ci/typos@master
 
   # Smoke build the full release wheel matrix on every PR so a
   # cross-compile or platform-specific maturin failure is caught
@@ -382,6 +439,9 @@ jobs:
     if: ${{ !cancelled() }}
     needs:
       - rust
+      - msrv
+      - cargo-deny
+      - typos
       - wheels
       - smoke-test-binary
       - install-script-smoke

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,15 @@
+# typos spell-check allow-list. Reproduce CI locally with `typos`.
+
+[default.extend-words]
+# Spelling used consistently across the crates, including the
+# queue::Unparseable variant — accept it rather than churn a rename.
+unparseable = "unparseable"
+# Hyphenated prefix in comments: "mis-configured", "mis-resolved",
+# "mis-indent" — typos splits on the hyphen and flags "mis".
+mis = "mis"
+# Relative-time format tokens: Nm / Nh / Nd (N minutes/hours/days).
+nd = "nd"
+# French input exercised by the slug tests ("l'authentification").
+authentification = "authentification"
+# Hex-like test Change-Id fixture token ("Idead0000…ff").
+idead = "idead"

--- a/crates/mergify-queue/src/unpause.rs
+++ b/crates/mergify-queue/src/unpause.rs
@@ -1,7 +1,7 @@
 //! `mergify queue unpause` — resume the merge queue for a
 //! repository.
 //!
-//! DELETEs ``/v1/repos/<repo>/merge-queue/pause``. When the API
+//! Sends a DELETE to ``/v1/repos/<repo>/merge-queue/pause``. When the API
 //! responds 404 the command prints "Queue is not currently paused"
 //! and exits with `MERGIFY_API_ERROR` — matches Python's behavior.
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,41 @@
+# cargo-deny supply-chain policy for the workspace.
+# Reproduce CI locally with `cargo deny check`.
+
+[advisories]
+# RUSTSEC advisory database. A yanked crate in the lockfile is a
+# hard fail — it signals the resolved version was pulled.
+yanked = "deny"
+
+[bans]
+# Duplicate versions of a crate are usually a feature/version-drift
+# symptom; surface them as a warning rather than blocking, since a
+# transitive diamond is often out of our hands.
+multiple-versions = "warn"
+# A wildcard ("*") version on a third-party crate is never
+# intentional — but the workspace's own path deps have no version
+# requirement and would register as wildcards, so exempt them.
+wildcards = "deny"
+allow-wildcard-paths = true
+
+[licenses]
+# SPDX identifiers we accept for anything we redistribute. Keep this
+# list tight; add an entry (with the crate that needs it) rather than
+# loosening confidence-threshold.
+allow = [
+    "Apache-2.0",
+    "MIT",
+    "MIT-0",                 # borrow-or-share (via jsonschema)
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "CDLA-Permissive-2.0",   # webpki-root-certs (via rustls)
+    "Zlib",
+    "MPL-2.0",
+]
+confidence-threshold = 0.9
+
+[sources]
+# crates.io only — no git or alternative registries slip in unnoticed.
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
CI ran fmt / clippy / test / build but lacked the supply-chain and
contract gates a distributed Rust CLI should enforce. Add them, all
wired into ci-gate:

- msrv: compile the workspace on the declared rust-version, read
  from Cargo.toml so the floor stays a single source of truth — the
  MSRV becomes a tested contract instead of a comment.
- cargo-deny (deny.toml): RUSTSEC advisories, a license allow-list,
  banned/duplicate crates, and crates.io-only source provenance.
- typos (_typos.toml): spellcheck source, comments, and docs.
- --locked on every cargo invocation so the committed Cargo.lock is
  the build contract; --all-features on clippy/test so feature-gated
  paths are linted and exercised.
- concurrency.cancel-in-progress: drop a superseded run on the same
  ref instead of finishing the obsolete matrix.

The one doc-comment reword in queue unpause.rs avoids a typos
false positive on "DELETEs".

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>