### PR TITLE
feat(cli): add a global --color flag and fix queue-show glyphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,6 +1218,7 @@ dependencies = [
  "mergify-freeze",
  "mergify-queue",
  "mergify-stack",
+ "mergify-tui",
  "regex",
  "reqwest",
  "self-replace",

--- a/crates/mergify-cli/Cargo.toml
+++ b/crates/mergify-cli/Cargo.toml
@@ -22,6 +22,9 @@ mergify-core = { path = "../mergify-core" }
 mergify-freeze = { path = "../mergify-freeze" }
 mergify-queue = { path = "../mergify-queue" }
 mergify-stack = { path = "../mergify-stack" }
+# Shared TTY/color palette — the binary resolves `--color` once at
+# startup and records it via `mergify_tui::set_color_choice`.
+mergify-tui = { path = "../mergify-tui" }
 # `mergify self-update`: hits the GitHub Releases API for the
 # latest tag, downloads the asset matching the current target,
 # verifies it against `SHA256SUMS` (same format the curl|sh

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -636,6 +636,9 @@ fn detect_dispatch(argv: &[String]) -> Dispatch {
         Ok(parsed) => parsed,
         Err(err) => err.exit(),
     };
+    // Resolve the color preference once, before any command builds a
+    // theme via `Theme::detect`.
+    mergify_tui::set_color_choice(parsed.color.into());
     dispatch_from_parsed(parsed)
 }
 
@@ -2540,8 +2543,33 @@ struct CliRoot {
     #[arg(long, global = true)]
     debug: bool,
 
+    /// When to use color in terminal output.
+    #[arg(long, global = true, value_enum, default_value_t = ColorArg::Auto)]
+    color: ColorArg,
+
     #[command(subcommand)]
     command: Subcommands,
+}
+
+/// `--color` choice. Mirrors [`mergify_tui::ColorChoice`]; kept
+/// separate so the clap derive lives in the binary and `mergify-tui`
+/// stays clap-free.
+#[derive(Clone, Copy, Debug, Default, clap::ValueEnum)]
+enum ColorArg {
+    #[default]
+    Auto,
+    Always,
+    Never,
+}
+
+impl From<ColorArg> for mergify_tui::ColorChoice {
+    fn from(c: ColorArg) -> Self {
+        match c {
+            ColorArg::Auto => Self::Auto,
+            ColorArg::Always => Self::Always,
+            ColorArg::Never => Self::Never,
+        }
+    }
 }
 
 #[derive(Subcommand)]

--- a/crates/mergify-queue/src/show.rs
+++ b/crates/mergify-queue/src/show.rs
@@ -361,17 +361,18 @@ fn print_checks_summary(w: &mut dyn Write, theme: &Theme, checks: &[Check]) -> s
     Ok(())
 }
 
-/// Map a check state string to its [`StyledGlyph`]. Mirrors Python's
-/// `CHECK_STATE_STYLES`; unknown states fall back to a dim `?` so
-/// the renderer never crashes on a new API code.
+/// Map a check state string to its [`StyledGlyph`], using the
+/// single-width terminal vocabulary (✓ ✗ ● ○ —); unknown states fall
+/// back to a dim `—` so the renderer never crashes on a new API code.
 fn check_state_glyph(theme: &Theme, state: &str) -> StyledGlyph {
     match state {
         "success" => StyledGlyph::new("✓", theme.fg(AnsiColor::Green)),
-        "pending" => StyledGlyph::new("◌", theme.fg(AnsiColor::Yellow)),
-        "failure" | "error" | "action_required" => StyledGlyph::new("✗", theme.fg(AnsiColor::Red)),
-        "timed_out" => StyledGlyph::new("⏰", theme.fg(AnsiColor::Red)),
+        "pending" => StyledGlyph::new("●", theme.fg(AnsiColor::Yellow)),
+        "failure" | "error" | "action_required" | "timed_out" => {
+            StyledGlyph::new("✗", theme.fg(AnsiColor::Red))
+        }
         "cancelled" | "neutral" | "skipped" | "stale" => StyledGlyph::new("○", theme.dim),
-        _ => StyledGlyph::new("?", theme.dim),
+        _ => StyledGlyph::new("—", theme.dim),
     }
 }
 

--- a/crates/mergify-tui/src/lib.rs
+++ b/crates/mergify-tui/src/lib.rs
@@ -37,5 +37,5 @@ pub mod time;
 pub mod tree;
 
 pub use glyph::StyledGlyph;
-pub use theme::Theme;
+pub use theme::{ColorChoice, Theme, set_color_choice};
 pub use time::relative_time;

--- a/crates/mergify-tui/src/theme.rs
+++ b/crates/mergify-tui/src/theme.rs
@@ -10,9 +10,29 @@
 //! is the empty string. Code reads the same in both modes.
 
 use std::io::IsTerminal;
+use std::sync::OnceLock;
 
 use anstyle::AnsiColor;
 use anstyle::Style;
+
+/// The user's `--color` preference. `Auto` defers to env vars and TTY
+/// detection; `Always`/`Never` override both.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ColorChoice {
+    #[default]
+    Auto,
+    Always,
+    Never,
+}
+
+static COLOR_CHOICE: OnceLock<ColorChoice> = OnceLock::new();
+
+/// Record the process-wide color preference (from `--color`), once,
+/// at startup before any [`Theme::detect`]. Subsequent calls are
+/// ignored, so a stray second call can't flip colors mid-run.
+pub fn set_color_choice(choice: ColorChoice) {
+    let _ = COLOR_CHOICE.set(choice);
+}
 
 /// Pre-built styles + reset escape, matched to the renderers in
 /// the ported commands. Each field is either a real `Style` (when
@@ -52,17 +72,13 @@ impl Theme {
     /// 1. `cfg!(test)` ⇒ disabled. `cargo test` may inherit a TTY
     ///    parent stdout, but tests assert on in-memory buffers and
     ///    shouldn't take a dependency on the developer's terminal.
-    /// 2. `stdout` is not a terminal ⇒ disabled (piped output stays
-    ///    pristine for downstream tools).
-    /// 3. `NO_COLOR` env var is set (any value) ⇒ disabled. The
-    ///    de-facto standard, <https://no-color.org>.
-    /// 4. Otherwise enabled.
+    /// 2. `--color always`/`never` (via [`set_color_choice`]) wins.
+    /// 3. Otherwise (`auto`): `NO_COLOR` forces off; `FORCE_COLOR` /
+    ///    `CLICOLOR_FORCE` force on (e.g. through a pager or CI
+    ///    viewer); else `stdout` must be a terminal.
     #[must_use]
     pub fn detect() -> Self {
-        let enabled = !cfg!(test)
-            && std::io::stdout().is_terminal()
-            && std::env::var_os("NO_COLOR").is_none();
-        Self::new(enabled)
+        Self::new(colors_enabled())
     }
 
     /// Construct with explicit `enabled`. Tests use this to
@@ -98,9 +114,59 @@ impl Theme {
     }
 }
 
+/// Pure color decision, factored out of [`colors_enabled`] so the
+/// precedence is unit-testable without touching global state, env, or
+/// the real TTY.
+fn resolve_enabled(choice: ColorChoice, no_color: bool, force_color: bool, is_tty: bool) -> bool {
+    match choice {
+        ColorChoice::Always => true,
+        ColorChoice::Never => false,
+        ColorChoice::Auto => {
+            if no_color {
+                false
+            } else if force_color {
+                true
+            } else {
+                is_tty
+            }
+        }
+    }
+}
+
+fn colors_enabled() -> bool {
+    // Tests assert on in-memory buffers; never depend on the dev's TTY.
+    if cfg!(test) {
+        return false;
+    }
+    let choice = COLOR_CHOICE.get().copied().unwrap_or_default();
+    let no_color = std::env::var_os("NO_COLOR").is_some();
+    let force_color =
+        std::env::var_os("FORCE_COLOR").is_some() || std::env::var_os("CLICOLOR_FORCE").is_some();
+    resolve_enabled(
+        choice,
+        no_color,
+        force_color,
+        std::io::stdout().is_terminal(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn color_precedence() {
+        // Explicit choice overrides everything.
+        assert!(resolve_enabled(ColorChoice::Always, true, false, false));
+        assert!(!resolve_enabled(ColorChoice::Never, false, true, true));
+        // Auto: NO_COLOR wins over FORCE_COLOR and TTY.
+        assert!(!resolve_enabled(ColorChoice::Auto, true, true, true));
+        // Auto: FORCE_COLOR turns it on without a TTY.
+        assert!(resolve_enabled(ColorChoice::Auto, false, true, false));
+        // Auto: otherwise follow the TTY.
+        assert!(resolve_enabled(ColorChoice::Auto, false, false, true));
+        assert!(!resolve_enabled(ColorChoice::Auto, false, false, false));
+    }
 
     #[test]
     fn disabled_theme_emits_no_escape_sequences() {


### PR DESCRIPTION
Color was decided solely by `NO_COLOR` + `stdout().is_terminal()`, so
there was no way to force color through a pager or CI log viewer, and
no `--color` switch.

Add a global `--color <auto|always|never>` (accepted on every
subcommand), resolved once at startup into a process-wide
`mergify_tui::ColorChoice`. `Theme::detect` now honors, in order:
explicit `always`/`never`; then `NO_COLOR` (off); then `FORCE_COLOR` /
`CLICOLOR_FORCE` (on); then the TTY check. The decision is factored
into a pure, unit-tested `resolve_enabled`.

Also fix `queue show`'s check-state glyphs, which used an `⏰`
double-width emoji (the exact column-misalignment failure the glyph
vocabulary forbids), plus an out-of-set `◌` and `?`: map them onto the
mandated single-width set (`●` pending, `✗` timed-out, `—` unknown).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>