### PR TITLE
fix(self-update): exit with the GitHub-API code and retry transients

### DIFF
--- a/crates/mergify-ci/src/junit_process/junit.rs
+++ b/crates/mergify-ci/src/junit_process/junit.rs
@@ -165,7 +165,9 @@ impl std::error::Error for InvalidJunitXml {}
 
 impl From<InvalidJunitXml> for CliError {
     fn from(err: InvalidJunitXml) -> Self {
-        Self::Generic(err.to_string())
+        // Preserve the typed error as a transparent source instead of
+        // flattening it to a string (same Display, stays downcastable).
+        Self::Source(Box::new(err))
     }
 }
 

--- a/crates/mergify-ci/src/junit_process/quarantine.rs
+++ b/crates/mergify-ci/src/junit_process/quarantine.rs
@@ -182,7 +182,9 @@ pub async fn check_failing(
 /// callers can `?` it.
 impl From<QuarantineFailed> for CliError {
     fn from(err: QuarantineFailed) -> Self {
-        Self::Generic(err.message)
+        // Preserve the typed error as a transparent source instead of
+        // flattening it (same Display, stays downcastable).
+        Self::Source(Box::new(err))
     }
 }
 

--- a/crates/mergify-cli/Cargo.toml
+++ b/crates/mergify-cli/Cargo.toml
@@ -25,11 +25,12 @@ mergify-stack = { path = "../mergify-stack" }
 # `mergify self-update`: hits the GitHub Releases API for the
 # latest tag, downloads the asset matching the current target,
 # verifies it against `SHA256SUMS` (same format the curl|sh
-# installer trusts), and atomically swaps the running binary. We
-# go through `reqwest` directly here instead of
-# `mergify-core::HttpClient` because the latter wraps GitHub-API
-# auth + retry, neither of which apply to unauthenticated public
-# release downloads. `self_replace` handles the Windows
+# installer trusts), and atomically swaps the running binary. Uses
+# `reqwest` directly rather than `mergify-core::http::Client`, which
+# is path/JSON/auth-oriented; self-update does unauthenticated
+# *binary* downloads across two hosts (api.github.com + asset CDN),
+# does its own retry, and maps GitHub failures to the GitHub-API
+# exit code. `self_replace` handles the Windows
 # can't-rename-over-a-running-exe dance cross-platform.
 reqwest = { workspace = true }
 self-replace = { workspace = true }

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -2504,6 +2504,13 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
         Err(err) => {
             let code = err.exit_code();
             eprintln!("mergify: {err}");
+            // Print any preserved cause chain (CliError::wrap /
+            // #[source]) so the underlying reason isn't lost.
+            let mut source = std::error::Error::source(&err);
+            while let Some(cause) = source {
+                eprintln!("  caused by: {cause}");
+                source = cause.source();
+            }
             ExitCode::from(code.as_u8())
         }
     }

--- a/crates/mergify-cli/src/self_update.rs
+++ b/crates/mergify-cli/src/self_update.rs
@@ -119,7 +119,8 @@ pub async fn run(opts: &Options) -> Result<(), CliError> {
     let current = crate::VERSION;
     let target = current_target()?;
     let client = http_client()?;
-    let release = fetch_latest_release(&client, &latest_release_url()).await?;
+    let url = latest_release_url();
+    let release = with_retry(3, || fetch_latest_release(&client, &url)).await?;
     let latest = release.tag_name.as_str();
 
     if opts.check_only {
@@ -143,9 +144,12 @@ pub async fn run(opts: &Options) -> Result<(), CliError> {
         .assets
         .iter()
         .find(|a| a.name == "SHA256SUMS")
-        .ok_or_else(|| CliError::Generic("latest release has no SHA256SUMS asset".to_string()))?;
-    let archive = download(&client, &asset.browser_download_url).await?;
-    let sums = download_text(&client, &sums_asset.browser_download_url).await?;
+        .ok_or_else(|| CliError::GitHubApi("latest release has no SHA256SUMS asset".to_string()))?;
+    let archive = with_retry(3, || download(&client, &asset.browser_download_url)).await?;
+    let sums = with_retry(3, || {
+        download_text(&client, &sums_asset.browser_download_url)
+    })
+    .await?;
     // Verify against the asset's *actual* published name, so the
     // `SHA256SUMS` lookup matches whatever scheme the release used.
     verify_checksum(&archive, &asset.name, &sums)?;
@@ -220,12 +224,12 @@ async fn fetch_latest_release(
         .get(url)
         .send()
         .await
-        .map_err(|e| CliError::Generic(format!("GET {url}: {e}")))?
+        .map_err(|e| CliError::GitHubApi(format!("GET {url}: {e}")))?
         .error_for_status()
-        .map_err(|e| CliError::Generic(format!("GitHub API: {e}")))?
+        .map_err(|e| CliError::GitHubApi(format!("GitHub API: {e}")))?
         .json::<LatestRelease>()
         .await
-        .map_err(|e| CliError::Generic(format!("parse latest-release: {e}")))
+        .map_err(|e| CliError::GitHubApi(format!("parse latest-release: {e}")))
 }
 
 async fn download(client: &reqwest::Client, url: &str) -> Result<Vec<u8>, CliError> {
@@ -233,19 +237,48 @@ async fn download(client: &reqwest::Client, url: &str) -> Result<Vec<u8>, CliErr
         .get(url)
         .send()
         .await
-        .map_err(|e| CliError::Generic(format!("GET {url}: {e}")))?
+        .map_err(|e| CliError::GitHubApi(format!("GET {url}: {e}")))?
         .error_for_status()
-        .map_err(|e| CliError::Generic(format!("GET {url}: {e}")))?
+        .map_err(|e| CliError::GitHubApi(format!("GET {url}: {e}")))?
         .bytes()
         .await
-        .map_err(|e| CliError::Generic(format!("read body {url}: {e}")))?
+        .map_err(|e| CliError::GitHubApi(format!("read body {url}: {e}")))?
         .to_vec())
 }
 
 async fn download_text(client: &reqwest::Client, url: &str) -> Result<String, CliError> {
     let bytes = download(client, url).await?;
     String::from_utf8(bytes)
-        .map_err(|e| CliError::Generic(format!("non-UTF8 body from {url}: {e}")))
+        .map_err(|e| CliError::GitHubApi(format!("non-UTF8 body from {url}: {e}")))
+}
+
+/// Retry a GitHub network read a few times on transient failures
+/// (connect/timeout). Release metadata and asset downloads are
+/// one-shot and idempotent, so a blip shouldn't fail the update.
+/// Only [`CliError::GitHubApi`] is retried — that's exactly what the
+/// network reads (`fetch_latest_release` / `download`) emit, so
+/// integrity errors (checksum/missing asset) that are raised outside
+/// the retried closure never get re-run.
+async fn with_retry<T, F, Fut>(attempts: u32, mut op: F) -> Result<T, CliError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, CliError>>,
+{
+    // 500ms, then 1s before the final try. Indexed by completed
+    // attempt; the last attempt's result is returned without sleeping.
+    let backoff = [Duration::from_millis(500), Duration::from_secs(1)];
+    for attempt in 1..attempts {
+        match op().await {
+            Ok(v) => return Ok(v),
+            Err(e @ CliError::GitHubApi(_)) => {
+                let idx = (attempt as usize - 1).min(backoff.len() - 1);
+                eprintln!("self-update: transient GitHub error ({e}); retrying...");
+                tokio::time::sleep(backoff[idx]).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    op().await
 }
 
 /// Render digest bytes as a lowercase hex string. `sha2` 0.11 returns
@@ -285,10 +318,10 @@ fn verify_checksum(archive: &[u8], asset_name: &str, sums: &str) -> Result<(), C
         }
     }
     let expected = expected.ok_or_else(|| {
-        CliError::Generic(format!("no checksum entry for {asset_name} in SHA256SUMS"))
+        CliError::GitHubApi(format!("no checksum entry for {asset_name} in SHA256SUMS"))
     })?;
     if expected.len() != 64 || !expected.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err(CliError::Generic(format!(
+        return Err(CliError::GitHubApi(format!(
             "malformed checksum entry for {asset_name}"
         )));
     }
@@ -298,7 +331,7 @@ fn verify_checksum(archive: &[u8], asset_name: &str, sums: &str) -> Result<(), C
     if actual.eq_ignore_ascii_case(expected) {
         Ok(())
     } else {
-        Err(CliError::Generic(format!(
+        Err(CliError::GitHubApi(format!(
             "checksum mismatch for {asset_name}: expected {expected}, got {actual}"
         )))
     }

--- a/crates/mergify-core/src/error.rs
+++ b/crates/mergify-core/src/error.rs
@@ -2,12 +2,22 @@
 //!
 //! Commands produce typed errors that map deterministically to an
 //! [`ExitCode`]. The binary's `main()` converts a `CliError` into
-//! the appropriate `ExitCode` and writes a human-readable message
-//! to stderr before exiting.
+//! the appropriate `ExitCode`, writes a human-readable message to
+//! stderr, and walks the [`std::error::Error::source`] chain so any
+//! preserved cause prints as a `caused by:` line before exiting.
 //!
 //! This enum grows as new error sources are added — add a variant
 //! per error category, never a generic `String` catch-all for new
 //! kinds of failure that have their own exit code.
+//!
+//! Prefer preserving a cause over flattening it into a string:
+//! - a self-describing typed error → [`CliError::Source`] (or `?` it
+//!   through the generated `From`), which keeps it transparently;
+//! - "doing X failed because of Y" → [`CliError::wrap`], which shows
+//!   the context as the headline and Y as a `caused by:` line.
+//!
+//! Reach for `CliError::Generic(e.to_string())` only when there is
+//! genuinely no typed cause worth keeping.
 
 use std::io;
 
@@ -51,13 +61,45 @@ pub enum CliError {
     #[error("{0}")]
     Generic(String),
 
-    /// `std::io` error surfaced verbatim. Maps to
+    /// `std::io` error surfaced verbatim. Its `Display` is the whole
+    /// message, so it is intentionally not exposed as a chainable
+    /// source (that would print the same text twice). Maps to
     /// [`ExitCode::GenericError`].
     #[error("{0}")]
-    Io(#[from] io::Error),
+    Io(io::Error),
+
+    /// A typed lower-level error preserved verbatim and transparently
+    /// (same `Display`, same source chain), so it survives as a
+    /// downcastable cause instead of being flattened to a string.
+    /// Maps to [`ExitCode::GenericError`].
+    #[error(transparent)]
+    Source(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// A contextual headline plus a preserved underlying cause. The
+    /// `context` is the message; `source` prints as a `caused by:`
+    /// line. Build with [`CliError::wrap`]. Maps to
+    /// [`ExitCode::GenericError`].
+    #[error("{context}")]
+    Wrapped {
+        context: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
 }
 
 impl CliError {
+    /// Wrap a lower-level error with a contextual message, keeping
+    /// the original as a `caused by:` source for the printed chain.
+    pub fn wrap(
+        context: impl Into<String>,
+        source: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    ) -> Self {
+        Self::Wrapped {
+            context: context.into(),
+            source: source.into(),
+        }
+    }
+
     /// The exit code the binary should return for this error.
     #[must_use]
     pub const fn exit_code(&self) -> ExitCode {
@@ -68,8 +110,16 @@ impl CliError {
             Self::Conflict(_) => ExitCode::Conflict,
             Self::GitHubApi(_) => ExitCode::GitHubApiError,
             Self::MergifyApi(_) => ExitCode::MergifyApiError,
-            Self::Generic(_) | Self::Io(_) => ExitCode::GenericError,
+            Self::Generic(_) | Self::Io(_) | Self::Source(_) | Self::Wrapped { .. } => {
+                ExitCode::GenericError
+            }
         }
+    }
+}
+
+impl From<io::Error> for CliError {
+    fn from(err: io::Error) -> Self {
+        Self::Io(err)
     }
 }
 
@@ -109,5 +159,37 @@ mod tests {
         );
         let io_err = io::Error::other("boom");
         assert_eq!(CliError::from(io_err).exit_code(), ExitCode::GenericError);
+        let boxed: Box<dyn std::error::Error + Send + Sync> = "boom".into();
+        assert_eq!(CliError::from(boxed).exit_code(), ExitCode::GenericError);
+        assert_eq!(
+            CliError::wrap("x", io::Error::other("y")).exit_code(),
+            ExitCode::GenericError,
+        );
+    }
+
+    #[test]
+    fn io_display_is_not_also_a_source() {
+        // `Io`'s Display is the whole message; exposing it as a
+        // source too would double-print it in the `caused by:` chain.
+        let err = CliError::from(io::Error::other("disk gone"));
+        assert_eq!(err.to_string(), "disk gone");
+        assert!(std::error::Error::source(&err).is_none());
+    }
+
+    #[test]
+    fn wrapped_keeps_context_as_headline_and_cause_as_source() {
+        let err = CliError::wrap("write config", io::Error::other("disk gone"));
+        assert_eq!(err.to_string(), "write config");
+        let cause = std::error::Error::source(&err).expect("cause preserved");
+        assert_eq!(cause.to_string(), "disk gone");
+    }
+
+    #[test]
+    fn source_is_transparent_for_a_self_describing_leaf() {
+        // A transparent `Source` shows the inner Display and delegates
+        // the chain to the inner error (a leaf has no further cause).
+        let err: CliError = CliError::Source(Box::new(io::Error::other("boom")));
+        assert_eq!(err.to_string(), "boom");
+        assert!(std::error::Error::source(&err).is_none());
     }
 }


### PR DESCRIPTION
`mergify self-update` mapped every failure — including GitHub network,
API, and release-integrity errors — to `CliError::Generic` (exit 1),
so a flaky-GitHub update was indistinguishable from a local bug and
wrapping scripts got the wrong exit code.

Classify GitHub failures as `CliError::GitHubApi` (exit 5): the release
metadata fetch, the asset/SHA256SUMS downloads, and the
release-integrity checks (missing/malformed checksum entry, checksum
mismatch). Purely-local failures (locating the binary, temp dirs,
writing the archive, the atomic swap, spawning the extractor) stay
`Generic`/`Io`.

Add a 3-attempt retry with backoff around the network reads
(`fetch_latest_release`, the asset and SHA256SUMS downloads), which are
one-shot and idempotent, so a transient blip no longer fails the
update. Integrity checks run outside the retry so a real mismatch
fails fast.

self-update keeps its own `reqwest` rather than `mergify_core::http`:
that client is path/JSON/auth-oriented, while self-update does
unauthenticated binary downloads across two hosts.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #1653