### PR TITLE
feat(cli): generate shell completions and a man page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +300,16 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "cmake"
@@ -1221,6 +1240,8 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "clap",
+ "clap_complete",
+ "clap_mangen",
  "mergify-ci",
  "mergify-config",
  "mergify-core",
@@ -1872,6 +1893,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "roff"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ authors = ["Mergify Team <hello@mergify.com>"]
 anstyle = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
 clap = { version = "4.5", features = ["derive", "env"] }
+clap_complete = "4.5"
+clap_mangen = "0.2"
 flate2 = "1"
 getrandom = "0.4"
 glob = "0.3"

--- a/crates/mergify-cli/Cargo.toml
+++ b/crates/mergify-cli/Cargo.toml
@@ -16,6 +16,8 @@ path = "src/main.rs"
 [dependencies]
 chrono = { workspace = true }
 clap = { workspace = true }
+clap_complete = { workspace = true }
+clap_mangen = { workspace = true }
 mergify-ci = { path = "../mergify-ci" }
 mergify-config = { path = "../mergify-config" }
 mergify-core = { path = "../mergify-core" }

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -13,6 +13,7 @@ use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+use clap::CommandFactory;
 use clap::Parser;
 use clap::Subcommand;
 use mergify_ci::git_refs::Format as GitRefsFormat;
@@ -147,6 +148,8 @@ const NATIVE_COMMANDS: &[(&str, &str)] = &[
     // Emits the machine-readable CLI schema the docs site renders
     // into the command reference. Hidden; not a stable surface.
     ("_internal", "dump-cli-schema"),
+    // Renders the roff man page to stdout, for packaging. Hidden.
+    ("_internal", "man"),
 ];
 
 /// Native commands the Rust binary handles without delegating to
@@ -264,6 +267,12 @@ enum NativeCommand {
     /// to JSON for the docs site. Pure introspection; no async, no I/O
     /// beyond stdout.
     InternalDumpCliSchema,
+    /// `mergify completions <shell>` — print a shell completion script
+    /// to stdout. Pure introspection.
+    Completions(clap_complete::Shell),
+    /// `_internal man` — render the roff man page to stdout for
+    /// packaging. Pure introspection.
+    InternalManPage,
     /// `mergify self-update [--force] [--check]` — replace the
     /// running binary with the latest release.
     SelfUpdate(self_update::Options),
@@ -757,6 +766,7 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
             StackSubcommand::Setup(cli) => Dispatch::Native(NativeCommand::StackSetup(cli.into())),
         },
         Subcommands::SelfUpdate(cli) => Dispatch::Native(NativeCommand::SelfUpdate(cli.into())),
+        Subcommands::Completions(cli) => Dispatch::Native(NativeCommand::Completions(cli.shell)),
         Subcommands::Internal(InternalArgs {
             command:
                 InternalSubcommand::StackLocalCommits(InternalStackLocalCommitsArgs {
@@ -814,6 +824,9 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
         Subcommands::Internal(InternalArgs {
             command: InternalSubcommand::DumpCliSchema,
         }) => Dispatch::Native(NativeCommand::InternalDumpCliSchema),
+        Subcommands::Internal(InternalArgs {
+            command: InternalSubcommand::Man,
+        }) => Dispatch::Native(NativeCommand::InternalManPage),
         Subcommands::Ci(CiArgs {
             command:
                 CiSubcommand::Scopes(ScopesCliArgs {
@@ -1379,6 +1392,25 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
     if matches!(cmd, NativeCommand::InternalDumpCliSchema) {
         return cli_schema::run();
     }
+    // Completions and the man page are pure introspection over the
+    // clap tree — emit to stdout and exit before tokio spins up.
+    match cmd {
+        NativeCommand::Completions(shell) => {
+            let mut command = CliRoot::command();
+            clap_complete::generate(shell, &mut command, "mergify", &mut std::io::stdout());
+            return ExitCode::SUCCESS;
+        }
+        NativeCommand::InternalManPage => {
+            return match clap_mangen::Man::new(CliRoot::command()).render(&mut std::io::stdout()) {
+                Ok(()) => ExitCode::SUCCESS,
+                Err(e) => {
+                    eprintln!("mergify: render man page: {e}");
+                    ExitCode::FAILURE
+                }
+            };
+        }
+        _ => {}
+    }
 
     let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -1407,8 +1439,10 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
     let result: Result<mergify_core::ExitCode, mergify_core::CliError> = rt.block_on(async {
         match cmd {
             // Handled above, before the runtime was built.
-            NativeCommand::InternalDumpCliSchema => {
-                unreachable!("dump-cli-schema is handled before the runtime starts")
+            NativeCommand::InternalDumpCliSchema
+            | NativeCommand::Completions(_)
+            | NativeCommand::InternalManPage => {
+                unreachable!("introspection commands are handled before the runtime starts")
             }
             NativeCommand::ConfigValidate { config_file } => {
                 mergify_config::validate::run(config_file.as_deref(), &mut output)
@@ -2650,6 +2684,8 @@ enum Subcommands {
     /// `curl | sh` installer.
     #[command(name = "self-update")]
     SelfUpdate(SelfUpdateCli),
+    /// Print a shell completion script (e.g. `mergify completions zsh`).
+    Completions(CompletionsCli),
     /// Internal helpers the Python side of the wheel calls during
     /// the Python→Rust migration. Hidden from `--help` because it
     /// is not part of the user-facing CLI; the wire format is not
@@ -2811,6 +2847,10 @@ enum InternalSubcommand {
     /// code, never hand-maintained. Not a stable user-facing surface.
     #[command(name = "dump-cli-schema")]
     DumpCliSchema,
+    /// Render the roff man page to stdout, for packaging to install
+    /// into `man/`. Not a stable user-facing surface.
+    #[command(name = "man")]
+    Man,
 }
 
 #[derive(clap::Args)]
@@ -3399,6 +3439,13 @@ impl From<SelfUpdateCli> for self_update::Options {
             check_only: cli.check,
         }
     }
+}
+
+#[derive(clap::Args)]
+struct CompletionsCli {
+    /// Shell to generate a completion script for.
+    #[arg(value_enum)]
+    shell: clap_complete::Shell,
 }
 
 impl TryFrom<StackSquashCli> for StackSquashOpts {
@@ -4293,7 +4340,8 @@ mod tests {
                 "queue",
                 "freeze",
                 "stack",
-                "self-update"
+                "self-update",
+                "completions"
             ]
         );
         assert!(!groups.contains(&"_internal"), "hidden group leaked");


### PR DESCRIPTION
A CLI shipped via wheels + curl|sh + self-update should offer
tab-completion and a man page; this one had the CommandFactory
plumbing but exposed neither.

Add a user-facing `mergify completions <bash|zsh|fish|…>` that prints
the completion script to stdout (clap_complete), and a hidden
`mergify _internal man` that renders the roff man page to stdout
(clap_mangen) for packaging to install. Both are pure introspection
over the clap command tree, handled before the tokio runtime starts —
so now that `stack` is a real subcommand group (not the old shim),
completions cover it correctly.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>