### PR TITLE
fix(ci): resolve junit-process token via the shared auth helper

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -66,17 +66,22 @@ jobs:
             target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
 
       - name: Stamp wheel version
         if: inputs.stamp-version
+        env:
+          # Read the input through the environment, not `${{ }}` shell
+          # interpolation, so a value with shell metacharacters reaches
+          # bash as a plain string and can't break out of the script.
+          OVERRIDE_VERSION: ${{ inputs.override-version }}
         shell: bash
         run: |
           set -eu
@@ -85,8 +90,8 @@ jobs:
           # passes `inputs.tag` here because no tag exists yet — it
           # gets created by `gh release create` later in the
           # workflow.
-          if [ -n "${{ inputs.override-version }}" ]; then
-              VERSION='${{ inputs.override-version }}'
+          if [ -n "${OVERRIDE_VERSION}" ]; then
+              VERSION="${OVERRIDE_VERSION}"
           else
               VERSION="${GITHUB_REF#refs/tags/}"
           fi
@@ -110,7 +115,7 @@ jobs:
           echo "MERGIFY_RELEASE_VERSION=${VERSION}" >> "${GITHUB_ENV}"
 
       - name: Build wheel
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           target: ${{ matrix.target }}
           # `manylinux: auto` picks the most-compatible glibc the
@@ -146,7 +151,7 @@ jobs:
       # builds just need the build to succeed — keeping the
       # artifact upload off saves cache space and a few seconds per
       # platform.
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: inputs.stamp-version
         with:
           name: wheel-${{ matrix.target }}
@@ -157,24 +162,27 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
 
       - name: Stamp wheel version
         if: inputs.stamp-version
+        env:
+          # Through the environment, not `${{ }}` — see the wheel job.
+          OVERRIDE_VERSION: ${{ inputs.override-version }}
         shell: bash
         run: |
           set -eu
           # Same source-priority as the wheel job above —
           # `override-version` wins, falls back to the tag.
-          if [ -n "${{ inputs.override-version }}" ]; then
-              VERSION='${{ inputs.override-version }}'
+          if [ -n "${OVERRIDE_VERSION}" ]; then
+              VERSION="${OVERRIDE_VERSION}"
           else
               VERSION="${GITHUB_REF#refs/tags/}"
           fi
@@ -185,7 +193,7 @@ jobs:
           sed -i.bak -E "s/^version = \".*\"$/version = \"${VERSION}\"/" pyproject.toml
           rm -f pyproject.toml.bak
 
-      - uses: PyO3/maturin-action@v1
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: sdist
           args: --out target/wheels
@@ -200,7 +208,7 @@ jobs:
           python -m pip install --quiet twine
           twine check --strict target/wheels/*.tar.gz
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: inputs.stamp-version
         with:
           name: wheel-sdist

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Rust toolchain
         run: |
@@ -27,7 +27,7 @@ jobs:
           rustup default stable
           rustup component add rustfmt clippy --toolchain stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: cargo fmt
         run: cargo fmt --all --check
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Resolve MSRV from Cargo.toml
         id: msrv
         run: |
@@ -62,7 +62,7 @@ jobs:
         run: |
           rustup toolchain install "${{ steps.msrv.outputs.version }}" --profile minimal
           rustup default "${{ steps.msrv.outputs.version }}"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: msrv
       - name: cargo check --locked on MSRV
@@ -76,8 +76,8 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6.0.3
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
         with:
           command: check advisories bans licenses sources
 
@@ -88,8 +88,8 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6.0.3
-      - uses: crate-ci/typos@master
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2
 
   # Smoke build the full release wheel matrix on every PR so a
   # cross-compile or platform-specific maturin failure is caught
@@ -119,15 +119,15 @@ jobs:
         os: [ubuntu-24.04, windows-2025, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6.0.3
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
       - name: Install Rust toolchain
         run: |
           rustup toolchain install stable --profile minimal
           rustup default stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: smoke-${{ matrix.os }}
       - name: Build wheel
@@ -179,12 +179,12 @@ jobs:
         os: [ubuntu-24.04, macos-15, windows-2025]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust toolchain
         run: |
           rustup toolchain install stable --profile minimal
           rustup default stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: install-${{ matrix.os }}
 
@@ -339,12 +339,12 @@ jobs:
         os: [ubuntu-24.04, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust toolchain
         run: |
           rustup toolchain install stable --profile minimal
           rustup default stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: self-update-${{ matrix.os }}
 
@@ -449,7 +449,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify all jobs succeeded
-        uses: Mergifyio/gha-mergify-ci@v22
+        uses: Mergifyio/gha-mergify-ci@f1feee72acd3b001406ff1cc0ce23e6033e26fe7 # v22
         with:
           action: wait-jobs
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,13 @@ on:
       - main
       - devs/**
 
+# Cancel superseded runs on the same ref — a force-push or a new
+# commit makes the in-flight matrix obsolete, so don't keep runners
+# busy finishing it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   rust:
     timeout-minutes: 10
@@ -26,13 +33,63 @@ jobs:
         run: cargo fmt --all --check
 
       - name: cargo clippy
-        run: cargo clippy --all-targets --workspace -- -D warnings
+        run: cargo clippy --all-targets --all-features --workspace --locked -- -D warnings
 
       - name: cargo test
-        run: cargo test --workspace
+        run: cargo test --workspace --all-features --locked
 
       - name: cargo build --release
-        run: cargo build --release
+        run: cargo build --release --locked
+
+  # Verify the workspace compiles on the declared MSRV. The version
+  # is read from Cargo.toml so the floor stays a single source of
+  # truth — bump rust-version there and this job follows it. `--locked`
+  # makes the committed lockfile part of the contract.
+  msrv:
+    name: cargo check (MSRV)
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - name: Resolve MSRV from Cargo.toml
+        id: msrv
+        run: |
+          set -euo pipefail
+          msrv=$(grep -m1 '^rust-version' Cargo.toml | sed -E 's/.*"([0-9.]+)".*/\1/')
+          echo "Declared MSRV: ${msrv}"
+          echo "version=${msrv}" >> "${GITHUB_OUTPUT}"
+      - name: Install MSRV toolchain
+        run: |
+          rustup toolchain install "${{ steps.msrv.outputs.version }}" --profile minimal
+          rustup default "${{ steps.msrv.outputs.version }}"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: msrv
+      - name: cargo check --locked on MSRV
+        run: cargo check --workspace --all-targets --locked
+
+  # Supply-chain gate: RUSTSEC advisories, license policy, banned /
+  # duplicate crates, and source provenance. Policy lives in
+  # deny.toml; reproduce locally with `cargo deny check`.
+  cargo-deny:
+    name: cargo-deny
+    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories bans licenses sources
+
+  # Spellcheck source, comments, and docs. Allow-list of project
+  # nouns lives in _typos.toml; reproduce locally with `typos`.
+  typos:
+    name: typos
+    timeout-minutes: 5
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - uses: crate-ci/typos@master
 
   # Smoke build the full release wheel matrix on every PR so a
   # cross-compile or platform-specific maturin failure is caught
@@ -382,6 +439,9 @@ jobs:
     if: ${{ !cancelled() }}
     needs:
       - rust
+      - msrv
+      - cargo-deny
+      - typos
       - wheels
       - smoke-test-binary
       - install-script-smoke

--- a/.github/workflows/func-tests-live.yaml
+++ b/.github/workflows/func-tests-live.yaml
@@ -10,19 +10,25 @@ permissions: read-all
 on:
   pull_request:
 
+# Drop a superseded run on the same ref — these hit the live Mergify
+# API, so finishing an obsolete run just wastes a real API budget.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   live-tests:
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     environment: func-tests-live
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Rust toolchain
         run: |
           rustup toolchain install stable --profile minimal
           rustup default stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Live smoke tests
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # `git tag -l` needs the full tag list to find today's
           # highest counter.
@@ -151,15 +151,19 @@ jobs:
     permissions:
       # `gh release create` writes the release.
       contents: write
+      # actions/attest-build-provenance mints a signed provenance for
+      # each binary asset (id-token to sign, attestations to record).
+      id-token: write
+      attestations: write
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # `--generate-notes` needs full history to walk back to
           # the previous tag.
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           # Skip `wheel-sdist` (single dash); each wheel artifact is
           # `wheel-<target>` with multiple dashes in the target.
@@ -212,6 +216,15 @@ jobs:
           (cd dist && sha256sum mergify-* > SHA256SUMS)
           echo "Built release assets:"
           ls -la dist
+
+      # Sign every binary asset with a build-provenance attestation,
+      # so a downloader can prove it was built by this workflow from
+      # this repo: `gh attestation verify <file> --repo Mergifyio/mergify-cli`.
+      # SHA256SUMS already chains integrity to these subjects, so it
+      # needs no separate attestation.
+      - uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-path: dist/mergify-*
 
       # Dump the CLI schema straight off the released binary so the
       # docs site renders the command reference from the same artifact
@@ -343,7 +356,7 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           # `wheel-*` covers both `wheel-<target>` artifacts and
           # `wheel-sdist` — PyPI gets both.
@@ -355,6 +368,9 @@ jobs:
         run: ls -la dist
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: dist
+          # Mint PEP 740 attestations for the wheels/sdist via the
+          # same Trusted Publishing identity (id-token: write above).
+          attestations: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,38 @@ license = "Apache-2.0"
 repository = "https://github.com/Mergifyio/mergify-cli"
 authors = ["Mergify Team <hello@mergify.com>"]
 
+[workspace.dependencies]
+anstyle = "1"
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
+clap = { version = "4.5", features = ["derive", "env"] }
+flate2 = "1"
+getrandom = "0.4"
+glob = "0.3"
+globset = "0.4"
+iana-time-zone = "0.1"
+jsonschema = { version = "0.46", default-features = false }
+opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic-messages", "trace"] }
+prost = "0.14"
+quick-xml = "0.40"
+regex = "1"
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
+self-replace = "1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_yaml_ng = "0.10"
+sha2 = "0.11"
+tempfile = "3.14"
+terminal_size = "0.4"
+thiserror = "2.0"
+# tokio: rt-multi-thread is intentionally NOT here — it is added only
+# in the dev-dependency entries that need it, so the shipped binary's
+# single current-thread runtime never pulls in the MT scheduler.
+tokio = { version = "1", default-features = false, features = ["macros", "rt", "time"] }
+unicode-width = "0.2"
+url = "2"
+temp-env = "0.3"
+wiremock = "0.6"
+
 [workspace.lints.rust]
 unsafe_code = "forbid"
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,15 @@
+# typos spell-check allow-list. Reproduce CI locally with `typos`.
+
+[default.extend-words]
+# Spelling used consistently across the crates, including the
+# queue::Unparseable variant — accept it rather than churn a rename.
+unparseable = "unparseable"
+# Hyphenated prefix in comments: "mis-configured", "mis-resolved",
+# "mis-indent" — typos splits on the hyphen and flags "mis".
+mis = "mis"
+# Relative-time format tokens: Nm / Nh / Nd (N minutes/hours/days).
+nd = "nd"
+# French input exercised by the slug tests ("l'authentification").
+authentification = "authentification"
+# Hex-like test Change-Id fixture token ("Idead0000…ff").
+idead = "idead"

--- a/crates/mergify-ci/Cargo.toml
+++ b/crates/mergify-ci/Cargo.toml
@@ -10,29 +10,29 @@ description = "Native implementation of `mergify ci` subcommands."
 publish = false
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
-flate2 = "1"
-getrandom = "0.4"
-glob = "0.3"
-globset = "0.4"
+chrono = { workspace = true }
+flate2 = { workspace = true }
+getrandom = { workspace = true }
+glob = { workspace = true }
+globset = { workspace = true }
 mergify-config = { path = "../mergify-config" }
 mergify-core = { path = "../mergify-core" }
-opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic-messages", "trace"] }
-prost = "0.14"
-quick-xml = "0.40"
-reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-serde_yaml_ng = "0.10"
-tokio = { version = "1", default-features = false, features = ["rt"] }
-url = "2"
+opentelemetry-proto = { workspace = true }
+prost = { workspace = true }
+quick-xml = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml_ng = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 mergify-test-support = { path = "../mergify-test-support" }
-tempfile = "3.14"
-temp-env = { version = "0.3", features = ["async_closure"] }
-tokio = { version = "1", default-features = false, features = ["macros", "rt", "time"] }
-wiremock = "0.6"
+tempfile = { workspace = true }
+temp-env = { workspace = true, features = ["async_closure"] }
+tokio = { workspace = true }
+wiremock = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mergify-ci/src/junit_process/command.rs
+++ b/crates/mergify-ci/src/junit_process/command.rs
@@ -24,9 +24,9 @@
 
 use std::path::{Path, PathBuf};
 
+use mergify_core::auth;
 use mergify_core::env::var_non_empty;
 use mergify_core::{CliError, ExitCode, Output};
-use url::Url;
 
 use crate::detector;
 use crate::junit_process::junit::{self, ParseResult, TestCase};
@@ -71,10 +71,8 @@ pub async fn run(
     // printing any of the banner — matches Python's click defaults
     // surfacing as exit code 2 when a required flag is missing,
     // before the command body runs.
-    let api_url_raw = resolve_api_url(opts.api_url);
-    let api_url = Url::parse(&api_url_raw)
-        .map_err(|e| CliError::Configuration(format!("--api-url is not a valid URL: {e}")))?;
-    let token = resolve_token(opts.token)?;
+    let api_url = auth::resolve_api_url(opts.api_url)?;
+    let token = auth::resolve_token(opts.token)?;
     let repository = detector::resolve_repository(opts.repository)?;
     let tests_target_branch = resolve_tests_target_branch(opts.tests_target_branch)?;
     let test_exit_code = resolve_test_exit_code(opts.test_exit_code)?;
@@ -163,9 +161,15 @@ pub async fn run(
     let built = spans::build_traces(&parsed, &metadata);
 
     let client = upload::default_client();
-    let upload_error = upload::upload(&client, &api_url_raw, &token, &repository, &built.request)
-        .await
-        .err();
+    let upload_error = upload::upload(
+        &client,
+        api_url.as_str(),
+        &token,
+        &repository,
+        &built.request,
+    )
+    .await
+    .err();
     maybe_write_github_output(upload_status_label(upload_error.as_ref()));
 
     // ── Report sections — order matches Python verbatim.
@@ -229,14 +233,6 @@ fn emit(output: &mut dyn Output, report: &str) -> Result<(), CliError> {
         .map_err(|e| CliError::Generic(format!("could not write output: {e}")))
 }
 
-fn resolve_api_url(explicit: Option<&str>) -> String {
-    explicit
-        .filter(|s| !s.is_empty())
-        .map(ToString::to_string)
-        .or_else(|| var_non_empty("MERGIFY_API_URL"))
-        .unwrap_or_else(|| "https://api.mergify.com".to_string())
-}
-
 /// Resolve `--test-exit-code` / `MERGIFY_TEST_EXIT_CODE`. Empty
 /// env value is treated as "unset" so callers like the
 /// `gha-mergify-ci` action can export `MERGIFY_TEST_EXIT_CODE=""`
@@ -257,18 +253,6 @@ fn resolve_test_exit_code(explicit: Option<i32>) -> Result<Option<i32>, CliError
             "MERGIFY_TEST_EXIT_CODE={raw:?} is not a valid integer: {e}",
         ))
     })
-}
-
-fn resolve_token(explicit: Option<&str>) -> Result<String, CliError> {
-    explicit
-        .filter(|s| !s.is_empty())
-        .map(ToString::to_string)
-        .or_else(|| var_non_empty("MERGIFY_TOKEN"))
-        .ok_or_else(|| {
-            CliError::Configuration(
-                "--token not provided and MERGIFY_TOKEN env var is empty".to_string(),
-            )
-        })
 }
 
 fn resolve_tests_target_branch(explicit: Option<&str>) -> Result<String, CliError> {

--- a/crates/mergify-cli/Cargo.toml
+++ b/crates/mergify-cli/Cargo.toml
@@ -14,8 +14,8 @@ name = "mergify"
 path = "src/main.rs"
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
-clap = { version = "4.5", features = ["derive", "env"] }
+chrono = { workspace = true }
+clap = { workspace = true }
 mergify-ci = { path = "../mergify-ci" }
 mergify-config = { path = "../mergify-config" }
 mergify-core = { path = "../mergify-core" }
@@ -31,25 +31,25 @@ mergify-stack = { path = "../mergify-stack" }
 # auth + retry, neither of which apply to unauthenticated public
 # release downloads. `self_replace` handles the Windows
 # can't-rename-over-a-running-exe dance cross-platform.
-reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
-self-replace = "1"
-sha2 = "0.11"
-tempfile = "3"
+reqwest = { workspace = true }
+self-replace = { workspace = true }
+sha2 = { workspace = true }
+tempfile = { workspace = true }
 # Backs the `_internal dump-cli-schema` generator (serializing the
 # clap command tree) and the Python-migration helpers (`_internal
 # stack-local-commits` et al.).
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tokio = { version = "1", default-features = false, features = ["macros", "rt", "time"] }
-url = "2"
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
-regex = "1"
-serde_yaml_ng = "0.10"
-temp-env = "0.3"
-tempfile = "3.14"
-tokio = { version = "1", default-features = false, features = ["macros", "rt", "rt-multi-thread"] }
-wiremock = "0.6"
+regex = { workspace = true }
+serde_yaml_ng = { workspace = true }
+temp-env = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+wiremock = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mergify-config/Cargo.toml
+++ b/crates/mergify-config/Cargo.toml
@@ -11,18 +11,18 @@ publish = false
 
 [dependencies]
 mergify-core = { path = "../mergify-core" }
-jsonschema = { version = "0.46", default-features = false }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-serde_yaml_ng = "0.10"
-url = "2"
+jsonschema = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml_ng = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 mergify-test-support = { path = "../mergify-test-support" }
-tempfile = "3.14"
-temp-env = "0.3"
-tokio = { version = "1", default-features = false, features = ["macros", "rt", "time"] }
-wiremock = "0.6"
+tempfile = { workspace = true }
+temp-env = { workspace = true }
+tokio = { workspace = true }
+wiremock = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mergify-core/Cargo.toml
+++ b/crates/mergify-core/Cargo.toml
@@ -10,17 +10,17 @@ description = "Shared foundations for mergify-cli: HTTP, auth, errors, output, g
 publish = false
 
 [dependencies]
-reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-thiserror = "2.0"
-tokio = { version = "1", default-features = false, features = ["macros", "rt", "time"] }
-url = "2"
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
-temp-env = "0.3"
-tokio = { version = "1", default-features = false, features = ["macros", "rt", "rt-multi-thread", "time"] }
-wiremock = "0.6"
+temp-env = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+wiremock = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mergify-freeze/Cargo.toml
+++ b/crates/mergify-freeze/Cargo.toml
@@ -12,16 +12,16 @@ publish = false
 [dependencies]
 mergify-core = { path = "../mergify-core" }
 mergify-tui = { path = "../mergify-tui" }
-anstyle = "1"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
-iana-time-zone = "0.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+anstyle = { workspace = true }
+chrono = { workspace = true }
+iana-time-zone = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 mergify-test-support = { path = "../mergify-test-support" }
-tokio = { version = "1", default-features = false, features = ["macros", "rt", "time"] }
-wiremock = "0.6"
+tokio = { workspace = true }
+wiremock = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mergify-queue/Cargo.toml
+++ b/crates/mergify-queue/Cargo.toml
@@ -12,16 +12,16 @@ publish = false
 [dependencies]
 mergify-core = { path = "../mergify-core" }
 mergify-tui = { path = "../mergify-tui" }
-anstyle = "1"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-url = "2"
+anstyle = { workspace = true }
+chrono = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 mergify-test-support = { path = "../mergify-test-support" }
-tokio = { version = "1", default-features = false, features = ["macros", "rt", "time"] }
-wiremock = "0.6"
+tokio = { workspace = true }
+wiremock = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mergify-queue/src/unpause.rs
+++ b/crates/mergify-queue/src/unpause.rs
@@ -1,7 +1,7 @@
 //! `mergify queue unpause` — resume the merge queue for a
 //! repository.
 //!
-//! DELETEs ``/v1/repos/<repo>/merge-queue/pause``. When the API
+//! Sends a DELETE to ``/v1/repos/<repo>/merge-queue/pause``. When the API
 //! responds 404 the command prints "Queue is not currently paused"
 //! and exits with `MERGIFY_API_ERROR` — matches Python's behavior.
 

--- a/crates/mergify-stack/Cargo.toml
+++ b/crates/mergify-stack/Cargo.toml
@@ -10,34 +10,34 @@ description = "Native implementation of `mergify stack` subcommands."
 publish = false
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
+chrono = { workspace = true }
 mergify-core = { path = "../mergify-core" }
 # `stack push` live progress reuses the shared TTY/`NO_COLOR`-aware
 # color palette instead of hand-rolling ANSI consts.
 mergify-tui = { path = "../mergify-tui" }
-regex = "1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tempfile = "3.14"
+regex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
 # `stack push` live progress: query the terminal width so each
 # in-place row is truncated to one physical line (multi-line
 # cursor-up redraw breaks if a row wraps).
-terminal_size = "0.4"
+terminal_size = { workspace = true }
 # Measure CJK/emoji/wide glyphs at their real terminal column width so
 # the in-place redraw's truncation never lets a row wrap (a wrap
 # desyncs the cursor-up math and corrupts the live block).
-unicode-width = "0.2"
+unicode-width = { workspace = true }
 # `rt` for `spawn_blocking` — runs the synchronous git fetch/push
 # off the async executor so the `stack push` progress spinner keeps
 # ticking smoothly across them.
-tokio = { version = "1", default-features = false, features = ["rt", "time"] }
-url = "2"
+tokio = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
-temp-env = "0.3"
-tokio = { version = "1", default-features = false, features = ["macros", "rt"] }
-url = "2"
-wiremock = "0.6"
+temp-env = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
+wiremock = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mergify-tui/Cargo.toml
+++ b/crates/mergify-tui/Cargo.toml
@@ -10,8 +10,8 @@ description = "Reusable terminal-UI primitives for mergify-cli: ANSI styling, re
 publish = false
 
 [dependencies]
-anstyle = "1"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
+anstyle = { workspace = true }
+chrono = { workspace = true }
 
 [lints]
 workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,41 @@
+# cargo-deny supply-chain policy for the workspace.
+# Reproduce CI locally with `cargo deny check`.
+
+[advisories]
+# RUSTSEC advisory database. A yanked crate in the lockfile is a
+# hard fail — it signals the resolved version was pulled.
+yanked = "deny"
+
+[bans]
+# Duplicate versions of a crate are usually a feature/version-drift
+# symptom; surface them as a warning rather than blocking, since a
+# transitive diamond is often out of our hands.
+multiple-versions = "warn"
+# A wildcard ("*") version on a third-party crate is never
+# intentional — but the workspace's own path deps have no version
+# requirement and would register as wildcards, so exempt them.
+wildcards = "deny"
+allow-wildcard-paths = true
+
+[licenses]
+# SPDX identifiers we accept for anything we redistribute. Keep this
+# list tight; add an entry (with the crate that needs it) rather than
+# loosening confidence-threshold.
+allow = [
+    "Apache-2.0",
+    "MIT",
+    "MIT-0",                 # borrow-or-share (via jsonschema)
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "CDLA-Permissive-2.0",   # webpki-root-certs (via rustls)
+    "Zlib",
+    "MPL-2.0",
+]
+confidence-threshold = 0.9
+
+[sources]
+# crates.io only — no git or alternative registries slip in unnoticed.
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
`ci junit-process` had a private token resolver that checked only
`--token` then `MERGIFY_TOKEN`. The canonical
`mergify_core::auth::resolve_token` also falls back to `GITHUB_TOKEN`
and `gh auth token` — which is exactly why it exists. junit-process
was the lone command missing those fallbacks, so in a GitHub Actions
job that exports only the standard `GITHUB_TOKEN`, it errored while
every sibling CI command succeeded.

Delete the private `resolve_token` and `resolve_api_url` and call
`auth::resolve_token` / `auth::resolve_api_url`, matching every
sibling (scopes-send, tests-show, …). `auth::resolve_api_url` returns
a parsed `Url`; the upload path takes `api_url.as_str()`, and
`endpoint_url` already trims a trailing slash so the request URL is
unchanged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #1650