### PR TITLE
refactor(core): preserve error sources and print the cause chain

### DIFF
--- a/crates/mergify-ci/src/junit_process/junit.rs
+++ b/crates/mergify-ci/src/junit_process/junit.rs
@@ -165,7 +165,9 @@ impl std::error::Error for InvalidJunitXml {}
 
 impl From<InvalidJunitXml> for CliError {
     fn from(err: InvalidJunitXml) -> Self {
-        Self::Generic(err.to_string())
+        // Preserve the typed error as a transparent source instead of
+        // flattening it to a string (same Display, stays downcastable).
+        Self::Source(Box::new(err))
     }
 }
 

--- a/crates/mergify-ci/src/junit_process/quarantine.rs
+++ b/crates/mergify-ci/src/junit_process/quarantine.rs
@@ -182,7 +182,9 @@ pub async fn check_failing(
 /// callers can `?` it.
 impl From<QuarantineFailed> for CliError {
     fn from(err: QuarantineFailed) -> Self {
-        Self::Generic(err.message)
+        // Preserve the typed error as a transparent source instead of
+        // flattening it (same Display, stays downcastable).
+        Self::Source(Box::new(err))
     }
 }
 

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -2504,6 +2504,13 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
         Err(err) => {
             let code = err.exit_code();
             eprintln!("mergify: {err}");
+            // Print any preserved cause chain (CliError::wrap /
+            // #[source]) so the underlying reason isn't lost.
+            let mut source = std::error::Error::source(&err);
+            while let Some(cause) = source {
+                eprintln!("  caused by: {cause}");
+                source = cause.source();
+            }
             ExitCode::from(code.as_u8())
         }
     }

--- a/crates/mergify-core/src/error.rs
+++ b/crates/mergify-core/src/error.rs
@@ -2,12 +2,22 @@
 //!
 //! Commands produce typed errors that map deterministically to an
 //! [`ExitCode`]. The binary's `main()` converts a `CliError` into
-//! the appropriate `ExitCode` and writes a human-readable message
-//! to stderr before exiting.
+//! the appropriate `ExitCode`, writes a human-readable message to
+//! stderr, and walks the [`std::error::Error::source`] chain so any
+//! preserved cause prints as a `caused by:` line before exiting.
 //!
 //! This enum grows as new error sources are added — add a variant
 //! per error category, never a generic `String` catch-all for new
 //! kinds of failure that have their own exit code.
+//!
+//! Prefer preserving a cause over flattening it into a string:
+//! - a self-describing typed error → [`CliError::Source`] (or `?` it
+//!   through the generated `From`), which keeps it transparently;
+//! - "doing X failed because of Y" → [`CliError::wrap`], which shows
+//!   the context as the headline and Y as a `caused by:` line.
+//!
+//! Reach for `CliError::Generic(e.to_string())` only when there is
+//! genuinely no typed cause worth keeping.
 
 use std::io;
 
@@ -51,13 +61,45 @@ pub enum CliError {
     #[error("{0}")]
     Generic(String),
 
-    /// `std::io` error surfaced verbatim. Maps to
+    /// `std::io` error surfaced verbatim. Its `Display` is the whole
+    /// message, so it is intentionally not exposed as a chainable
+    /// source (that would print the same text twice). Maps to
     /// [`ExitCode::GenericError`].
     #[error("{0}")]
-    Io(#[from] io::Error),
+    Io(io::Error),
+
+    /// A typed lower-level error preserved verbatim and transparently
+    /// (same `Display`, same source chain), so it survives as a
+    /// downcastable cause instead of being flattened to a string.
+    /// Maps to [`ExitCode::GenericError`].
+    #[error(transparent)]
+    Source(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// A contextual headline plus a preserved underlying cause. The
+    /// `context` is the message; `source` prints as a `caused by:`
+    /// line. Build with [`CliError::wrap`]. Maps to
+    /// [`ExitCode::GenericError`].
+    #[error("{context}")]
+    Wrapped {
+        context: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
 }
 
 impl CliError {
+    /// Wrap a lower-level error with a contextual message, keeping
+    /// the original as a `caused by:` source for the printed chain.
+    pub fn wrap(
+        context: impl Into<String>,
+        source: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    ) -> Self {
+        Self::Wrapped {
+            context: context.into(),
+            source: source.into(),
+        }
+    }
+
     /// The exit code the binary should return for this error.
     #[must_use]
     pub const fn exit_code(&self) -> ExitCode {
@@ -68,8 +110,16 @@ impl CliError {
             Self::Conflict(_) => ExitCode::Conflict,
             Self::GitHubApi(_) => ExitCode::GitHubApiError,
             Self::MergifyApi(_) => ExitCode::MergifyApiError,
-            Self::Generic(_) | Self::Io(_) => ExitCode::GenericError,
+            Self::Generic(_) | Self::Io(_) | Self::Source(_) | Self::Wrapped { .. } => {
+                ExitCode::GenericError
+            }
         }
+    }
+}
+
+impl From<io::Error> for CliError {
+    fn from(err: io::Error) -> Self {
+        Self::Io(err)
     }
 }
 
@@ -109,5 +159,37 @@ mod tests {
         );
         let io_err = io::Error::other("boom");
         assert_eq!(CliError::from(io_err).exit_code(), ExitCode::GenericError);
+        let boxed: Box<dyn std::error::Error + Send + Sync> = "boom".into();
+        assert_eq!(CliError::from(boxed).exit_code(), ExitCode::GenericError);
+        assert_eq!(
+            CliError::wrap("x", io::Error::other("y")).exit_code(),
+            ExitCode::GenericError,
+        );
+    }
+
+    #[test]
+    fn io_display_is_not_also_a_source() {
+        // `Io`'s Display is the whole message; exposing it as a
+        // source too would double-print it in the `caused by:` chain.
+        let err = CliError::from(io::Error::other("disk gone"));
+        assert_eq!(err.to_string(), "disk gone");
+        assert!(std::error::Error::source(&err).is_none());
+    }
+
+    #[test]
+    fn wrapped_keeps_context_as_headline_and_cause_as_source() {
+        let err = CliError::wrap("write config", io::Error::other("disk gone"));
+        assert_eq!(err.to_string(), "write config");
+        let cause = std::error::Error::source(&err).expect("cause preserved");
+        assert_eq!(cause.to_string(), "disk gone");
+    }
+
+    #[test]
+    fn source_is_transparent_for_a_self_describing_leaf() {
+        // A transparent `Source` shows the inner Display and delegates
+        // the chain to the inner error (a leaf has no further cause).
+        let err: CliError = CliError::Source(Box::new(io::Error::other("boom")));
+        assert_eq!(err.to_string(), "boom");
+        assert!(std::error::Error::source(&err).is_none());
     }
 }


### PR DESCRIPTION
Every non-Io `CliError` variant was `Variant(String)`, so a wrapped
cause could only survive by being flattened into the message with
`format!("...: {e}")` — `source()` was always `None` and a typed
lower-level error (e.g. `InvalidJunitXml`, `QuarantineFailed`) was
collapsed via `.to_string()`, losing its type.

Give `CliError` two ways to keep a cause:

- `Source(#[from] Box<dyn Error + Send + Sync>)` — transparent: same
  Display, preserves the typed error as a downcastable, chainable
  source. `From<InvalidJunitXml>` / `From<QuarantineFailed>` now use
  it instead of `.to_string()` (output unchanged — both are
  self-describing leaves).
- `Wrapped { context, #[source] source }` via `CliError::wrap(ctx, e)`
  — a context headline plus a preserved cause, for "doing X failed
  because of Y".

`main()` now walks `source()` and prints each cause as a
`caused by:` line. `Io` drops its `#[from]` (kept as a manual `From`)
so its full-message Display isn't also exposed as a source and
double-printed; it stays a self-contained leaf.

This is the idiomatic foundation; commands adopt `wrap()` for their
network/IO failures in later commits.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>