### PR TITLE
feat(cli): add a -v/-vv verbosity ladder backed by tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,6 +1175,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1238,8 @@ dependencies = [
  "temp-env",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "url",
  "wiremock",
 ]
@@ -1260,6 +1271,7 @@ dependencies = [
  "temp-env",
  "thiserror",
  "tokio",
+ "tracing",
  "url",
  "wiremock",
 ]
@@ -1354,6 +1366,15 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -2099,6 +2120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,6 +2281,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2376,7 +2415,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2386,6 +2437,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ thiserror = "2.0"
 # in the dev-dependency entries that need it, so the shipped binary's
 # single current-thread runtime never pulls in the MT scheduler.
 tokio = { version = "1", default-features = false, features = ["macros", "rt", "time"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "ansi"] }
 unicode-width = "0.2"
 url = "2"
 temp-env = "0.3"

--- a/crates/mergify-cli/Cargo.toml
+++ b/crates/mergify-cli/Cargo.toml
@@ -45,6 +45,8 @@ tempfile = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -9,6 +9,7 @@
 //! distance.
 
 use std::env;
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -639,7 +640,36 @@ fn detect_dispatch(argv: &[String]) -> Dispatch {
     // Resolve the color preference once, before any command builds a
     // theme via `Theme::detect`.
     mergify_tui::set_color_choice(parsed.color.into());
+    init_tracing(parsed.verbose, parsed.debug);
     dispatch_from_parsed(parsed)
+}
+
+/// Install the tracing subscriber, writing structured logs to stderr
+/// so stdout stays pipeable. The level comes from `-v` (info / debug /
+/// trace), with `--debug` flooring at debug; an explicit `RUST_LOG`
+/// overrides both. Only our own crates are raised — third-party deps
+/// stay at `warn` so `-vv` doesn't drown in hyper/reqwest noise.
+fn init_tracing(verbose: u8, debug: bool) {
+    use tracing_subscriber::EnvFilter;
+
+    let level = match verbose {
+        0 if debug => "debug",
+        0 => "warn",
+        1 => "info",
+        2 => "debug",
+        _ => "trace",
+    };
+    let directives = format!(
+        "warn,mergify_cli={level},mergify_core={level},mergify_stack={level},\
+         mergify_ci={level},mergify_queue={level},mergify_freeze={level},\
+         mergify_config={level},mergify_tui={level}"
+    );
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(directives));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .with_ansi(std::io::stderr().is_terminal())
+        .try_init();
 }
 
 /// Build the run options for `quarantines add`.
@@ -716,7 +746,12 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
             }
             StackSubcommand::Sync(cli) => Dispatch::Native(NativeCommand::StackSync(cli.into())),
             StackSubcommand::Push(cli) => Dispatch::Native(NativeCommand::StackPush(cli.into())),
-            StackSubcommand::List(cli) => Dispatch::Native(NativeCommand::StackList(cli.into())),
+            StackSubcommand::List(cli) => {
+                Dispatch::Native(NativeCommand::StackList(StackListOpts {
+                    verbose: parsed.verbose > 0,
+                    ..cli.into()
+                }))
+            }
             StackSubcommand::Open(cli) => Dispatch::Native(NativeCommand::StackOpen(cli.into())),
             StackSubcommand::Hooks(cli) => Dispatch::Native(NativeCommand::StackHooks(cli.into())),
             StackSubcommand::Setup(cli) => Dispatch::Native(NativeCommand::StackSetup(cli.into())),
@@ -967,18 +1002,13 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
             repository,
             token,
             api_url,
-            command:
-                QueueSubcommand::Show(ShowCliArgs {
-                    pr_number,
-                    verbose,
-                    json,
-                }),
+            command: QueueSubcommand::Show(ShowCliArgs { pr_number, json }),
         }) => Dispatch::Native(NativeCommand::QueueShow(QueueShowOpts {
             repository,
             token,
             api_url,
             pr_number,
-            verbose,
+            verbose: parsed.verbose > 0,
             output_json: json,
         })),
         Subcommands::Freeze(FreezeArgs {
@@ -2534,12 +2564,13 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
 #[derive(Parser)]
 #[command(name = "mergify", disable_help_subcommand = true, version = VERSION)]
 struct CliRoot {
-    /// Enable verbose debug logging.
-    ///
-    /// Print extra internal diagnostics, useful when reporting a bug
-    /// or investigating unexpected behavior. Accepted on every
-    /// command.
-    // No command path consults it yet.
+    /// Increase log verbosity: -v info, -vv debug, -vvv trace. Logs
+    /// go to stderr so stdout stays clean for piping. `RUST_LOG`
+    /// overrides this.
+    #[arg(short, long, global = true, action = clap::ArgAction::Count)]
+    verbose: u8,
+
+    /// Shorthand for at least debug-level logging (like -vv).
     #[arg(long, global = true)]
     debug: bool,
 
@@ -3241,10 +3272,6 @@ struct StackListCli {
     /// Emit machine-readable JSON.
     #[arg(long, action = clap::ArgAction::SetTrue)]
     json: bool,
-
-    /// Show per-check / per-reviewer detail.
-    #[arg(short = 'v', long, action = clap::ArgAction::SetTrue)]
-    verbose: bool,
 }
 
 impl From<StackListCli> for StackListOpts {
@@ -3256,7 +3283,8 @@ impl From<StackListCli> for StackListOpts {
             trunk: cli.trunk,
             token: cli.token,
             json: cli.json,
-            verbose: cli.verbose,
+            // Driven by the global `-v`/`--verbose` flag, applied in dispatch.
+            verbose: false,
         }
     }
 }
@@ -4085,11 +4113,6 @@ struct ShowCliArgs {
     /// Pull request number to inspect.
     #[arg(value_name = "PR_NUMBER")]
     pr_number: u64,
-
-    /// Show the full checks table and the conditions tree instead
-    /// of compact summaries.
-    #[arg(long, short = 'v', default_value_t = false)]
-    verbose: bool,
 
     /// Emit the raw API response as a single JSON document.
     #[arg(long, default_value_t = false)]

--- a/crates/mergify-core/Cargo.toml
+++ b/crates/mergify-core/Cargo.toml
@@ -15,6 +15,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/crates/mergify-core/src/http.rs
+++ b/crates/mergify-core/src/http.rs
@@ -304,6 +304,12 @@ impl Client {
                 None => cloned,
             };
 
+            tracing::debug!(
+                service = self.service_name(),
+                attempt = attempt + 1,
+                max_attempts = self.retry.max_attempts,
+                "sending HTTP request"
+            );
             match req.send().await {
                 Ok(resp) => {
                     let status = resp.status();
@@ -336,6 +342,12 @@ impl Client {
                             Some(wait) => wait,
                             None => backoff,
                         };
+                        tracing::warn!(
+                            service = self.service_name(),
+                            %status,
+                            ?delay,
+                            "retrying after error response"
+                        );
                         tokio::time::sleep(delay).await;
                         backoff *= 2;
                         continue;
@@ -343,6 +355,12 @@ impl Client {
                     return Err(self.api_error(last_message));
                 }
                 Err(e) if is_transient(&e) && attempt + 1 < self.retry.max_attempts => {
+                    tracing::debug!(
+                        service = self.service_name(),
+                        error = %e,
+                        ?backoff,
+                        "retrying after transient network error"
+                    );
                     last_message = format!("network error: {e}");
                     tokio::time::sleep(backoff).await;
                     backoff *= 2;


### PR DESCRIPTION
`--debug` was a documented no-op and there was no structured logging,
so when a network-heavy command hung or retried there was no way to
see what it was doing.

Add a global `-v/--verbose` (repeatable: -v info, -vv debug, -vvv
trace) and initialise a `tracing_subscriber` that writes to stderr —
stdout stays clean for piping. `--debug` is repurposed as a shorthand
that floors the level at debug. `RUST_LOG` overrides the flag-derived
filter; only our own crates are raised so -vv doesn't drown in
hyper/reqwest noise.

`stack list` and `queue show` previously declared their own `--verbose`
detail flag; they now read the global one, so `-v` carries a single
meaning everywhere and clap no longer sees a colliding arg id.

Instrument the HTTP retry driver (mergify-core::http) with debug/warn
events for each request attempt and every retry decision (5xx,
rate-limit, transient send error) including the backoff/wait — never
logging the bearer token. `mergify <cmd> -vv` now shows the request
attempts and retry timing on stderr.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #1656