### PR TITLE
feat(install): drop completions and a man page during install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,153 +1,248 @@
 # Agent Instructions
 
-## CLI Output Style
+`mergify` is a native Rust CLI — a Cargo workspace under `crates/`, with the
+binary built from `crates/mergify-cli` (`[[bin]] name = "mergify"`). There is no
+Python: the port is complete and every command runs in-process. If you find a
+doc, comment, or rule mentioning `console_error`, `click`, `DYMGroup`,
+`mergify_cli.dym`, `crates/mergify-py-shim`, or a "Python shim", it is stale —
+fix it.
 
-Use compact Unicode symbols for terminal output, not emoji. This keeps new and
-updated terminal output consistent and avoids rendering issues across terminals.
+The bar is ruff/uv-grade Rust: typed errors, no panics in library code, clippy
+pedantic clean, snapshot-tested output. Concrete rules follow.
 
-**Preferred symbols:**
-- `✓` success, approved, merged
-- `✗` failure, conflict, changes requested
-- `●` active, pending, in progress
-- `○` inactive, skipped, none
-- `—` unknown, not applicable
+## Workspace layout
 
-**Avoid in terminal output:** `✅`, `❌`, `🟢`, `🔴`, `📝`, `⚠️`, `🔄`, `📦`, `🤖`, `🔗`
-and other emoji. They can render at inconsistent widths across terminals and
-break column alignment.
+- `mergify-core` — shared foundations: `CliError`/`ExitCode`, the HTTP `Client`,
+  `auth`, `Output`, `env`.
+- `mergify-tui` — terminal primitives: `Theme` (color), glyphs, relative time.
+  Stays dependency-light and **clap-free**.
+- `mergify-cli` — the binary: clap tree, dispatch, `run_native`, `self_update`,
+  `cli_schema`.
+- `mergify-stack` / `mergify-ci` / `mergify-queue` / `mergify-freeze` /
+  `mergify-config` — one crate per command group.
+- `mergify-test-support` — shared test scaffolding (not published).
 
-**Exceptions — emoji are acceptable in:**
-- Markdown output destined for GitHub (PR comments, CI summaries)
-- CI log output (`ci junit-process`, `ci scopes`) — these are read in CI
-  runners (GitHub Actions, CircleCI, etc.) where emoji render consistently
-  and improve log scanability
+## Error handling
 
-## Error Messages
+Library and command code **never prints errors and never calls `process::exit`**.
+Return `Result<_, mergify_core::CliError>`. `main()` is the single error sink: it
+writes `mergify: {err}` to stderr, walks the `source()` chain printing each cause
+as a `caused by:` line, and exits with `err.exit_code()`.
 
-Use `console_error(message)` from `mergify_cli` for all user-facing error
-messages. It prints `error: {message}` in red with `markup=False` (safe for
-user data containing `[`/`]`). Keep the message
-lowercase after `error:` (the function adds the prefix).
+`CliError` is a typed enum; each variant maps to a stable `ExitCode`
+(`GitHubApi`→5, `MergifyApi`→6, `Configuration`→7, … see `exit_code.rs`). Pick the
+variant whose exit code matches the failure class. Never add a `String` catch-all
+for a new failure category that deserves its own code — add a variant.
 
-```python
-from mergify_cli import console_error
+```rust
+// GOOD — typed variant, lowercase message, no prefix (the sink adds "mergify:")
+return Err(CliError::StackNotFound(format!("branch {name} not found")));
 
-console_error("commit not found")          # -> "error: commit not found"
-console_error(f"failed to fetch: {e}")     # -> "error: failed to fetch: ..."
+// BAD — printing + exiting inside a command
+eprintln!("error: branch not found");
+std::process::exit(1);
+
+// BAD — capitalized / pre-prefixed (the sink double-prefixes it)
+return Err(CliError::Generic("Error: branch not found".into()));
 ```
 
-For follow-up hints after an error, use plain `console.print()`:
-```python
-console_error("rebase failed — there may be conflicts")
-console.print("Resolve conflicts then run: git rebase --continue")
+**Preserve causes — don't flatten them into a string.** Prefer keeping a typed
+cause over `format!("...: {e}")`:
+
+- self-describing typed error → `CliError::Source` (or `?` it through the
+  generated `From<Box<dyn Error + Send + Sync>>`), which keeps it transparently.
+- "doing X failed because of Y" → `CliError::wrap(context, e)`, which shows the
+  context as the headline and `e` as a `caused by:` line.
+
+```rust
+// GOOD — context + preserved cause, prints a `caused by:` line
+let exe = std::env::current_exe().map_err(|e| CliError::wrap("locate binary", e))?;
+
+// AVOID — flattens the cause; reach for Generic only when there's no typed cause
+let exe = std::env::current_exe()
+    .map_err(|e| CliError::Generic(format!("locate binary: {e}")))?;
 ```
 
-Do **not** use `console.print(..., style="red")` or `[red]...[/]` markup
-for error messages — use `console_error()` instead.
+**No `anyhow` / `eyre` / `miette`.** Deliberate house stance: libraries return the
+typed `CliError`; the binary prints it (and the chain). If you need a richer
+rendered report, extend `CliError` + the `main()` sink in the PR — don't add
+`anyhow`.
 
-## Success Messages
+**API calls go through `mergify_core::http::Client`** with the right `ApiFlavor`,
+which assigns the correct exit code and gets retries (5xx, 429/`Retry-After`
+rate-limits), timeouts, and the `User-Agent` for free. **Never `use reqwest`
+directly from a command crate** (the one exception is `self_update`, documented in
+place: it does unauthenticated cross-host binary downloads the JSON client can't
+model).
 
-End success messages with a period:
-```python
-console.print("[green]Freeze created successfully.[/]")
-console.print("Stack reordered successfully.", style="green")
+## No panics in library / command paths
+
+A panic is a crash with no exit-code contract. In non-test code do not
+`.unwrap()`, `.expect()`, `panic!`, `unreachable!`, or `todo!` on anything derived
+from user input, the network, the filesystem, or git output. Return a `CliError`.
+
+```rust
+// BAD
+let n = pull["number"].as_u64().unwrap();
+// GOOD
+let n = pull["number"].as_u64()
+    .ok_or_else(|| CliError::Generic("pull payload missing `number`".into()))?;
 ```
 
-## JSON Output
+**Allowed exceptions** (must be provably infallible; add a one-line comment why):
+`Regex::new` on a literal behind `LazyLock`; `write!`/`writeln!` into a `String`;
+a mandatory regex capture group after the overall match succeeded; an
+`unreachable!` arm for a case handled earlier in the same function (e.g. the
+pre-runtime introspection commands). Prefer encoding an invariant in the type so
+the `expect` disappears; a stringly `match … => panic!("unknown X")` is **not**
+allowed — use an exhaustive `enum` match.
 
-Commands with `--json` flags must write JSON to **stdout** using
-`click.echo()`, not `console.print()` (which may add Rich formatting).
-This ensures clean output pipeable to `jq` and other tools.
+## clap conventions
 
-```python
-if output_json:
-    click.echo(json.dumps(data, indent=2))
+- Every command group is a derive subcommand enum: `Group(GroupArgs)` where
+  `GroupArgs` holds `#[command(subcommand)] command: GroupSubcommand`. Do **not**
+  hand-roll a `trailing_var_arg` catch-all and re-parse argv — clap gives correct
+  usage, help, did-you-mean, and global-flag inheritance for free. (`stack` is a
+  normal subcommand group; if you see a "shim"/`ShimmedArgs`, it's a regression.)
+- Register every new `(group, subcommand)` pair in `NATIVE_COMMANDS` in
+  `main.rs` — it's the single source of truth behind `--list-native-commands`,
+  and the schema golden asserts the `stack` set matches it. Adding a command
+  without updating it makes the test fail.
+- Global flags (`--debug`, `-v/--verbose`, `--color`) are `#[arg(global = true)]`
+  so they work on every subcommand.
+- Pure-introspection commands (`completions`, `_internal dump-cli-schema`,
+  `_internal man`) are handled before the tokio runtime starts.
+
+## stdout / stderr / `--json` / color
+
+- **Machine output (JSON) → stdout. Human chatter, progress, prompts, errors,
+  and logs → stderr.** Piping stdout into `jq` must stay clean.
+- Commands emit results through `&mut dyn mergify_core::output::Output`, not
+  `println!`. Call `emit` / `emit_json_value` once.
+- **Color goes through `mergify_tui::theme`**, never hardcoded SGR escapes. The
+  theme honors `--color <auto|always|never>` (resolved once via
+  `set_color_choice`), then `NO_COLOR`, then `FORCE_COLOR`/`CLICOLOR_FORCE`, then
+  the TTY. Cursor-movement / erase escapes in the progress renderer are not color
+  and are fine.
+
+```rust
+// GOOD
+writeln!(w, "{}created.{}", theme.green.render(), theme.green.render_reset())?;
+// BAD
+writeln!(w, "\x1b[32mcreated.\x1b[0m")?;
 ```
 
-## Command Groups
+## Terminal output symbols
 
-All top-level command groups must use `DYMGroup` (from `mergify_cli.dym`)
-with `invoke_without_command=True` for consistent "did you mean?"
-suggestions. Add an explicit `click.echo(ctx.get_help())` in the group
-callback when `ctx.invoked_subcommand is None` for help display.
+Compact, single-width Unicode only — never emoji (they render at inconsistent
+widths and break column alignment).
 
-## Rust Port Workflow
+| Symbol | Meaning |
+|---|---|
+| `✓` | success, approved, merged |
+| `✗` | failure, conflict, changes requested |
+| `●` | active, pending, in progress |
+| `○` | inactive, skipped, none |
+| `—` | unknown, not applicable |
 
-The CLI is being ported from Python to Rust incrementally. The shipped
-binary is `mergify` (built from `crates/mergify-cli`); commands not yet
-ported fall through to a Python shim implemented by the
-`crates/mergify-py-shim` crate, which invokes `python -m mergify_cli`
-on the bundled Python source. Native Rust commands are dispatched
-directly. Drift between the two implementations is prevented
-structurally: when porting a command, the Python implementation MUST
-be deleted in the same PR that adds the Rust implementation. There is
-no period where both copies coexist.
+**Forbidden in terminal output:** `✅ ❌ 🟢 🔴 ⏰ ⏳ ⚠️ 🔄 📦` and other emoji.
+**Emoji are allowed only in** Markdown destined for GitHub (PR comments, CI
+summaries) and CI-log output (`ci junit-process`, `ci scopes`) read in CI runners.
 
-A single PR therefore contains:
+Success messages end with a period ("Stack reordered successfully.") in the
+theme's green, applied inside the human-render closure.
 
-1. The Rust implementation (in the relevant `crates/*` crate) plus tests.
-2. Removal of the Python implementation file(s) and their tests.
-3. Any wiring updates (click registration, shim allow-list, etc.).
+## Logging
 
-Reviewers should reject PRs that port a command without removing the
-Python copy. Removing the Python copy without a Rust replacement is
-fine when the command is being deprecated/dropped from the CLI — the
-rule is "no two live copies of the same command", not "every Python
-copy must be replaced".
+Structured logs use `tracing`, emitted to **stderr** by the subscriber `main()`
+installs. `-v`/`-vv`/`-vvv` map to info/debug/trace; `--debug` floors at debug;
+`RUST_LOG` overrides. Only our own crates are raised, so dep noise stays quiet.
+Instrument network/process boundaries at `debug`; **never log the bearer token**
+or any auth header.
 
-### Port review checklist
+## HTTP / API rules
 
-Walk through this before opening a port PR. Most regressions caught so
-far have been a violation of one of these.
+- Match the endpoint's real response shape. Empty-body success → use
+  `post_no_response` / `delete_if_exists`, never `let _: serde_json::Value =
+  client.post(...)` (that fails to deserialize an empty body).
+- Fields the server may omit/null are `Option<T>` with `#[serde(default)]`.
+- Build one `reqwest::Client` per command run and reuse it across same-host calls
+  (it owns the connection pool); don't rebuild per request.
 
-**HTTP calls — match the Python original's response handling exactly.**
+## Testing
 
-- If the Python original calls a method on the client and **ignores
-  the response** (e.g. `await client.post(...)` with no `.json()`),
-  use `post_no_response` / `delete_if_exists` / equivalent on the
-  Rust side. Do NOT write `let _: serde_json::Value = client.post(...)`
-  — `Value` still requires a valid JSON body, and a server that
-  returns an empty body fails at deserialization with `parse response
-  JSON: error decoding response body`. This regressed `ci scopes-send`
-  once (fixed in #1356); the cure is structural — pick the right HTTP
-  method up-front.
-- If the Python original parses the response, keep the same shape on
-  the Rust side. Fields the Python type-hints as `T | None` (or that
-  the server has historically tolerated as missing/null) should be
-  `Option<T>` with `#[serde(default)]` so a missing/null field doesn't
-  abort deserialization.
+A change is not done without a test. Use the highest-fidelity tool per layer.
 
-**Test fixtures — mirror the real server, not what's convenient.**
+- **Snapshot the output that *is* the product** with `insta`. The CLI schema has
+  a golden (`cli_schema_golden`, version redacted) that catches any flag /
+  subcommand / help / value-hint drift; accept intentional changes with
+  `cargo insta review`. Add insta goldens for colorized human renders (a fixed
+  `now` seam and `cfg!(test)` color-off make them deterministic). Keep exact
+  `assert_eq!` on `serde_json::Value` for `--json` payloads — stronger than a
+  string snapshot.
+- **HTTP commands: wiremock with payload + call-count fidelity.** Assert
+  `body_json(...)` and `.expect(N)`, not just "didn't crash". Stub an empty-body
+  endpoint with `ResponseTemplate::new(200)` — never `set_body_json(json!({}))`,
+  which masks the empty-body bug the rule exists to catch.
+- Pin exact exit codes for the `CliError` contract; add a regression test for
+  every fixed failure mode (exit code, message, missing-field tolerance).
+- Use `temp_env::with_var` for env-dependent tests — never the unsound
+  process-global `std::env::set_var` (`unsafe_code = "forbid"` bans it anyway).
 
-- Wiremock body templates must match what the real endpoint actually
-  returns. If the real endpoint sends an empty body, use
-  `ResponseTemplate::new(200)` — never `set_body_json(json!({}))`. The
-  latter passes deserialization in tests and masks empty-body bugs
-  that fail in production.
-- Add a regression test for the specific failure mode you're
-  preventing — exit code, error message, missing-field tolerance —
-  not just the happy path.
+## Dependencies
 
-**Strings & UX parity with click.**
+Shared third-party deps live in the root `[workspace.dependencies]` table; each
+crate references them as `dep = { workspace = true }` (add extra features with
+`features = [...]`, which are additive). When adding or bumping a shared dep, edit
+the **root table**, not the crate — that's the single source of truth.
 
-- Char-bounded validators ("must be ≤ N characters") use
-  `s.chars().count()`, not `s.len()`. The latter counts UTF-8 bytes
-  and rejects valid non-ASCII input.
-- Confirmation prompts go to stderr, matching click's `confirm` /
-  `prompt`. Stdout stays pipeable.
-- Resolve all required state (repository, token, API URL) before
-  prompting the user. A missing-token error surfacing after the user
-  types `y` is bad UX and worse for non-interactive invocations.
+- TLS is `rustls` everywhere (`default-features = false, features = ["rustls"]`).
+  Never pull in `native-tls`/`openssl`.
+- Internal crates are `{ path = "../…" }` path deps.
+- `cargo-deny` gates advisories, licenses, bans, and sources (`deny.toml`); a new
+  dep with a non-allowed license fails CI — add the SPDX id (with the crate that
+  needs it) rather than loosening the policy.
+
+## clippy / fmt / MSRV bar
+
+- CI runs `cargo fmt --all --check` and
+  `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`.
+  **Warnings fail the build.** Run both before pushing.
+- Lints are `clippy::all` + `clippy::pedantic` (warn) with a short allow-list. Do
+  not add `#[allow(...)]` without a one-line reason, and don't grow the workspace
+  allow-list without justifying it in the PR.
+- MSRV is `rust-version = "1.88"`, gated by a CI job that compiles on exactly that
+  toolchain. Don't use features stabilized after it unless you bump
+  `rust-version` (and say so in the commit) — the job will catch it.
 
 ## Documentation
 
-When adding or changing a CLI feature, always update the documentation:
+Doc updates ship in the **same** commit/PR as the change, never a follow-up.
 
-1. **README.md** — keep the Features and Usage sections current with all
-   top-level commands and a brief description of what each does.
-2. **Skills** (`skills/` directory) — if the feature is something an AI agent
-   should know how to use, ensure a corresponding SKILL.md exists and covers it.
-   Update existing skills when command signatures or workflows change.
+1. **README.md** — keep Commands/Usage current with every top-level command
+   (including `self-update` and `completions`).
+2. **Skills** (`skills/`) — update the *matching* skill (don't create a
+   duplicate). Directory names aren't 1:1 with command groups:
 
-Documentation updates should be part of the same commit/PR as the feature
-change, not a follow-up.
+   | command group | skill dir |
+   |---|---|
+   | `stack` | `mergify-stack` |
+   | `ci`, `tests` | `mergify-ci` |
+   | `config` | `mergify-config` |
+   | `queue` | `mergify-merge-queue` |
+   | `freeze` | `mergify-merge-protections` |
+
+3. **Crate `//!` module docs** — keep the purpose/invariant header accurate when
+   you change a module's contract (the `Output` stdout-purity invariant, the
+   `CliError`→`ExitCode` mapping, the HTTP retry policy).
+
+## Commits & PRs
+
+- Conventional-commit subjects scoped by area: `feat(stack):`, `fix(ci):`,
+  `chore(deps):`, `feat(cli):`. Imperative, no trailing period. The commit body
+  becomes the PR body — put ticket refs and context there.
+- Never commit on `main`; never `git push` — use `mergify stack push`. Each
+  commit becomes its own PR and must pass CI **independently** (compile, clippy
+  `-D warnings`, tests). Fold lint/fmt fixes into the commit that caused them.
+- Small in-flight polish → `git commit --amend` (+ `mergify stack note -m "why"`
+  before re-pushing), not a pile of fixup commits.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +300,16 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "cmake"
@@ -1221,6 +1240,8 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "clap",
+ "clap_complete",
+ "clap_mangen",
  "mergify-ci",
  "mergify-config",
  "mergify-core",
@@ -1872,6 +1893,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "roff"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,15 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
@@ -337,6 +346,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +380,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -374,6 +403,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -411,13 +450,23 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -451,6 +500,12 @@ checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -641,6 +696,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1018,6 +1083,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+dependencies = [
+ "console",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,6 +1322,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
+ "insta",
  "mergify-ci",
  "mergify-config",
  "mergify-core",
@@ -1255,7 +1336,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "sha2",
+ "sha2 0.11.0",
  "temp-env",
  "tempfile",
  "tokio",
@@ -1580,6 +1661,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2137,13 +2261,24 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2182,6 +2317,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
@@ -2493,6 +2634,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-general-category"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "ansi"] }
 unicode-width = "0.2"
 url = "2"
+insta = { version = "1", features = ["json", "redactions"] }
 temp-env = "0.3"
 wiremock = "0.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ authors = ["Mergify Team <hello@mergify.com>"]
 anstyle = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
 clap = { version = "4.5", features = ["derive", "env"] }
+clap_complete = "4.5"
+clap_mangen = "0.2"
 flate2 = "1"
 getrandom = "0.4"
 glob = "0.3"

--- a/crates/mergify-cli/Cargo.toml
+++ b/crates/mergify-cli/Cargo.toml
@@ -52,6 +52,7 @@ tracing-subscriber = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+insta = { workspace = true }
 regex = { workspace = true }
 serde_yaml_ng = { workspace = true }
 temp-env = { workspace = true }

--- a/crates/mergify-cli/Cargo.toml
+++ b/crates/mergify-cli/Cargo.toml
@@ -16,6 +16,8 @@ path = "src/main.rs"
 [dependencies]
 chrono = { workspace = true }
 clap = { workspace = true }
+clap_complete = { workspace = true }
+clap_mangen = { workspace = true }
 mergify-ci = { path = "../mergify-ci" }
 mergify-config = { path = "../mergify-config" }
 mergify-core = { path = "../mergify-core" }

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -13,6 +13,7 @@ use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+use clap::CommandFactory;
 use clap::Parser;
 use clap::Subcommand;
 use mergify_ci::git_refs::Format as GitRefsFormat;
@@ -147,6 +148,8 @@ const NATIVE_COMMANDS: &[(&str, &str)] = &[
     // Emits the machine-readable CLI schema the docs site renders
     // into the command reference. Hidden; not a stable surface.
     ("_internal", "dump-cli-schema"),
+    // Renders the roff man page to stdout, for packaging. Hidden.
+    ("_internal", "man"),
 ];
 
 /// Native commands the Rust binary handles without delegating to
@@ -264,6 +267,12 @@ enum NativeCommand {
     /// to JSON for the docs site. Pure introspection; no async, no I/O
     /// beyond stdout.
     InternalDumpCliSchema,
+    /// `mergify completions <shell>` — print a shell completion script
+    /// to stdout. Pure introspection.
+    Completions(clap_complete::Shell),
+    /// `_internal man` — render the roff man page to stdout for
+    /// packaging. Pure introspection.
+    InternalManPage,
     /// `mergify self-update [--force] [--check]` — replace the
     /// running binary with the latest release.
     SelfUpdate(self_update::Options),
@@ -757,6 +766,7 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
             StackSubcommand::Setup(cli) => Dispatch::Native(NativeCommand::StackSetup(cli.into())),
         },
         Subcommands::SelfUpdate(cli) => Dispatch::Native(NativeCommand::SelfUpdate(cli.into())),
+        Subcommands::Completions(cli) => Dispatch::Native(NativeCommand::Completions(cli.shell)),
         Subcommands::Internal(InternalArgs {
             command:
                 InternalSubcommand::StackLocalCommits(InternalStackLocalCommitsArgs {
@@ -814,6 +824,9 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
         Subcommands::Internal(InternalArgs {
             command: InternalSubcommand::DumpCliSchema,
         }) => Dispatch::Native(NativeCommand::InternalDumpCliSchema),
+        Subcommands::Internal(InternalArgs {
+            command: InternalSubcommand::Man,
+        }) => Dispatch::Native(NativeCommand::InternalManPage),
         Subcommands::Ci(CiArgs {
             command:
                 CiSubcommand::Scopes(ScopesCliArgs {
@@ -1379,6 +1392,25 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
     if matches!(cmd, NativeCommand::InternalDumpCliSchema) {
         return cli_schema::run();
     }
+    // Completions and the man page are pure introspection over the
+    // clap tree — emit to stdout and exit before tokio spins up.
+    match cmd {
+        NativeCommand::Completions(shell) => {
+            let mut command = CliRoot::command();
+            clap_complete::generate(shell, &mut command, "mergify", &mut std::io::stdout());
+            return ExitCode::SUCCESS;
+        }
+        NativeCommand::InternalManPage => {
+            return match clap_mangen::Man::new(CliRoot::command()).render(&mut std::io::stdout()) {
+                Ok(()) => ExitCode::SUCCESS,
+                Err(e) => {
+                    eprintln!("mergify: render man page: {e}");
+                    ExitCode::FAILURE
+                }
+            };
+        }
+        _ => {}
+    }
 
     let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -1407,8 +1439,10 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
     let result: Result<mergify_core::ExitCode, mergify_core::CliError> = rt.block_on(async {
         match cmd {
             // Handled above, before the runtime was built.
-            NativeCommand::InternalDumpCliSchema => {
-                unreachable!("dump-cli-schema is handled before the runtime starts")
+            NativeCommand::InternalDumpCliSchema
+            | NativeCommand::Completions(_)
+            | NativeCommand::InternalManPage => {
+                unreachable!("introspection commands are handled before the runtime starts")
             }
             NativeCommand::ConfigValidate { config_file } => {
                 mergify_config::validate::run(config_file.as_deref(), &mut output)
@@ -2650,6 +2684,8 @@ enum Subcommands {
     /// `curl | sh` installer.
     #[command(name = "self-update")]
     SelfUpdate(SelfUpdateCli),
+    /// Print a shell completion script (e.g. `mergify completions zsh`).
+    Completions(CompletionsCli),
     /// Internal helpers the Python side of the wheel calls during
     /// the Python→Rust migration. Hidden from `--help` because it
     /// is not part of the user-facing CLI; the wire format is not
@@ -2811,6 +2847,10 @@ enum InternalSubcommand {
     /// code, never hand-maintained. Not a stable user-facing surface.
     #[command(name = "dump-cli-schema")]
     DumpCliSchema,
+    /// Render the roff man page to stdout, for packaging to install
+    /// into `man/`. Not a stable user-facing surface.
+    #[command(name = "man")]
+    Man,
 }
 
 #[derive(clap::Args)]
@@ -3399,6 +3439,13 @@ impl From<SelfUpdateCli> for self_update::Options {
             check_only: cli.check,
         }
     }
+}
+
+#[derive(clap::Args)]
+struct CompletionsCli {
+    /// Shell to generate a completion script for.
+    #[arg(value_enum)]
+    shell: clap_complete::Shell,
 }
 
 impl TryFrom<StackSquashCli> for StackSquashOpts {
@@ -4293,7 +4340,8 @@ mod tests {
                 "queue",
                 "freeze",
                 "stack",
-                "self-update"
+                "self-update",
+                "completions"
             ]
         );
         assert!(!groups.contains(&"_internal"), "hidden group leaked");

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -727,7 +727,7 @@ fn quarantine_get_opts(args: TestsQuarantineGetCliArgs) -> TestsQuarantineGetOpt
 
 #[allow(clippy::too_many_lines)] // mostly mechanical match arms
 fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
-    let _ = parsed.debug; // global flag — consulted by command impls, not here
+    let _ = parsed.debug; // already consumed by init_tracing(); ignored during dispatch
     match parsed.command {
         Subcommands::Stack(StackArgs { command }) => match command {
             StackSubcommand::New(cli) => Dispatch::Native(NativeCommand::StackNew(cli.into())),
@@ -744,10 +744,9 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
             StackSubcommand::Move(cli) => Dispatch::Native(NativeCommand::StackMove(cli.into())),
             StackSubcommand::Squash(cli) => match StackSquashOpts::try_from(cli) {
                 Ok(opts) => Dispatch::Native(NativeCommand::StackSquash(opts)),
-                Err(msg) => {
-                    eprintln!("error: {msg}");
-                    std::process::exit(2);
-                }
+                Err(msg) => CliRoot::command()
+                    .error(clap::error::ErrorKind::ValueValidation, msg)
+                    .exit(),
             },
             StackSubcommand::Checkout(cli) => {
                 Dispatch::Native(NativeCommand::StackCheckout(cli.into()))

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -200,8 +200,7 @@ enum NativeCommand {
     InternalStackRemoteChanges(InternalStackRemoteChangesOpts),
     /// `mergify stack new <name> [--base REMOTE/BRANCH]
     /// [--checkout/--no-checkout]` — create a new stack branch
-    /// tracking the resolved trunk. First stack subcommand to land
-    /// natively; the rest still shim to Python.
+    /// tracking the resolved trunk.
     StackNew(StackNewOpts),
     /// `mergify stack note [<commit>] [-m <msg>] [--append]
     /// [--remove]` — attach/append/remove the "why was this commit
@@ -1385,6 +1384,19 @@ fn render_hooks_status(status: &mergify_stack::commands::setup::HooksStatus) {
     }
 }
 
+/// Absolute path to the running `mergify` binary. The rebase-family
+/// stack subcommands set it as `GIT_SEQUENCE_EDITOR` so the spawned
+/// `git rebase -i` re-invokes this binary to rewrite the todo file in
+/// place. Keeps the original I/O error as a `caused by:` source.
+fn mergify_self_exe() -> Result<PathBuf, mergify_core::CliError> {
+    std::env::current_exe().map_err(|e| {
+        mergify_core::CliError::wrap(
+            "could not locate current binary path for GIT_SEQUENCE_EDITOR",
+            e,
+        )
+    })
+}
+
 #[allow(clippy::too_many_lines)] // one match arm per native command
 fn run_native(cmd: NativeCommand) -> ExitCode {
     // Pure introspection — no async runtime, network, or shared output
@@ -1777,11 +1789,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 Ok(mergify_core::ExitCode::Success)
             }
             NativeCommand::StackEdit(opts) => {
-                let mergify_binary = std::env::current_exe().map_err(|e| {
-                    mergify_core::CliError::Generic(format!(
-                        "could not locate current binary path for GIT_SEQUENCE_EDITOR: {e}"
-                    ))
-                })?;
+                let mergify_binary = mergify_self_exe()?;
                 let outcome = mergify_stack::commands::edit::run(
                     &mergify_stack::commands::edit::Options {
                         repo_dir: None,
@@ -1805,11 +1813,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 Ok(mergify_core::ExitCode::Success)
             }
             NativeCommand::StackDrop(opts) => {
-                let mergify_binary = std::env::current_exe().map_err(|e| {
-                    mergify_core::CliError::Generic(format!(
-                        "could not locate current binary path for GIT_SEQUENCE_EDITOR: {e}"
-                    ))
-                })?;
+                let mergify_binary = mergify_self_exe()?;
                 let outcome = mergify_stack::commands::drop::run(
                     &mergify_stack::commands::drop::Options {
                         repo_dir: None,
@@ -1838,11 +1842,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 Ok(mergify_core::ExitCode::Success)
             }
             NativeCommand::StackFixup(opts) => {
-                let mergify_binary = std::env::current_exe().map_err(|e| {
-                    mergify_core::CliError::Generic(format!(
-                        "could not locate current binary path for GIT_SEQUENCE_EDITOR: {e}"
-                    ))
-                })?;
+                let mergify_binary = mergify_self_exe()?;
                 let outcome = mergify_stack::commands::fixup::run(
                     &mergify_stack::commands::fixup::Options {
                         repo_dir: None,
@@ -1871,11 +1871,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 Ok(mergify_core::ExitCode::Success)
             }
             NativeCommand::StackReword(opts) => {
-                let mergify_binary = std::env::current_exe().map_err(|e| {
-                    mergify_core::CliError::Generic(format!(
-                        "could not locate current binary path for GIT_SEQUENCE_EDITOR: {e}"
-                    ))
-                })?;
+                let mergify_binary = mergify_self_exe()?;
                 let outcome = mergify_stack::commands::reword::run(
                     &mergify_stack::commands::reword::Options {
                         repo_dir: None,
@@ -1905,11 +1901,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 Ok(mergify_core::ExitCode::Success)
             }
             NativeCommand::StackReorder(opts) => {
-                let mergify_binary = std::env::current_exe().map_err(|e| {
-                    mergify_core::CliError::Generic(format!(
-                        "could not locate current binary path for GIT_SEQUENCE_EDITOR: {e}"
-                    ))
-                })?;
+                let mergify_binary = mergify_self_exe()?;
                 let outcome = mergify_stack::commands::reorder::run(
                     &mergify_stack::commands::reorder::Options {
                         repo_dir: None,
@@ -1941,11 +1933,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 Ok(mergify_core::ExitCode::Success)
             }
             NativeCommand::StackMove(opts) => {
-                let mergify_binary = std::env::current_exe().map_err(|e| {
-                    mergify_core::CliError::Generic(format!(
-                        "could not locate current binary path for GIT_SEQUENCE_EDITOR: {e}"
-                    ))
-                })?;
+                let mergify_binary = mergify_self_exe()?;
                 let position = match opts.position {
                     StackMovePosition::First => mergify_stack::commands::move_cmd::Position::First,
                     StackMovePosition::Last => mergify_stack::commands::move_cmd::Position::Last,
@@ -1984,11 +1972,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 Ok(mergify_core::ExitCode::Success)
             }
             NativeCommand::StackSquash(opts) => {
-                let mergify_binary = std::env::current_exe().map_err(|e| {
-                    mergify_core::CliError::Generic(format!(
-                        "could not locate current binary path for GIT_SEQUENCE_EDITOR: {e}"
-                    ))
-                })?;
+                let mergify_binary = mergify_self_exe()?;
                 let outcome = mergify_stack::commands::squash::run(
                     &mergify_stack::commands::squash::Options {
                         repo_dir: None,
@@ -2149,11 +2133,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                     mergify_stack::stack_context::resolve_default_branch_prefix(None, &author)
                 });
 
-                let mergify_binary = std::env::current_exe().map_err(|e| {
-                    mergify_core::CliError::Generic(format!(
-                        "could not locate current binary path for GIT_SEQUENCE_EDITOR: {e}"
-                    ))
-                })?;
+                let mergify_binary = mergify_self_exe()?;
 
                 let outcome = mergify_stack::commands::sync::run(
                     &mergify_stack::commands::sync::Options {

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -4367,6 +4367,27 @@ mod tests {
             "expected only `native` stack subcommands",
         );
 
+        // The stack subcommand set in the generated schema must match
+        // the NATIVE_COMMANDS registry exactly. Under the old shim
+        // these were two hand-maintained lists that could drift (a
+        // dropped leaf would silently vanish from the reference); now
+        // both derive from the same clap tree, so pin the invariant.
+        let schema_stack: std::collections::BTreeSet<&str> = stack["commands"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c["name"].as_str().expect("name"))
+            .collect();
+        let registry_stack: std::collections::BTreeSet<&str> = NATIVE_COMMANDS
+            .iter()
+            .filter(|(group, _)| *group == "stack")
+            .map(|(_, sub)| *sub)
+            .collect();
+        assert_eq!(
+            schema_stack, registry_stack,
+            "stack subcommands in the schema drifted from NATIVE_COMMANDS",
+        );
+
         // The exit-code contract rides alongside the command tree,
         // sourced from `mergify_core::ExitCode`. Pin the codes so a
         // dropped or renumbered variant surfaces here.
@@ -4377,6 +4398,18 @@ mod tests {
             .map(|c| c["code"].as_u64().expect("code"))
             .collect();
         assert_eq!(codes, [0, 1, 3, 4, 5, 6, 7, 8]);
+    }
+
+    /// Golden snapshot of the whole CLI surface. Catches drift the
+    /// structural checks above can't — a dropped flag, a renamed leaf
+    /// subcommand, a changed `value_hint`, reworded help. Review
+    /// intentional changes with `cargo insta review`. The
+    /// version field is release-stamped, so redact it.
+    #[test]
+    fn cli_schema_golden() {
+        let schema: serde_json::Value =
+            serde_json::from_str(&cli_schema::dump()).expect("schema is valid JSON");
+        insta::assert_json_snapshot!(schema, { ".cli.version" => "[version]" });
     }
 
     #[test]

--- a/crates/mergify-cli/src/snapshots/mergify__tests__cli_schema_golden.snap
+++ b/crates/mergify-cli/src/snapshots/mergify__tests__cli_schema_golden.snap
@@ -1,0 +1,3816 @@
+---
+source: crates/mergify-cli/src/main.rs
+expression: schema
+---
+{
+  "cli": {
+    "about": "Mergify command-line interface",
+    "name": "mergify",
+    "version": "[version]"
+  },
+  "command": {
+    "about": "Mergify command-line interface",
+    "aliases": [],
+    "args": [
+      {
+        "default": "0",
+        "env": null,
+        "global": true,
+        "help": "Increase log verbosity: -v info, -vv debug, -vvv trace. Logs go to stderr so stdout stays clean for piping. `RUST_LOG` overrides this",
+        "id": "verbose",
+        "kind": "flag",
+        "long": "verbose",
+        "longHelp": "Increase log verbosity: -v info, -vv debug, -vvv trace. Logs go to stderr so stdout stays clean for piping. `RUST_LOG` overrides this",
+        "numArgs": "0",
+        "possibleValues": [],
+        "required": false,
+        "short": "v",
+        "valueHint": null,
+        "valueNames": []
+      },
+      {
+        "default": "false",
+        "env": null,
+        "global": true,
+        "help": "Shorthand for at least debug-level logging (like -vv)",
+        "id": "debug",
+        "kind": "flag",
+        "long": "debug",
+        "longHelp": "Shorthand for at least debug-level logging (like -vv)",
+        "numArgs": "0",
+        "possibleValues": [],
+        "required": false,
+        "short": null,
+        "valueHint": null,
+        "valueNames": []
+      },
+      {
+        "default": "auto",
+        "env": null,
+        "global": true,
+        "help": "When to use color in terminal output",
+        "id": "color",
+        "kind": "option",
+        "long": "color",
+        "longHelp": "When to use color in terminal output",
+        "numArgs": "1",
+        "possibleValues": [
+          {
+            "help": null,
+            "name": "auto"
+          },
+          {
+            "help": null,
+            "name": "always"
+          },
+          {
+            "help": null,
+            "name": "never"
+          }
+        ],
+        "required": false,
+        "short": null,
+        "valueHint": null,
+        "valueNames": [
+          "COLOR"
+        ]
+      }
+    ],
+    "commands": [
+      {
+        "about": "Validate and simulate your Mergify configuration",
+        "aliases": [],
+        "args": [
+          {
+            "default": null,
+            "env": null,
+            "global": true,
+            "help": "Path to the Mergify configuration file (auto-detected if not provided)",
+            "id": "config_file",
+            "kind": "option",
+            "long": "config-file",
+            "longHelp": "Path to the Mergify configuration file (auto-detected if not provided)",
+            "numArgs": "1",
+            "possibleValues": [],
+            "required": false,
+            "short": "f",
+            "valueHint": "anyPath",
+            "valueNames": [
+              "CONFIG_FILE"
+            ]
+          }
+        ],
+        "commands": [
+          {
+            "about": "Validate the Mergify configuration file against the schema",
+            "aliases": [],
+            "args": [],
+            "commands": [],
+            "longAbout": "Validate the Mergify configuration file against the schema.\n\nCheck that your configuration file parses and conforms to the Mergify schema, reporting the first error with its location. Run it locally or in CI to catch mistakes before they reach the default branch. The file is auto-detected unless you pass `--config-file`.",
+            "name": "validate",
+            "path": [
+              "mergify",
+              "config",
+              "validate"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify config validate [OPTIONS]"
+          },
+          {
+            "about": "Simulate Mergify actions on a pull request using the local configuration",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Pull request URL (e.g. <https://github.com/owner/repo/pull/123>)",
+                "id": "pull_request",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "Pull request URL (e.g. <https://github.com/owner/repo/pull/123>)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "PULL_REQUEST_URL"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+                "id": "token",
+                "kind": "option",
+                "long": "token",
+                "longHelp": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "t",
+                "valueHint": null,
+                "valueNames": [
+                  "TOKEN"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+                "id": "api_url",
+                "kind": "option",
+                "long": "api-url",
+                "longHelp": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "u",
+                "valueHint": null,
+                "valueNames": [
+                  "API_URL"
+                ]
+              }
+            ],
+            "commands": [],
+            "longAbout": "Simulate Mergify actions on a pull request using the local configuration.\n\nEvaluate your local configuration against a real pull request and report which rules match and what actions Mergify would take — without changing anything on GitHub. Useful to test a configuration change before pushing it.",
+            "name": "simulate",
+            "path": [
+              "mergify",
+              "config",
+              "simulate"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify config simulate [OPTIONS] <PULL_REQUEST_URL>"
+          }
+        ],
+        "longAbout": "Validate and simulate your Mergify configuration.\n\nCheck your `.mergify.yml` against the schema before pushing it, or simulate how Mergify's rules would evaluate against a given pull request using your local configuration.",
+        "name": "config",
+        "path": [
+          "mergify",
+          "config"
+        ],
+        "source": "native",
+        "subcommandRequired": true,
+        "usage": "mergify config [OPTIONS] <COMMAND>"
+      },
+      {
+        "about": "Run Mergify CI Insights commands from your pipeline",
+        "aliases": [],
+        "args": [],
+        "commands": [
+          {
+            "about": "Send scopes tied to a pull request to Mergify",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Repository full name (owner/repo). Detected from the CI environment or the local git remote when omitted",
+                "id": "repository",
+                "kind": "option",
+                "long": "repository",
+                "longHelp": "Repository full name (owner/repo). Detected from the CI environment or the local git remote when omitted",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "r",
+                "valueHint": null,
+                "valueNames": [
+                  "REPOSITORY"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Pull request number. Falls back to ``GITHUB_EVENT_PATH`` (reads ``.pull_request.number``). When neither is available the command prints a skip message and exits 0",
+                "id": "pull_request",
+                "kind": "option",
+                "long": "pull-request",
+                "longHelp": "Pull request number. Falls back to ``GITHUB_EVENT_PATH`` (reads ``.pull_request.number``). When neither is available the command prints a skip message and exits 0",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "p",
+                "valueHint": null,
+                "valueNames": [
+                  "PULL_REQUEST"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+                "id": "token",
+                "kind": "option",
+                "long": "token",
+                "longHelp": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "t",
+                "valueHint": null,
+                "valueNames": [
+                  "TOKEN"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+                "id": "api_url",
+                "kind": "option",
+                "long": "api-url",
+                "longHelp": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "u",
+                "valueHint": null,
+                "valueNames": [
+                  "API_URL"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Scope to upload (repeatable)",
+                "id": "scope",
+                "kind": "option",
+                "long": "scope",
+                "longHelp": "Scope to upload (repeatable)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "s",
+                "valueHint": null,
+                "valueNames": [
+                  "SCOPE"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "JSON file containing scopes to upload (output of ``mergify ci scopes --write``)",
+                "id": "scopes_json",
+                "kind": "option",
+                "long": "scopes-json",
+                "longHelp": "JSON file containing scopes to upload (output of ``mergify ci scopes --write``)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": "anyPath",
+                "valueNames": [
+                  "SCOPES_JSON"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Plain-text file with one scope per line",
+                "id": "scopes_file",
+                "kind": "option",
+                "long": "scopes-file",
+                "longHelp": "Plain-text file with one scope per line",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": "anyPath",
+                "valueNames": [
+                  "SCOPES_FILE"
+                ]
+              }
+            ],
+            "commands": [],
+            "longAbout": "Send scopes tied to a pull request to Mergify.\n\nUpload the scopes affected by a pull request so CI Insights can attribute test results to them. Reads scopes from repeated --scope flags or from a file produced by \"mergify ci scopes --write\". Exits 0 without doing anything when no pull request can be determined.",
+            "name": "scopes-send",
+            "path": [
+              "mergify",
+              "ci",
+              "scopes-send"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify ci scopes-send [OPTIONS]"
+          },
+          {
+            "about": "Print the base/head git references for the current build",
+            "aliases": [],
+            "args": [
+              {
+                "default": "text",
+                "env": null,
+                "global": false,
+                "help": "Output format: `text` (default), `shell` for eval-friendly `MERGIFY_GIT_REFS_*` lines, or `json` for a single JSON object",
+                "id": "format",
+                "kind": "option",
+                "long": "format",
+                "longHelp": "Output format: `text` (default), `shell` for eval-friendly `MERGIFY_GIT_REFS_*` lines, or `json` for a single JSON object",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "FORMAT"
+                ]
+              }
+            ],
+            "commands": [],
+            "longAbout": "Print the base/head git references for the current build.\n\nDetect and print the base and head git references for the build from the CI environment, as plain text, eval-friendly shell lines, or JSON. Useful for wiring later steps to the same refs Mergify computed.",
+            "name": "git-refs",
+            "path": [
+              "mergify",
+              "ci",
+              "git-refs"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify ci git-refs [OPTIONS]"
+          },
+          {
+            "about": "Print the current build's merge queue batch metadata (from the Mergify git note)",
+            "aliases": [],
+            "args": [],
+            "commands": [],
+            "longAbout": "Print the current build's merge queue batch metadata (from the Mergify git note).\n\nRead the Mergify git note attached to the current HEAD and print the merge queue batch the build belongs to. Needs only plain git and no token, so it works in any CI runner.",
+            "name": "queue-info",
+            "path": [
+              "mergify",
+              "ci",
+              "queue-info"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify ci queue-info [OPTIONS]"
+          },
+          {
+            "about": "Give the list of scopes impacted by changed files",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Path to YAML config file. Falls back to the `MERGIFY_CONFIG_PATH` env var, then auto-detects `.mergify.yml`, `.mergify/config.yml`, or `.github/mergify.yml`",
+                "id": "config",
+                "kind": "option",
+                "long": "config",
+                "longHelp": "Path to YAML config file. Falls back to the `MERGIFY_CONFIG_PATH` env var, then auto-detects `.mergify.yml`, `.mergify/config.yml`, or `.github/mergify.yml`",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": "anyPath",
+                "valueNames": [
+                  "CONFIG"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Base git reference to use to look for changed files",
+                "id": "base",
+                "kind": "option",
+                "long": "base",
+                "longHelp": "Base git reference to use to look for changed files",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "BASE"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Head git reference to use to look for changed files",
+                "id": "head",
+                "kind": "option",
+                "long": "head",
+                "longHelp": "Head git reference to use to look for changed files",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "HEAD"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Write the detected scopes to a file (JSON, consumed by `ci scopes-send --scopes-json`)",
+                "id": "write",
+                "kind": "option",
+                "long": "write",
+                "longHelp": "Write the detected scopes to a file (JSON, consumed by `ci scopes-send --scopes-json`)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "w",
+                "valueHint": "anyPath",
+                "valueNames": [
+                  "WRITE"
+                ]
+              }
+            ],
+            "commands": [],
+            "longAbout": "Give the list of scopes impacted by changed files.\n\nCompute the configured scopes impacted by the files changed between two git references, using your Mergify configuration. Print them, or write them to a file with --write for a later \"mergify ci scopes-send\".",
+            "name": "scopes",
+            "path": [
+              "mergify",
+              "ci",
+              "scopes"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify ci scopes [OPTIONS]"
+          },
+          {
+            "about": "Upload JUnit XML reports and ignore failed tests with Mergify's CI Insights Quarantine",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default (`https://api.mergify.com`)",
+                "id": "api_url",
+                "kind": "option",
+                "long": "api-url",
+                "longHelp": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default (`https://api.mergify.com`)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "u",
+                "valueHint": null,
+                "valueNames": [
+                  "API_URL"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "CI Issues application key. Falls back to ``MERGIFY_TOKEN``",
+                "id": "token",
+                "kind": "option",
+                "long": "token",
+                "longHelp": "CI Issues application key. Falls back to ``MERGIFY_TOKEN``",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "t",
+                "valueHint": null,
+                "valueNames": [
+                  "TOKEN"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Repository full name (owner/repo). Detected from the CI environment or the local git remote when omitted",
+                "id": "repository",
+                "kind": "option",
+                "long": "repository",
+                "longHelp": "Repository full name (owner/repo). Detected from the CI environment or the local git remote when omitted",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "r",
+                "valueHint": null,
+                "valueNames": [
+                  "REPOSITORY"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Test framework label (e.g. `pytest`). Optional; passed as a span attribute",
+                "id": "test_framework",
+                "kind": "option",
+                "long": "test-framework",
+                "longHelp": "Test framework label (e.g. `pytest`). Optional; passed as a span attribute",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "TEST_FRAMEWORK"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Test language label (e.g. `python`). Optional; passed as a span attribute",
+                "id": "test_language",
+                "kind": "option",
+                "long": "test-language",
+                "longHelp": "Test language label (e.g. `python`). Optional; passed as a span attribute",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "TEST_LANGUAGE"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Branch the quarantine API should look up tests on. Defaults to the PR base branch, or the head branch as a fallback",
+                "id": "tests_target_branch",
+                "kind": "option",
+                "long": "tests-target-branch",
+                "longHelp": "Branch the quarantine API should look up tests on. Defaults to the PR base branch, or the head branch as a fallback",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "b",
+                "valueHint": null,
+                "valueNames": [
+                  "TESTS_TARGET_BRANCH"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Exit code of the test runner. When this is non-zero but no failures appear in the JUnit report, the run is flagged as a silent failure. Falls back to ``MERGIFY_TEST_EXIT_CODE``",
+                "id": "test_exit_code",
+                "kind": "option",
+                "long": "test-exit-code",
+                "longHelp": "Exit code of the test runner. When this is non-zero but no failures appear in the JUnit report, the run is flagged as a silent failure. Falls back to ``MERGIFY_TEST_EXIT_CODE``",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "e",
+                "valueHint": null,
+                "valueNames": [
+                  "TEST_EXIT_CODE"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "JUnit XML files or glob patterns (e.g. `reports/**/*.xml`). At least one path or pattern is required",
+                "id": "files",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "JUnit XML files or glob patterns (e.g. `reports/**/*.xml`). At least one path or pattern is required",
+                "numArgs": "1..",
+                "possibleValues": [],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "FILE"
+                ]
+              }
+            ],
+            "commands": [],
+            "longAbout": "Upload JUnit XML reports and ignore failed tests with Mergify's CI Insights Quarantine.\n\nParse one or more JUnit XML reports, upload the results to CI Insights, and reconcile them against the quarantine so known-flaky tests don't fail the build. Accepts file paths or glob patterns; pass the runner's exit code with --test-exit-code to detect silent failures.",
+            "name": "junit-process",
+            "path": [
+              "mergify",
+              "ci",
+              "junit-process"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify ci junit-process [OPTIONS] <FILE>..."
+          },
+          {
+            "about": "Upload JUnit XML reports (deprecated: use junit-process)",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default (`https://api.mergify.com`)",
+                "id": "api_url",
+                "kind": "option",
+                "long": "api-url",
+                "longHelp": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default (`https://api.mergify.com`)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "u",
+                "valueHint": null,
+                "valueNames": [
+                  "API_URL"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "CI Issues application key. Falls back to ``MERGIFY_TOKEN``",
+                "id": "token",
+                "kind": "option",
+                "long": "token",
+                "longHelp": "CI Issues application key. Falls back to ``MERGIFY_TOKEN``",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "t",
+                "valueHint": null,
+                "valueNames": [
+                  "TOKEN"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Repository full name (owner/repo). Detected from the CI environment or the local git remote when omitted",
+                "id": "repository",
+                "kind": "option",
+                "long": "repository",
+                "longHelp": "Repository full name (owner/repo). Detected from the CI environment or the local git remote when omitted",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "r",
+                "valueHint": null,
+                "valueNames": [
+                  "REPOSITORY"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Test framework label (e.g. `pytest`). Optional; passed as a span attribute",
+                "id": "test_framework",
+                "kind": "option",
+                "long": "test-framework",
+                "longHelp": "Test framework label (e.g. `pytest`). Optional; passed as a span attribute",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "TEST_FRAMEWORK"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Test language label (e.g. `python`). Optional; passed as a span attribute",
+                "id": "test_language",
+                "kind": "option",
+                "long": "test-language",
+                "longHelp": "Test language label (e.g. `python`). Optional; passed as a span attribute",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "TEST_LANGUAGE"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Branch the quarantine API should look up tests on. Defaults to the PR base branch, or the head branch as a fallback",
+                "id": "tests_target_branch",
+                "kind": "option",
+                "long": "tests-target-branch",
+                "longHelp": "Branch the quarantine API should look up tests on. Defaults to the PR base branch, or the head branch as a fallback",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "b",
+                "valueHint": null,
+                "valueNames": [
+                  "TESTS_TARGET_BRANCH"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Exit code of the test runner. When this is non-zero but no failures appear in the JUnit report, the run is flagged as a silent failure. Falls back to ``MERGIFY_TEST_EXIT_CODE``",
+                "id": "test_exit_code",
+                "kind": "option",
+                "long": "test-exit-code",
+                "longHelp": "Exit code of the test runner. When this is non-zero but no failures appear in the JUnit report, the run is flagged as a silent failure. Falls back to ``MERGIFY_TEST_EXIT_CODE``",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "e",
+                "valueHint": null,
+                "valueNames": [
+                  "TEST_EXIT_CODE"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "JUnit XML files or glob patterns (e.g. `reports/**/*.xml`). At least one path or pattern is required",
+                "id": "files",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "JUnit XML files or glob patterns (e.g. `reports/**/*.xml`). At least one path or pattern is required",
+                "numArgs": "1..",
+                "possibleValues": [],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "FILE"
+                ]
+              }
+            ],
+            "commands": [],
+            "longAbout": "Upload JUnit XML reports (deprecated: use junit-process).\n\nDeprecated alias for junit-process, kept for backward compatibility. It runs the same processing and prints a deprecation warning; use junit-process instead.",
+            "name": "junit-upload",
+            "path": [
+              "mergify",
+              "ci",
+              "junit-upload"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify ci junit-upload [OPTIONS] <FILE>..."
+          }
+        ],
+        "longAbout": "Run Mergify CI Insights commands from your pipeline.\n\nHelpers meant to run inside a CI job: upload test reports, detect the build's git references, report the merge queue batch the build belongs to, and compute the scopes impacted by the changed files.",
+        "name": "ci",
+        "path": [
+          "mergify",
+          "ci"
+        ],
+        "source": "native",
+        "subcommandRequired": true,
+        "usage": "mergify ci [OPTIONS] <COMMAND>"
+      },
+      {
+        "about": "Inspect the tests tracked by Mergify CI Insights",
+        "aliases": [],
+        "args": [],
+        "commands": [
+          {
+            "about": "Look up tests by name and print their health and metrics",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Test name(s) to look up. Glob patterns (`*`, `?`) are supported by the API",
+                "id": "test_names",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "Test name(s) to look up. Glob patterns (`*`, `?`) are supported by the API",
+                "numArgs": "1..",
+                "possibleValues": [],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "NAME"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Repository full name (owner/repo). Detected from the CI environment or the local git remote when omitted",
+                "id": "repository",
+                "kind": "option",
+                "long": "repository",
+                "longHelp": "Repository full name (owner/repo). Detected from the CI environment or the local git remote when omitted",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "r",
+                "valueHint": null,
+                "valueNames": [
+                  "REPOSITORY"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+                "id": "token",
+                "kind": "option",
+                "long": "token",
+                "longHelp": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "t",
+                "valueHint": null,
+                "valueNames": [
+                  "TOKEN"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+                "id": "api_url",
+                "kind": "option",
+                "long": "api-url",
+                "longHelp": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "u",
+                "valueHint": null,
+                "valueNames": [
+                  "API_URL"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Restrict matches to the given pipeline name(s)",
+                "id": "pipeline_name",
+                "kind": "option",
+                "long": "pipeline-name",
+                "longHelp": "Restrict matches to the given pipeline name(s)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "PIPELINE_NAME"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Exclude matches from the given pipeline name(s)",
+                "id": "pipeline_name_exclude",
+                "kind": "option",
+                "long": "pipeline-name-exclude",
+                "longHelp": "Exclude matches from the given pipeline name(s)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "PIPELINE_NAME_EXCLUDE"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Restrict matches to the given job name(s)",
+                "id": "job_name",
+                "kind": "option",
+                "long": "job-name",
+                "longHelp": "Restrict matches to the given job name(s)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "JOB_NAME"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Exclude matches from the given job name(s)",
+                "id": "job_name_exclude",
+                "kind": "option",
+                "long": "job-name-exclude",
+                "longHelp": "Exclude matches from the given job name(s)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "JOB_NAME_EXCLUDE"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Maximum number of identities the search endpoint may return per page (1–100, server default is 10)",
+                "id": "per_page",
+                "kind": "option",
+                "long": "per-page",
+                "longHelp": "Maximum number of identities the search endpoint may return per page (1–100, server default is 10)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "PER_PAGE"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Emit a single JSON document to stdout instead of human prose",
+                "id": "json",
+                "kind": "flag",
+                "long": "json",
+                "longHelp": "Emit a single JSON document to stdout instead of human prose",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": []
+              }
+            ],
+            "commands": [],
+            "longAbout": "Look up tests by name and print their health and metrics.\n\nSearch CI Insights for one or more tests (by exact name or glob) and report their flakiness, failure rate, and recent history. Pass `--json` for machine-readable output.",
+            "name": "show",
+            "path": [
+              "mergify",
+              "tests",
+              "show"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify tests show [OPTIONS] <NAME>..."
+          },
+          {
+            "about": "Manage the CI Insights quarantine",
+            "aliases": [],
+            "args": [],
+            "commands": [
+              {
+                "about": "Add a test to the CI Insights quarantine",
+                "aliases": [],
+                "args": [
+                  {
+                    "default": null,
+                    "env": null,
+                    "global": false,
+                    "help": "Fully qualified name of the test to quarantine",
+                    "id": "test_name",
+                    "kind": "positional",
+                    "long": null,
+                    "longHelp": "Fully qualified name of the test to quarantine",
+                    "numArgs": "1",
+                    "possibleValues": [],
+                    "required": true,
+                    "short": null,
+                    "valueHint": null,
+                    "valueNames": [
+                      "NAME"
+                    ]
+                  },
+                  {
+                    "default": null,
+                    "env": null,
+                    "global": false,
+                    "help": "Repository full name (owner/repo). Detected from the CI environment or the local git remote when omitted",
+                    "id": "repository",
+                    "kind": "option",
+                    "long": "repository",
+                    "longHelp": "Repository full name (owner/repo). Detected from the CI environment or the local git remote when omitted",
+                    "numArgs": "1",
+                    "possibleValues": [],
+                    "required": false,
+                    "short": "r",
+                    "valueHint": null,
+                    "valueNames": [
+                      "REPOSITORY"
+                    ]
+                  },
+                  {
+                    "default": null,
+                    "env": null,
+                    "global": false,
+                    "help": "Reason recorded for quarantining the test",
+                    "id": "reason",
+                    "kind": "option",
+                    "long": "reason",
+                    "longHelp": "Reason recorded for quarantining the test",
+                    "numArgs": "1",
+                    "possibleValues": [],
+                    "required": true,
+                    "short": null,
+                    "valueHint": null,
+                    "valueNames": [
+                      "REASON"
+                    ]
+                  },
+                  {
+                    "default": null,
+                    "env": null,
+                    "global": false,
+                    "help": "Branch name or pattern to scope the quarantine to. Omit to quarantine on all branches",
+                    "id": "branch",
+                    "kind": "option",
+                    "long": "branch",
+                    "longHelp": "Branch name or pattern to scope the quarantine to. Omit to quarantine on all branches",
+                    "numArgs": "1",
+                    "possibleValues": [],
+                    "required": false,
+                    "short": "b",
+                    "valueHint": null,
+                    "valueNames": [
+                      "BRANCH"
+                    ]
+                  },
+                  {
+                    "default": null,
+                    "env": null,
+                    "global": false,
+                    "help": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+                    "id": "token",
+                    "kind": "option",
+                    "long": "token",
+                    "longHelp": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+                    "numArgs": "1",
+                    "possibleValues": [],
+                    "required": false,
+                    "short": "t",
+                    "valueHint": null,
+                    "valueNames": [
+                      "TOKEN"
+                    ]
+                  },
+                  {
+                    "default": null,
+                    "env": null,
+                    "global": false,
+                    "help": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+                    "id": "api_url",
+                    "kind": "option",
+                    "long": "api-url",
+                    "longHelp": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+                    "numArgs": "1",
+                    "possibleValues": [],
+                    "required": false,
+                    "short": "u",
+                    "valueHint": null,
+                    "valueNames": [
+                      "API_URL"
+                    ]
+                  },
+                  {
+                    "default": "false",
+                    "env": null,
+                    "global": false,
+                    "help": "Emit a single JSON document to stdout instead of human prose",
+                    "id": "json",
+                    "kind": "flag",
+                    "long": "json",
+                    "longHelp": "Emit a single JSON document to stdout instead of human prose",
+                    "numArgs": "0",
+                    "possibleValues": [],
+                    "required": false,
+                    "short": null,
+                    "valueHint": null,
+                    "valueNames": []
+                  }
+                ],
+                "commands": [],
+                "longAbout": "Add a test to the CI Insights quarantine.\n\nQuarantine a test by its fully qualified name so its failures stop blocking the merge queue. A reason is required; scope it to a branch with `--branch`, or quarantine on all branches by default.",
+                "name": "add",
+                "path": [
+                  "mergify",
+                  "tests",
+                  "quarantines",
+                  "add"
+                ],
+                "source": "native",
+                "subcommandRequired": false,
+                "usage": "mergify tests quarantines add [OPTIONS] --reason <REASON> <NAME>"
+              },
+              {
+                "about": "Remove a test from the CI Insights quarantine",
+                "aliases": [],
+                "args": [
+                  {
+                    "default": null,
+                    "env": null,
+                    "global": false,
+                    "help": "Test to remove from quarantine: either its fully qualified name or the quarantine id (as printed by `tests quarantines add`)",
+                    "id": "name_or_id",
+                    "kind": "positional",
+                    "long": null,
+                    "longHelp": "Test to remove from quarantine: either its fully qualified name or the quarantine id (as printed by `tests quarantines add`)",
+                    "numArgs": "1",
+                    "possibleValues": [],
+                    "required": true,
+                    "short": null,
+                    "valueHint": null,
+                    "valueNames": [
+                      "NAME_OR_ID"
+                    ]
+                  },
+                  {
+                    "default": null,
+                    "env": null,
+                    "global": false,
+                    "help": "Repository full name (owner/repo). Detected from the CI environment or the local git remote when omitted",
+                    "id": "repository",
+                    "kind": "option",
+                    "long": "repository",
+                    "longHelp": "Repository full name (owner/repo). Detected from the CI environment or the local git remote when omitted",
+                    "numArgs": "1",
+                    "possibleValues": [],
+                    "required": false,
+                    "short": "r",
+                    "valueHint": null,
+                    "valueNames": [
+                      "REPOSITORY"
+                    ]
+                  },
+                  {
+                    "default": null,
+                    "env": null,
+                    "global": false,
+                    "help": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+                    "id": "token",
+                    "kind": "option",
+                    "long": "token",
+                    "longHelp": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+                    "numArgs": "1",
+                    "possibleValues": [],
+                    "required": false,
+                    "short": "t",
+                    "valueHint": null,
+                    "valueNames": [
+                      "TOKEN"
+                    ]
+                  },
+                  {
+                    "default": null,
+                    "env": null,
+                    "global": false,
+                    "help": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+                    "id": "api_url",
+                    "kind": "option",
+                    "long": "api-url",
+                    "longHelp": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+                    "numArgs": "1",
+                    "possibleValues": [],
+                    "required": false,
+                    "short": "u",
+                    "valueHint": null,
+                    "valueNames": [
+                      "API_URL"
+                    ]
+                  },
+                  {
+                    "default": "false",
+                    "env": null,
+                    "global": false,
+                    "help": "Emit a single JSON document to stdout instead of human prose",
+                    "id": "json",
+                    "kind": "flag",
+                    "long": "json",
+                    "longHelp": "Emit a single JSON document to stdout instead of human prose",
+                    "numArgs": "0",
+                    "possibleValues": [],
+                    "required": false,
+                    "short": null,
+                    "valueHint": null,
+                    "valueNames": []
+                  }
+                ],
+                "commands": [],
+                "longAbout": "Remove a test from the CI Insights quarantine.\n\nTake a test out of the quarantine so its results count again. Identify it by test name or by quarantine id.",
+                "name": "remove",
+                "path": [
+                  "mergify",
+                  "tests",
+                  "quarantines",
+                  "remove"
+                ],
+                "source": "native",
+                "subcommandRequired": false,
+                "usage": "mergify tests quarantines remove [OPTIONS] <NAME_OR_ID>"
+              },
+              {
+                "about": "Print a single quarantine by test name or id",
+                "aliases": [],
+                "args": [
+                  {
+                    "default": null,
+                    "env": null,
+                    "global": false,
+                    "help": "Quarantine to print: either the test's fully qualified name or the quarantine id (as printed by `tests quarantines add`)",
+                    "id": "name_or_id",
+                    "kind": "positional",
+                    "long": null,
+                    "longHelp": "Quarantine to print: either the test's fully qualified name or the quarantine id (as printed by `tests quarantines add`)",
+                    "numArgs": "1",
+                    "possibleValues": [],
+                    "required": true,
+                    "short": null,
+                    "valueHint": null,
+                    "valueNames": [
+                      "NAME_OR_ID"
+                    ]
+                  },
+                  {
+                    "default": null,
+                    "env": null,
+                    "global": false,
+                    "help": "Repository full name (owner/repo). Detected from the CI environment or the local git remote when omitted",
+                    "id": "repository",
+                    "kind": "option",
+                    "long": "repository",
+                    "longHelp": "Repository full name (owner/repo). Detected from the CI environment or the local git remote when omitted",
+                    "numArgs": "1",
+                    "possibleValues": [],
+                    "required": false,
+                    "short": "r",
+                    "valueHint": null,
+                    "valueNames": [
+                      "REPOSITORY"
+                    ]
+                  },
+                  {
+                    "default": null,
+                    "env": null,
+                    "global": false,
+                    "help": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+                    "id": "token",
+                    "kind": "option",
+                    "long": "token",
+                    "longHelp": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+                    "numArgs": "1",
+                    "possibleValues": [],
+                    "required": false,
+                    "short": "t",
+                    "valueHint": null,
+                    "valueNames": [
+                      "TOKEN"
+                    ]
+                  },
+                  {
+                    "default": null,
+                    "env": null,
+                    "global": false,
+                    "help": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+                    "id": "api_url",
+                    "kind": "option",
+                    "long": "api-url",
+                    "longHelp": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+                    "numArgs": "1",
+                    "possibleValues": [],
+                    "required": false,
+                    "short": "u",
+                    "valueHint": null,
+                    "valueNames": [
+                      "API_URL"
+                    ]
+                  },
+                  {
+                    "default": "false",
+                    "env": null,
+                    "global": false,
+                    "help": "Emit a single JSON document to stdout instead of human prose",
+                    "id": "json",
+                    "kind": "flag",
+                    "long": "json",
+                    "longHelp": "Emit a single JSON document to stdout instead of human prose",
+                    "numArgs": "0",
+                    "possibleValues": [],
+                    "required": false,
+                    "short": null,
+                    "valueHint": null,
+                    "valueNames": []
+                  }
+                ],
+                "commands": [],
+                "longAbout": "Print a single quarantine by test name or id.\n\nShow the details of one quarantined test — its reason, branch scope, and when it was added. Identify it by test name or by quarantine id.",
+                "name": "get",
+                "path": [
+                  "mergify",
+                  "tests",
+                  "quarantines",
+                  "get"
+                ],
+                "source": "native",
+                "subcommandRequired": false,
+                "usage": "mergify tests quarantines get [OPTIONS] <NAME_OR_ID>"
+              },
+              {
+                "about": "List the tests currently in the CI Insights quarantine",
+                "aliases": [],
+                "args": [
+                  {
+                    "default": null,
+                    "env": null,
+                    "global": false,
+                    "help": "Repository full name (owner/repo). Detected from the CI environment or the local git remote when omitted",
+                    "id": "repository",
+                    "kind": "option",
+                    "long": "repository",
+                    "longHelp": "Repository full name (owner/repo). Detected from the CI environment or the local git remote when omitted",
+                    "numArgs": "1",
+                    "possibleValues": [],
+                    "required": false,
+                    "short": "r",
+                    "valueHint": null,
+                    "valueNames": [
+                      "REPOSITORY"
+                    ]
+                  },
+                  {
+                    "default": null,
+                    "env": null,
+                    "global": false,
+                    "help": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+                    "id": "token",
+                    "kind": "option",
+                    "long": "token",
+                    "longHelp": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+                    "numArgs": "1",
+                    "possibleValues": [],
+                    "required": false,
+                    "short": "t",
+                    "valueHint": null,
+                    "valueNames": [
+                      "TOKEN"
+                    ]
+                  },
+                  {
+                    "default": null,
+                    "env": null,
+                    "global": false,
+                    "help": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+                    "id": "api_url",
+                    "kind": "option",
+                    "long": "api-url",
+                    "longHelp": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+                    "numArgs": "1",
+                    "possibleValues": [],
+                    "required": false,
+                    "short": "u",
+                    "valueHint": null,
+                    "valueNames": [
+                      "API_URL"
+                    ]
+                  },
+                  {
+                    "default": "false",
+                    "env": null,
+                    "global": false,
+                    "help": "Emit a single JSON document to stdout instead of human prose",
+                    "id": "json",
+                    "kind": "flag",
+                    "long": "json",
+                    "longHelp": "Emit a single JSON document to stdout instead of human prose",
+                    "numArgs": "0",
+                    "possibleValues": [],
+                    "required": false,
+                    "short": null,
+                    "valueHint": null,
+                    "valueNames": []
+                  }
+                ],
+                "commands": [],
+                "longAbout": "List the tests currently in the CI Insights quarantine.\n\nPrint every test currently held in the quarantine for the repository. Pass `--json` for machine-readable output.",
+                "name": "list",
+                "path": [
+                  "mergify",
+                  "tests",
+                  "quarantines",
+                  "list"
+                ],
+                "source": "native",
+                "subcommandRequired": false,
+                "usage": "mergify tests quarantines list [OPTIONS]"
+              }
+            ],
+            "longAbout": "Manage the CI Insights quarantine.\n\nAdd, remove, inspect, and list the tests held in the CI Insights quarantine — the set of known-flaky tests whose failures are ignored so they don't block the merge queue.",
+            "name": "quarantines",
+            "path": [
+              "mergify",
+              "tests",
+              "quarantines"
+            ],
+            "source": "native",
+            "subcommandRequired": true,
+            "usage": "mergify tests quarantines [OPTIONS] <COMMAND>"
+          }
+        ],
+        "longAbout": "Inspect the tests tracked by Mergify CI Insights.\n\nLook up a test's health and flakiness metrics, and manage the quarantine that keeps known-flaky tests from failing the merge queue.",
+        "name": "tests",
+        "path": [
+          "mergify",
+          "tests"
+        ],
+        "source": "native",
+        "subcommandRequired": true,
+        "usage": "mergify tests [OPTIONS] <COMMAND>"
+      },
+      {
+        "about": "Inspect and control the Mergify merge queue",
+        "aliases": [],
+        "args": [
+          {
+            "default": null,
+            "env": null,
+            "global": true,
+            "help": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+            "id": "token",
+            "kind": "option",
+            "long": "token",
+            "longHelp": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+            "numArgs": "1",
+            "possibleValues": [],
+            "required": false,
+            "short": "t",
+            "valueHint": null,
+            "valueNames": [
+              "TOKEN"
+            ]
+          },
+          {
+            "default": null,
+            "env": null,
+            "global": true,
+            "help": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+            "id": "api_url",
+            "kind": "option",
+            "long": "api-url",
+            "longHelp": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+            "numArgs": "1",
+            "possibleValues": [],
+            "required": false,
+            "short": "u",
+            "valueHint": null,
+            "valueNames": [
+              "API_URL"
+            ]
+          },
+          {
+            "default": null,
+            "env": null,
+            "global": true,
+            "help": "Repository full name (owner/repo). Falls back to ``GITHUB_REPOSITORY`` env var",
+            "id": "repository",
+            "kind": "option",
+            "long": "repository",
+            "longHelp": "Repository full name (owner/repo). Falls back to ``GITHUB_REPOSITORY`` env var",
+            "numArgs": "1",
+            "possibleValues": [],
+            "required": false,
+            "short": "r",
+            "valueHint": null,
+            "valueNames": [
+              "REPOSITORY"
+            ]
+          }
+        ],
+        "commands": [
+          {
+            "about": "Pause the merge queue for the repository",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Reason for pausing the queue (max 255 characters)",
+                "id": "reason",
+                "kind": "option",
+                "long": "reason",
+                "longHelp": "Reason for pausing the queue (max 255 characters)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "REASON"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Skip the confirmation prompt. Required in non-interactive sessions",
+                "id": "yes_i_am_sure",
+                "kind": "flag",
+                "long": "yes-i-am-sure",
+                "longHelp": "Skip the confirmation prompt. Required in non-interactive sessions",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": []
+              }
+            ],
+            "commands": [],
+            "longAbout": "Pause the merge queue for the repository.\n\nStop the queue from merging any pull request until it is resumed — useful during an incident or release window. A reason is required and shown to your team; queued pull requests stay in place.",
+            "name": "pause",
+            "path": [
+              "mergify",
+              "queue",
+              "pause"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify queue pause [OPTIONS] --reason <REASON>"
+          },
+          {
+            "about": "Unpause the merge queue for the repository",
+            "aliases": [],
+            "args": [],
+            "commands": [],
+            "longAbout": "Unpause the merge queue for the repository.\n\nResume merging after a pause. The queue picks up where it left off with the pull requests still queued.",
+            "name": "unpause",
+            "path": [
+              "mergify",
+              "queue",
+              "unpause"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify queue unpause [OPTIONS]"
+          },
+          {
+            "about": "Show merge queue status for the repository",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Filter the queue by branch name",
+                "id": "branch",
+                "kind": "option",
+                "long": "branch",
+                "longHelp": "Filter the queue by branch name",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "b",
+                "valueHint": null,
+                "valueNames": [
+                  "BRANCH"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Emit the raw API response as a single JSON document",
+                "id": "json",
+                "kind": "flag",
+                "long": "json",
+                "longHelp": "Emit the raw API response as a single JSON document",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": []
+              }
+            ],
+            "commands": [],
+            "longAbout": "Show merge queue status for the repository.\n\nList the pull requests currently in the queue with their position and state. Filter by branch with `--branch`, or pass `--json` for machine-readable output.",
+            "name": "status",
+            "path": [
+              "mergify",
+              "queue",
+              "status"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify queue status [OPTIONS]"
+          },
+          {
+            "about": "Show detailed state of a pull request in the merge queue",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Pull request number to inspect",
+                "id": "pr_number",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "Pull request number to inspect",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "PR_NUMBER"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Emit the raw API response as a single JSON document",
+                "id": "json",
+                "kind": "flag",
+                "long": "json",
+                "longHelp": "Emit the raw API response as a single JSON document",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": []
+              }
+            ],
+            "commands": [],
+            "longAbout": "Show detailed state of a pull request in the merge queue.\n\nReport the full queue state of a single pull request: its checks, the conditions it still needs to satisfy, and why it is or isn't mergeable. Pass `--verbose` for the full checks table and conditions tree, or `--json` for the raw response.",
+            "name": "show",
+            "path": [
+              "mergify",
+              "queue",
+              "show"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify queue show [OPTIONS] <PR_NUMBER>"
+          }
+        ],
+        "longAbout": "Inspect and control the Mergify merge queue.\n\nCheck the status of queued pull requests, inspect a single pull request's queue state, and pause or resume merging for a repository.",
+        "name": "queue",
+        "path": [
+          "mergify",
+          "queue"
+        ],
+        "source": "native",
+        "subcommandRequired": true,
+        "usage": "mergify queue [OPTIONS] <COMMAND>"
+      },
+      {
+        "about": "Schedule and manage merge freezes",
+        "aliases": [],
+        "args": [
+          {
+            "default": null,
+            "env": null,
+            "global": true,
+            "help": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+            "id": "token",
+            "kind": "option",
+            "long": "token",
+            "longHelp": "Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and then ``GITHUB_TOKEN`` env vars",
+            "numArgs": "1",
+            "possibleValues": [],
+            "required": false,
+            "short": "t",
+            "valueHint": null,
+            "valueNames": [
+              "TOKEN"
+            ]
+          },
+          {
+            "default": null,
+            "env": null,
+            "global": true,
+            "help": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+            "id": "api_url",
+            "kind": "option",
+            "long": "api-url",
+            "longHelp": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+            "numArgs": "1",
+            "possibleValues": [],
+            "required": false,
+            "short": "u",
+            "valueHint": null,
+            "valueNames": [
+              "API_URL"
+            ]
+          },
+          {
+            "default": null,
+            "env": null,
+            "global": true,
+            "help": "Repository full name (owner/repo). Falls back to ``GITHUB_REPOSITORY`` env var",
+            "id": "repository",
+            "kind": "option",
+            "long": "repository",
+            "longHelp": "Repository full name (owner/repo). Falls back to ``GITHUB_REPOSITORY`` env var",
+            "numArgs": "1",
+            "possibleValues": [],
+            "required": false,
+            "short": "r",
+            "valueHint": null,
+            "valueNames": [
+              "REPOSITORY"
+            ]
+          }
+        ],
+        "commands": [
+          {
+            "about": "List scheduled freezes for a repository",
+            "aliases": [],
+            "args": [
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Emit the raw `scheduled_freezes` array as a single JSON document",
+                "id": "json",
+                "kind": "flag",
+                "long": "json",
+                "longHelp": "Emit the raw `scheduled_freezes` array as a single JSON document",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": []
+              }
+            ],
+            "commands": [],
+            "longAbout": "List scheduled freezes for a repository.\n\nShow the freezes currently configured for the repository, with their name, schedule, and state. Pass `--json` for machine-readable output.",
+            "name": "list",
+            "path": [
+              "mergify",
+              "freeze",
+              "list"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify freeze list [OPTIONS]"
+          },
+          {
+            "about": "Create a new scheduled freeze",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Reason for the freeze",
+                "id": "reason",
+                "kind": "option",
+                "long": "reason",
+                "longHelp": "Reason for the freeze",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "REASON"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "IANA timezone name (e.g. ``Europe/Paris``, ``US/Eastern``). Defaults to the system timezone when omitted",
+                "id": "timezone",
+                "kind": "option",
+                "long": "timezone",
+                "longHelp": "IANA timezone name (e.g. ``Europe/Paris``, ``US/Eastern``). Defaults to the system timezone when omitted",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "TIMEZONE"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Matching condition (repeatable, e.g. `-c base=main`)",
+                "id": "condition",
+                "kind": "option",
+                "long": "condition",
+                "longHelp": "Matching condition (repeatable, e.g. `-c base=main`)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "c",
+                "valueHint": null,
+                "valueNames": [
+                  "CONDITION"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Start time in ISO 8601 format (default: now)",
+                "id": "start",
+                "kind": "option",
+                "long": "start",
+                "longHelp": "Start time in ISO 8601 format (default: now)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "START"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "End time in ISO 8601 format (default: no end / emergency freeze)",
+                "id": "end",
+                "kind": "option",
+                "long": "end",
+                "longHelp": "End time in ISO 8601 format (default: no end / emergency freeze)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "END"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Exclude condition (repeatable, e.g. `-e label=hotfix`)",
+                "id": "exclude",
+                "kind": "option",
+                "long": "exclude",
+                "longHelp": "Exclude condition (repeatable, e.g. `-e label=hotfix`)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "e",
+                "valueHint": null,
+                "valueNames": [
+                  "EXCLUDE"
+                ]
+              }
+            ],
+            "commands": [],
+            "longAbout": "Create a new scheduled freeze.\n\nAdd a freeze that stops the merge queue from merging while it is active — for a release window, incident, or code freeze.",
+            "name": "create",
+            "path": [
+              "mergify",
+              "freeze",
+              "create"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify freeze create [OPTIONS] --reason <REASON>"
+          },
+          {
+            "about": "Update an existing scheduled freeze",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Freeze ID (UUID)",
+                "id": "freeze_id",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "Freeze ID (UUID)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "FREEZE_ID"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Reason for the freeze",
+                "id": "reason",
+                "kind": "option",
+                "long": "reason",
+                "longHelp": "Reason for the freeze",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "REASON"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "IANA timezone name",
+                "id": "timezone",
+                "kind": "option",
+                "long": "timezone",
+                "longHelp": "IANA timezone name",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "TIMEZONE"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Matching condition (repeatable, e.g. `-c base=main`). Passing the flag one or more times replaces the existing list with the values supplied. Omitting `-c` entirely leaves the stored list untouched",
+                "id": "condition",
+                "kind": "option",
+                "long": "condition",
+                "longHelp": "Matching condition (repeatable, e.g. `-c base=main`). Passing the flag one or more times replaces the existing list with the values supplied. Omitting `-c` entirely leaves the stored list untouched",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "c",
+                "valueHint": null,
+                "valueNames": [
+                  "CONDITION"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Start time in ISO 8601 format",
+                "id": "start",
+                "kind": "option",
+                "long": "start",
+                "longHelp": "Start time in ISO 8601 format",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "START"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "End time in ISO 8601 format",
+                "id": "end",
+                "kind": "option",
+                "long": "end",
+                "longHelp": "End time in ISO 8601 format",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "END"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Exclude condition (repeatable)",
+                "id": "exclude",
+                "kind": "option",
+                "long": "exclude",
+                "longHelp": "Exclude condition (repeatable)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "e",
+                "valueHint": null,
+                "valueNames": [
+                  "EXCLUDE"
+                ]
+              }
+            ],
+            "commands": [],
+            "longAbout": "Update an existing scheduled freeze.\n\nChange the settings of an existing freeze, identified by its ID. Only the fields you pass are changed; the rest are left as they are.",
+            "name": "update",
+            "path": [
+              "mergify",
+              "freeze",
+              "update"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify freeze update [OPTIONS] <FREEZE_ID>"
+          },
+          {
+            "about": "Delete a scheduled freeze",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Freeze ID (UUID)",
+                "id": "freeze_id",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "Freeze ID (UUID)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "FREEZE_ID"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Reason for deleting the freeze (required if the freeze is currently active)",
+                "id": "delete_reason",
+                "kind": "option",
+                "long": "reason",
+                "longHelp": "Reason for deleting the freeze (required if the freeze is currently active)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "DELETE_REASON"
+                ]
+              }
+            ],
+            "commands": [],
+            "longAbout": "Delete a scheduled freeze.\n\nRemove a freeze by its ID. If the freeze is currently active a reason is required, and the queue resumes merging once it's gone.",
+            "name": "delete",
+            "path": [
+              "mergify",
+              "freeze",
+              "delete"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify freeze delete [OPTIONS] <FREEZE_ID>"
+          }
+        ],
+        "longAbout": "Schedule and manage merge freezes.\n\nCreate, list, update, and delete freezes that temporarily stop the merge queue from merging — for release windows, incidents, or code freezes.",
+        "name": "freeze",
+        "path": [
+          "mergify",
+          "freeze"
+        ],
+        "source": "native",
+        "subcommandRequired": true,
+        "usage": "mergify freeze [OPTIONS] <COMMAND>"
+      },
+      {
+        "about": "Create and maintain stacked pull requests",
+        "aliases": [],
+        "args": [],
+        "commands": [
+          {
+            "about": "Create a new stack branch",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Name of the new branch",
+                "id": "name",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "Name of the new branch",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "NAME"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Base branch to fork from, formatted as `REMOTE/BRANCH` (e.g. `origin/main`). When omitted, the trunk is resolved from the current branch's tracking info or `refs/remotes/origin/HEAD`",
+                "id": "base",
+                "kind": "option",
+                "long": "base",
+                "longHelp": "Base branch to fork from, formatted as `REMOTE/BRANCH` (e.g. `origin/main`). When omitted, the trunk is resolved from the current branch's tracking info or `refs/remotes/origin/HEAD`",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "b",
+                "valueHint": null,
+                "valueNames": [
+                  "BASE"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Checkout the new branch after creation. This is the default. Pass `--no-checkout` to keep the current branch checked out",
+                "id": "checkout",
+                "kind": "flag",
+                "long": "checkout",
+                "longHelp": "Checkout the new branch after creation. This is the default. Pass `--no-checkout` to keep the current branch checked out",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": []
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Leave the current branch checked out and just create the new branch ref",
+                "id": "no_checkout",
+                "kind": "flag",
+                "long": "no-checkout",
+                "longHelp": "Leave the current branch checked out and just create the new branch ref",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": []
+              }
+            ],
+            "commands": [],
+            "longAbout": "Create a new stack branch.\n\nCreate a branch that tracks your trunk and start a fresh stack on top of it. The new branch is checked out by default; pass `--no-checkout` to only create the ref and stay on the current branch.",
+            "name": "new",
+            "path": [
+              "mergify",
+              "stack",
+              "new"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify stack new [OPTIONS] <NAME>"
+          },
+          {
+            "about": "Attach a note explaining why a commit was amended",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Target commit. Accepts a SHA prefix, a ref (`HEAD~1`, branch name, …), or a Change-Id prefix (resolved against the stack walk). Defaults to HEAD",
+                "id": "commit",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "Target commit. Accepts a SHA prefix, a ref (`HEAD~1`, branch name, …), or a Change-Id prefix (resolved against the stack walk). Defaults to HEAD",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "COMMIT"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Note message. If omitted, opens `$GIT_EDITOR` / `$VISUAL` / `$EDITOR` / `vi` on a tempfile",
+                "id": "message",
+                "kind": "option",
+                "long": "message",
+                "longHelp": "Note message. If omitted, opens `$GIT_EDITOR` / `$VISUAL` / `$EDITOR` / `vi` on a tempfile",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "m",
+                "valueHint": null,
+                "valueNames": [
+                  "MESSAGE"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Append to an existing note instead of replacing",
+                "id": "append",
+                "kind": "flag",
+                "long": "append",
+                "longHelp": "Append to an existing note instead of replacing",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": []
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Remove the note on the target commit. Mutually exclusive with `--message` and `--append`",
+                "id": "remove",
+                "kind": "flag",
+                "long": "remove",
+                "longHelp": "Remove the note on the target commit. Mutually exclusive with `--message` and `--append`",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": []
+              }
+            ],
+            "commands": [],
+            "longAbout": "Attach a note explaining why a commit was amended.\n\nRecord a note on a stack commit describing why it changed; the note is surfaced when reviewing the stack. Edit it in your editor or pass `-m`, add to an existing note with `--append`, or clear it with `--remove`. Defaults to the commit at HEAD.",
+            "name": "note",
+            "path": [
+              "mergify",
+              "stack",
+              "note"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify stack note [OPTIONS] [COMMIT]"
+          },
+          {
+            "about": "Edit a commit in the stack",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Commit to pause the rebase on. Accepts a SHA prefix or a Change-Id prefix; omit for a fully interactive rebase",
+                "id": "commit",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "Commit to pause the rebase on. Accepts a SHA prefix or a Change-Id prefix; omit for a fully interactive rebase",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "COMMIT"
+                ]
+              }
+            ],
+            "commands": [],
+            "longAbout": "Edit a commit in the stack.\n\nPause an interactive rebase on the target commit so you can amend it, then resume. Omit the commit to start a fully interactive rebase of the whole stack.",
+            "name": "edit",
+            "path": [
+              "mergify",
+              "stack",
+              "edit"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify stack edit [OPTIONS] [COMMIT]"
+          },
+          {
+            "about": "Drop commits from the stack",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Commits to drop. Each accepts a SHA prefix or a Change-Id prefix",
+                "id": "commits",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "Commits to drop. Each accepts a SHA prefix or a Change-Id prefix",
+                "numArgs": "1..",
+                "possibleValues": [],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "COMMITS"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Show the plan without dropping",
+                "id": "dry_run",
+                "kind": "flag",
+                "long": "dry-run",
+                "longHelp": "Show the plan without dropping",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": "n",
+                "valueHint": null,
+                "valueNames": []
+              }
+            ],
+            "commands": [],
+            "longAbout": "Drop commits from the stack.\n\nRemove one or more commits from the stack and rebase the commits above them down. Each accepts a SHA prefix or a Change-Id prefix. Use `--dry-run` to preview the resulting order first.",
+            "name": "drop",
+            "path": [
+              "mergify",
+              "stack",
+              "drop"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify stack drop [OPTIONS] <COMMITS>..."
+          },
+          {
+            "about": "Fold commits into their parent",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Commits to fold into their parent",
+                "id": "commits",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "Commits to fold into their parent",
+                "numArgs": "1..",
+                "possibleValues": [],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "COMMITS"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Show the plan without rebasing",
+                "id": "dry_run",
+                "kind": "flag",
+                "long": "dry-run",
+                "longHelp": "Show the plan without rebasing",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": "n",
+                "valueHint": null,
+                "valueNames": []
+              }
+            ],
+            "commands": [],
+            "longAbout": "Fold commits into their parent.\n\nSquash each given commit into the commit below it, discarding the folded commit's message (the parent's message is kept). Each accepts a SHA prefix or a Change-Id prefix. Use `--dry-run` to preview.",
+            "name": "fixup",
+            "path": [
+              "mergify",
+              "stack",
+              "fixup"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify stack fixup [OPTIONS] <COMMITS>..."
+          },
+          {
+            "about": "Change a commit's message",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Commit to reword. Accepts a SHA prefix or a Change-Id prefix",
+                "id": "commit",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "Commit to reword. Accepts a SHA prefix or a Change-Id prefix",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "COMMIT"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "New message. When omitted, `git rebase -i` pauses at the target and opens `$GIT_EDITOR`",
+                "id": "message",
+                "kind": "option",
+                "long": "message",
+                "longHelp": "New message. When omitted, `git rebase -i` pauses at the target and opens `$GIT_EDITOR`",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "m",
+                "valueHint": null,
+                "valueNames": [
+                  "MESSAGE"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Show the plan without rebasing",
+                "id": "dry_run",
+                "kind": "flag",
+                "long": "dry-run",
+                "longHelp": "Show the plan without rebasing",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": "n",
+                "valueHint": null,
+                "valueNames": []
+              }
+            ],
+            "commands": [],
+            "longAbout": "Change a commit's message.\n\nRewrite the message of a commit in the stack. Pass `-m` to set the new message inline, or omit it to edit the message in your editor. Use `--dry-run` to preview.",
+            "name": "reword",
+            "path": [
+              "mergify",
+              "stack",
+              "reword"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify stack reword [OPTIONS] <COMMIT>"
+          },
+          {
+            "about": "Reorder the stack's commits",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Commits in the order you want them rebased into",
+                "id": "commits",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "Commits in the order you want them rebased into",
+                "numArgs": "1..",
+                "possibleValues": [],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "COMMITS"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Show the plan without reordering",
+                "id": "dry_run",
+                "kind": "flag",
+                "long": "dry-run",
+                "longHelp": "Show the plan without reordering",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": "n",
+                "valueHint": null,
+                "valueNames": []
+              }
+            ],
+            "commands": [],
+            "longAbout": "Reorder the stack's commits.\n\nRebase the stack into the commit order you list. Commits you don't mention keep their relative order. Each accepts a SHA prefix or a Change-Id prefix. Use `--dry-run` to preview.",
+            "name": "reorder",
+            "path": [
+              "mergify",
+              "stack",
+              "reorder"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify stack reorder [OPTIONS] <COMMITS>..."
+          },
+          {
+            "about": "Move a commit within the stack",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Commit to move. Accepts a SHA prefix or a Change-Id prefix",
+                "id": "commit",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "Commit to move. Accepts a SHA prefix or a Change-Id prefix",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "COMMIT"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Where to put it: `first`, `last`, `before`, `after`",
+                "id": "position",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "Where to put it: `first`, `last`, `before`, `after`",
+                "numArgs": "1",
+                "possibleValues": [
+                  {
+                    "help": null,
+                    "name": "first"
+                  },
+                  {
+                    "help": null,
+                    "name": "last"
+                  },
+                  {
+                    "help": null,
+                    "name": "before"
+                  },
+                  {
+                    "help": null,
+                    "name": "after"
+                  }
+                ],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "POSITION"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Required when `position` is `before` or `after`",
+                "id": "target",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "Required when `position` is `before` or `after`",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "TARGET"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Show the plan without moving",
+                "id": "dry_run",
+                "kind": "flag",
+                "long": "dry-run",
+                "longHelp": "Show the plan without moving",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": "n",
+                "valueHint": null,
+                "valueNames": []
+              }
+            ],
+            "commands": [],
+            "longAbout": "Move a commit within the stack.\n\nMove one commit to a new position in the stack: to the `first` or `last` slot, or `before`/`after` another commit (passed as TARGET). Use `--dry-run` to preview.",
+            "name": "move",
+            "path": [
+              "mergify",
+              "stack",
+              "move"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify stack move [OPTIONS] <COMMIT> <POSITION> [TARGET]"
+          },
+          {
+            "about": "Squash commits into a target commit",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "`SRC1 SRC2 ... into TARGET` — must contain exactly one `into` token; everything before is a source, the single token after is the target",
+                "id": "tokens",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "`SRC1 SRC2 ... into TARGET` — must contain exactly one `into` token; everything before is a source, the single token after is the target",
+                "numArgs": "3..",
+                "possibleValues": [],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "TOKENS"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Final commit message (required to rename; otherwise the target's message is kept)",
+                "id": "message",
+                "kind": "option",
+                "long": "message",
+                "longHelp": "Final commit message (required to rename; otherwise the target's message is kept)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "m",
+                "valueHint": null,
+                "valueNames": [
+                  "MESSAGE"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Show the plan without rebasing",
+                "id": "dry_run",
+                "kind": "flag",
+                "long": "dry-run",
+                "longHelp": "Show the plan without rebasing",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": "n",
+                "valueHint": null,
+                "valueNames": []
+              }
+            ],
+            "commands": [],
+            "longAbout": "Squash commits into a target commit.\n\nFold one or more source commits into a target commit, reordering them adjacent to it first. Use the form `SRC... into TARGET`. Pass `-m` to set the combined message; otherwise the target's message is kept. Use `--dry-run` to preview.",
+            "name": "squash",
+            "path": [
+              "mergify",
+              "stack",
+              "squash"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify stack squash [OPTIONS] <TOKENS> <TOKENS> <TOKENS>..."
+          },
+          {
+            "about": "Check out a pull request stack from GitHub",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Name of the stack to check out",
+                "id": "name",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "Name of the stack to check out",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": true,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "NAME"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Author of the stack. Defaults to the token's user",
+                "id": "author",
+                "kind": "option",
+                "long": "author",
+                "longHelp": "Author of the stack. Defaults to the token's user",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "AUTHOR"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "`owner/repo`. Falls back to the URL of `--trunk`'s remote",
+                "id": "repository",
+                "kind": "option",
+                "long": "repository",
+                "longHelp": "`owner/repo`. Falls back to the URL of `--trunk`'s remote",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "REPOSITORY"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Local branch name. Defaults to the normalised NAME",
+                "id": "branch",
+                "kind": "option",
+                "long": "branch",
+                "longHelp": "Local branch name. Defaults to the normalised NAME",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "BRANCH"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Override the stack branch prefix",
+                "id": "branch_prefix",
+                "kind": "option",
+                "long": "branch-prefix",
+                "longHelp": "Override the stack branch prefix",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "BRANCH_PREFIX"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Show the plan without checking out",
+                "id": "dry_run",
+                "kind": "flag",
+                "long": "dry-run",
+                "longHelp": "Show the plan without checking out",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": "n",
+                "valueHint": null,
+                "valueNames": []
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Target trunk as `REMOTE/BRANCH`. Defaults to the resolved trunk for the current branch",
+                "id": "trunk",
+                "kind": "option",
+                "long": "trunk",
+                "longHelp": "Target trunk as `REMOTE/BRANCH`. Defaults to the resolved trunk for the current branch",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "t",
+                "valueHint": null,
+                "valueNames": [
+                  "TRUNK"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "GitHub token (falls back to `MERGIFY_TOKEN` / `GITHUB_TOKEN` / `gh auth token`)",
+                "id": "token",
+                "kind": "option",
+                "long": "token",
+                "longHelp": "GitHub token (falls back to `MERGIFY_TOKEN` / `GITHUB_TOKEN` / `gh auth token`)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "TOKEN"
+                ]
+              }
+            ],
+            "commands": [],
+            "longAbout": "Check out a pull request stack from GitHub.\n\nFetch a stack of pull requests by name and create a local branch that tracks its leaf, so you can continue working on a stack created elsewhere (a teammate's, or your own from another machine).",
+            "name": "checkout",
+            "path": [
+              "mergify",
+              "stack",
+              "checkout"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify stack checkout [OPTIONS] <NAME>"
+          },
+          {
+            "about": "Sync the stack with its trunk",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Author of the stack. Defaults to the token's user",
+                "id": "author",
+                "kind": "option",
+                "long": "author",
+                "longHelp": "Author of the stack. Defaults to the token's user",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "AUTHOR"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "`owner/repo`. Falls back to the URL of `--trunk`'s remote",
+                "id": "repository",
+                "kind": "option",
+                "long": "repository",
+                "longHelp": "`owner/repo`. Falls back to the URL of `--trunk`'s remote",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "REPOSITORY"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Override the stack branch prefix",
+                "id": "branch_prefix",
+                "kind": "option",
+                "long": "branch-prefix",
+                "longHelp": "Override the stack branch prefix",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "BRANCH_PREFIX"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Show the plan without changing anything",
+                "id": "dry_run",
+                "kind": "flag",
+                "long": "dry-run",
+                "longHelp": "Show the plan without changing anything",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": "n",
+                "valueHint": null,
+                "valueNames": []
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Target trunk as `REMOTE/BRANCH`. Defaults to the resolved trunk for the current branch",
+                "id": "trunk",
+                "kind": "option",
+                "long": "trunk",
+                "longHelp": "Target trunk as `REMOTE/BRANCH`. Defaults to the resolved trunk for the current branch",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "t",
+                "valueHint": null,
+                "valueNames": [
+                  "TRUNK"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "GitHub token (falls back to `MERGIFY_TOKEN` / `GITHUB_TOKEN` / `gh auth token`)",
+                "id": "token",
+                "kind": "option",
+                "long": "token",
+                "longHelp": "GitHub token (falls back to `MERGIFY_TOKEN` / `GITHUB_TOKEN` / `gh auth token`)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "TOKEN"
+                ]
+              }
+            ],
+            "commands": [],
+            "longAbout": "Sync the stack with its trunk.\n\nFetch the latest trunk, drop commits whose pull request has already merged, and rebase the remaining stack on top. Use `--dry-run` to preview.",
+            "name": "sync",
+            "path": [
+              "mergify",
+              "stack",
+              "sync"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify stack sync [OPTIONS]"
+          },
+          {
+            "about": "Push the stack and create or update its pull requests",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Author of the stack. Defaults to the token's user",
+                "id": "author",
+                "kind": "option",
+                "long": "author",
+                "longHelp": "Author of the stack. Defaults to the token's user",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "AUTHOR"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "`owner/repo`. Falls back to the URL of `--trunk`'s remote",
+                "id": "repository",
+                "kind": "option",
+                "long": "repository",
+                "longHelp": "`owner/repo`. Falls back to the URL of `--trunk`'s remote",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "REPOSITORY"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Override the stack branch prefix",
+                "id": "branch_prefix",
+                "kind": "option",
+                "long": "branch-prefix",
+                "longHelp": "Override the stack branch prefix",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "BRANCH_PREFIX"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Target trunk as `REMOTE/BRANCH`. Defaults to the resolved trunk for the current branch",
+                "id": "trunk",
+                "kind": "option",
+                "long": "trunk",
+                "longHelp": "Target trunk as `REMOTE/BRANCH`. Defaults to the resolved trunk for the current branch",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "t",
+                "valueHint": null,
+                "valueNames": [
+                  "TRUNK"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "GitHub token (falls back to `MERGIFY_TOKEN` / `GITHUB_TOKEN` / `gh auth token`)",
+                "id": "token",
+                "kind": "option",
+                "long": "token",
+                "longHelp": "GitHub token (falls back to `MERGIFY_TOKEN` / `GITHUB_TOKEN` / `gh auth token`)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "TOKEN"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Skip the rebase step. By default `stack push` rebases on trunk before pushing when there are no approvals to dismiss",
+                "id": "skip_rebase",
+                "kind": "flag",
+                "long": "skip-rebase",
+                "longHelp": "Skip the rebase step. By default `stack push` rebases on trunk before pushing when there are no approvals to dismiss",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": "R",
+                "valueHint": null,
+                "valueNames": []
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Force the rebase even when PRs are approved (the rebase will dismiss the reviews). Mutually exclusive with `--skip-rebase`",
+                "id": "force_rebase",
+                "kind": "flag",
+                "long": "force-rebase",
+                "longHelp": "Force the rebase even when PRs are approved (the rebase will dismiss the reviews). Mutually exclusive with `--skip-rebase`",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": []
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Only push the bottom commit of the stack",
+                "id": "next_only",
+                "kind": "flag",
+                "long": "next-only",
+                "longHelp": "Only push the bottom commit of the stack",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": "x",
+                "valueHint": null,
+                "valueNames": []
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Dry-run: render the plan + the rebase decision and exit",
+                "id": "dry_run",
+                "kind": "flag",
+                "long": "dry-run",
+                "longHelp": "Dry-run: render the plan + the rebase decision and exit",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": "n",
+                "valueHint": null,
+                "valueNames": []
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Open new PRs as drafts. Default falls back to git config `mergify-cli.stack-create-as-draft` (`false` when unset)",
+                "id": "create_as_draft",
+                "kind": "option",
+                "long": "draft",
+                "longHelp": "Open new PRs as drafts. Default falls back to git config `mergify-cli.stack-create-as-draft` (`false` when unset)",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": "d",
+                "valueHint": null,
+                "valueNames": [
+                  "CREATE_AS_DRAFT"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Don't rewrite the PR title + body from the commit message; only update the rendered Depends-On chain in the body. Default falls back to git config `mergify-cli.stack-keep-pr-title-body` (`false` when unset)",
+                "id": "keep_pull_request_title_and_body",
+                "kind": "option",
+                "long": "keep-pull-request-title-and-body",
+                "longHelp": "Don't rewrite the PR title + body from the commit message; only update the rendered Depends-On chain in the body. Default falls back to git config `mergify-cli.stack-keep-pr-title-body` (`false` when unset)",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": "k",
+                "valueHint": null,
+                "valueNames": [
+                  "KEEP_PULL_REQUEST_TITLE_AND_BODY"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Don't create new PRs; surface would-be-created ones in the plan instead",
+                "id": "only_update_existing_pulls",
+                "kind": "flag",
+                "long": "only-update-existing-pulls",
+                "longHelp": "Don't create new PRs; surface would-be-created ones in the plan instead",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": "u",
+                "valueHint": null,
+                "valueNames": []
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Suppress the revision-history sticky comment update. Default falls back to git config `mergify-cli.stack-revision-history` (`true` when unset)",
+                "id": "revision_history",
+                "kind": "option",
+                "long": "no-revision-history",
+                "longHelp": "Suppress the revision-history sticky comment update. Default falls back to git config `mergify-cli.stack-revision-history` (`true` when unset)",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "REVISION_HISTORY"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Pass `--no-verify` to `git push` (skips local pre-push hooks)",
+                "id": "no_verify",
+                "kind": "flag",
+                "long": "no-verify",
+                "longHelp": "Pass `--no-verify` to `git push` (skips local pre-push hooks)",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": []
+              }
+            ],
+            "commands": [],
+            "longAbout": "Push the stack and create or update its pull requests.\n\nWalk the local stack, optionally rebase it on trunk, push each commit to its own branch, and create or update the matching pull request and its Depends-On chain on GitHub. Use `--dry-run` to preview the plan and the rebase decision without touching anything.",
+            "name": "push",
+            "path": [
+              "mergify",
+              "stack",
+              "push"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify stack push [OPTIONS]"
+          },
+          {
+            "about": "List the stack's commits and their pull requests",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Author of the stack. Defaults to the token's user",
+                "id": "author",
+                "kind": "option",
+                "long": "author",
+                "longHelp": "Author of the stack. Defaults to the token's user",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "AUTHOR"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "`owner/repo`. Falls back to the URL of `--trunk`'s remote",
+                "id": "repository",
+                "kind": "option",
+                "long": "repository",
+                "longHelp": "`owner/repo`. Falls back to the URL of `--trunk`'s remote",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "REPOSITORY"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Override the stack branch prefix",
+                "id": "branch_prefix",
+                "kind": "option",
+                "long": "branch-prefix",
+                "longHelp": "Override the stack branch prefix",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "BRANCH_PREFIX"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Target trunk as `REMOTE/BRANCH`. Defaults to the resolved trunk for the current branch",
+                "id": "trunk",
+                "kind": "option",
+                "long": "trunk",
+                "longHelp": "Target trunk as `REMOTE/BRANCH`. Defaults to the resolved trunk for the current branch",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "t",
+                "valueHint": null,
+                "valueNames": [
+                  "TRUNK"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "GitHub token (falls back to `MERGIFY_TOKEN` / `GITHUB_TOKEN` / `gh auth token`)",
+                "id": "token",
+                "kind": "option",
+                "long": "token",
+                "longHelp": "GitHub token (falls back to `MERGIFY_TOKEN` / `GITHUB_TOKEN` / `gh auth token`)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "TOKEN"
+                ]
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Emit machine-readable JSON",
+                "id": "json",
+                "kind": "flag",
+                "long": "json",
+                "longHelp": "Emit machine-readable JSON",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": []
+              }
+            ],
+            "commands": [],
+            "longAbout": "List the stack's commits and their pull requests.\n\nShow each commit in the current stack alongside its pull request, CI, and review state. Pass `--verbose` for per-check and per-reviewer detail, or `--json` for machine-readable output.",
+            "name": "list",
+            "path": [
+              "mergify",
+              "stack",
+              "list"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify stack list [OPTIONS]"
+          },
+          {
+            "about": "Open a stack commit's pull request in the browser",
+            "aliases": [],
+            "args": [
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Commit whose pull request to open. Accepts a SHA prefix or a Change-Id prefix; defaults to HEAD",
+                "id": "commit",
+                "kind": "positional",
+                "long": null,
+                "longHelp": "Commit whose pull request to open. Accepts a SHA prefix or a Change-Id prefix; defaults to HEAD",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "COMMIT"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Author of the stack. Defaults to the token's user",
+                "id": "author",
+                "kind": "option",
+                "long": "author",
+                "longHelp": "Author of the stack. Defaults to the token's user",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "AUTHOR"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "`owner/repo`. Falls back to the URL of `--trunk`'s remote",
+                "id": "repository",
+                "kind": "option",
+                "long": "repository",
+                "longHelp": "`owner/repo`. Falls back to the URL of `--trunk`'s remote",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "REPOSITORY"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Override the stack branch prefix",
+                "id": "branch_prefix",
+                "kind": "option",
+                "long": "branch-prefix",
+                "longHelp": "Override the stack branch prefix",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "BRANCH_PREFIX"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Target trunk as `REMOTE/BRANCH`. Defaults to the resolved trunk for the current branch",
+                "id": "trunk",
+                "kind": "option",
+                "long": "trunk",
+                "longHelp": "Target trunk as `REMOTE/BRANCH`. Defaults to the resolved trunk for the current branch",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": "t",
+                "valueHint": null,
+                "valueNames": [
+                  "TRUNK"
+                ]
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "GitHub token (falls back to `MERGIFY_TOKEN` / `GITHUB_TOKEN` / `gh auth token`)",
+                "id": "token",
+                "kind": "option",
+                "long": "token",
+                "longHelp": "GitHub token (falls back to `MERGIFY_TOKEN` / `GITHUB_TOKEN` / `gh auth token`)",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "TOKEN"
+                ]
+              }
+            ],
+            "commands": [],
+            "longAbout": "Open a stack commit's pull request in the browser.\n\nOpen the GitHub pull request for a commit in the stack in your default browser. Defaults to the commit at HEAD.",
+            "name": "open",
+            "path": [
+              "mergify",
+              "stack",
+              "open"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify stack open [OPTIONS] [COMMIT]"
+          },
+          {
+            "about": "Show or install the stack git hooks",
+            "aliases": [],
+            "args": [
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Install or upgrade hooks",
+                "id": "do_setup",
+                "kind": "flag",
+                "long": "setup",
+                "longHelp": "Install or upgrade hooks",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": []
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Force reinstall wrappers (use with --setup)",
+                "id": "force",
+                "kind": "flag",
+                "long": "force",
+                "longHelp": "Force reinstall wrappers (use with --setup)",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": "f",
+                "valueHint": null,
+                "valueNames": []
+              }
+            ],
+            "commands": [],
+            "longAbout": "Show or install the stack git hooks.\n\nReport the status of the git hooks that keep `Change-Id` trailers on your commits (stacks rely on them to track commits across rebases). Pass `--setup` to install or upgrade them.",
+            "name": "hooks",
+            "path": [
+              "mergify",
+              "stack",
+              "hooks"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify stack hooks [OPTIONS]"
+          },
+          {
+            "about": "Install the stack git hooks",
+            "aliases": [],
+            "args": [
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Force reinstall of hook wrappers, even if user modified them",
+                "id": "force",
+                "kind": "flag",
+                "long": "force",
+                "longHelp": "Force reinstall of hook wrappers, even if user modified them",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": "f",
+                "valueHint": null,
+                "valueNames": []
+              },
+              {
+                "default": "false",
+                "env": null,
+                "global": false,
+                "help": "Check status only (use 'stack hooks' instead)",
+                "id": "check",
+                "kind": "flag",
+                "long": "check",
+                "longHelp": "Check status only (use 'stack hooks' instead)",
+                "numArgs": "0",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": []
+              }
+            ],
+            "commands": [],
+            "longAbout": "Install the stack git hooks.\n\nInstall or upgrade the git hooks that add `Change-Id` trailers to your commits. This is an alias for `stack hooks --setup`; pass `--check` to report status instead of installing.",
+            "name": "setup",
+            "path": [
+              "mergify",
+              "stack",
+              "setup"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify stack setup [OPTIONS]"
+          }
+        ],
+        "longAbout": "Create and maintain stacked pull requests.\n\nManage a stack of dependent branches and their pull requests: create, push, sync, reorder, reword, squash, and check out stacks built on top of your trunk.",
+        "name": "stack",
+        "path": [
+          "mergify",
+          "stack"
+        ],
+        "source": "native",
+        "subcommandRequired": true,
+        "usage": "mergify stack [OPTIONS] <COMMAND>"
+      },
+      {
+        "about": "Update mergify to the latest release",
+        "aliases": [],
+        "args": [
+          {
+            "default": "false",
+            "env": null,
+            "global": false,
+            "help": "Re-download and re-install even when the running binary already matches the latest release tag. Useful for repairing a corrupted install without bumping the version",
+            "id": "force",
+            "kind": "flag",
+            "long": "force",
+            "longHelp": "Re-download and re-install even when the running binary already matches the latest release tag. Useful for repairing a corrupted install without bumping the version",
+            "numArgs": "0",
+            "possibleValues": [],
+            "required": false,
+            "short": null,
+            "valueHint": null,
+            "valueNames": []
+          },
+          {
+            "default": "false",
+            "env": null,
+            "global": false,
+            "help": "Print the current and latest release tags and exit without touching the binary",
+            "id": "check",
+            "kind": "flag",
+            "long": "check",
+            "longHelp": "Print the current and latest release tags and exit without touching the binary",
+            "numArgs": "0",
+            "possibleValues": [],
+            "required": false,
+            "short": null,
+            "valueHint": null,
+            "valueNames": []
+          }
+        ],
+        "commands": [],
+        "longAbout": "Update mergify to the latest release.\n\nDownload the newest published binary, verify it against the release `SHA256SUMS`, and atomically replace the running executable. Uses the same artifact and checksum contract as the `curl | sh` installer.",
+        "name": "self-update",
+        "path": [
+          "mergify",
+          "self-update"
+        ],
+        "source": "native",
+        "subcommandRequired": false,
+        "usage": "mergify self-update [OPTIONS]"
+      },
+      {
+        "about": "Print a shell completion script (e.g. `mergify completions zsh`)",
+        "aliases": [],
+        "args": [
+          {
+            "default": null,
+            "env": null,
+            "global": false,
+            "help": "Shell to generate a completion script for",
+            "id": "shell",
+            "kind": "positional",
+            "long": null,
+            "longHelp": "Shell to generate a completion script for",
+            "numArgs": "1",
+            "possibleValues": [
+              {
+                "help": null,
+                "name": "bash"
+              },
+              {
+                "help": null,
+                "name": "elvish"
+              },
+              {
+                "help": null,
+                "name": "fish"
+              },
+              {
+                "help": null,
+                "name": "powershell"
+              },
+              {
+                "help": null,
+                "name": "zsh"
+              }
+            ],
+            "required": true,
+            "short": null,
+            "valueHint": null,
+            "valueNames": [
+              "SHELL"
+            ]
+          }
+        ],
+        "commands": [],
+        "longAbout": "Print a shell completion script (e.g. `mergify completions zsh`)",
+        "name": "completions",
+        "path": [
+          "mergify",
+          "completions"
+        ],
+        "source": "native",
+        "subcommandRequired": false,
+        "usage": "mergify completions [OPTIONS] <SHELL>"
+      }
+    ],
+    "longAbout": "Mergify command-line interface.\n\nDrive Mergify from your terminal. Validate and simulate your configuration, manage and inspect the merge queue, schedule merge freezes, look at the tests tracked by CI Insights, and create and maintain stacked pull requests.\n\nMost commands talk to the Mergify API and need a token. Set `MERGIFY_TOKEN` (or `GITHUB_TOKEN`) to apply it to every command, or pass `--token` to an individual command — there is no global `--token` on `mergify` itself. Run `mergify <command> --help` for detailed help and options on any command.",
+    "name": "mergify",
+    "path": [
+      "mergify"
+    ],
+    "source": "native",
+    "subcommandRequired": true,
+    "usage": "mergify [OPTIONS] <COMMAND>"
+  },
+  "exitCodes": [
+    {
+      "code": 0,
+      "description": "Command completed successfully.",
+      "name": "Success"
+    },
+    {
+      "code": 1,
+      "description": "Unclassified runtime failure (I/O error, bug, or captured panic).",
+      "name": "GenericError"
+    },
+    {
+      "code": 3,
+      "description": "Stack, branch, or commit not found.",
+      "name": "StackNotFound"
+    },
+    {
+      "code": 4,
+      "description": "Rebase or merge conflict.",
+      "name": "Conflict"
+    },
+    {
+      "code": 5,
+      "description": "GitHub API request failed.",
+      "name": "GitHubApiError"
+    },
+    {
+      "code": 6,
+      "description": "Mergify API request failed.",
+      "name": "MergifyApiError"
+    },
+    {
+      "code": 7,
+      "description": "CLI invariant violated (e.g. command run outside a valid context).",
+      "name": "InvalidState"
+    },
+    {
+      "code": 8,
+      "description": "Configuration file missing, unparseable, or failing validation.",
+      "name": "ConfigurationError"
+    }
+  ],
+  "generator": "mergify _internal dump-cli-schema",
+  "schemaVersion": 1
+}

--- a/crates/mergify-stack/src/commands/push.rs
+++ b/crates/mergify-stack/src/commands/push.rs
@@ -19,13 +19,11 @@
 //!    via [`crate::comment_upsert`].
 //! 10. Tear down orphan branches.
 //!
-//! Ported from `mergify_cli/stack/push.py::stack_push`. The
-//! Python version fans out PR upserts through `asyncio.gather +
-//! asyncio.Event` so a `Create` predecessor doesn't block its
-//! dependent; the Rust port runs them sequentially because for
-//! the typical 2–5 PR stacks the latency difference is dominated
-//! by the GitHub round-trip anyway, and the simpler code avoids
-//! a `tokio::sync::Notify` graph.
+//! PR upserts run sequentially. Async here is incidental — it comes
+//! from reqwest's async-only client, not from a need for concurrency:
+//! for the typical 2–5 PR stacks the latency is dominated by the
+//! GitHub round-trip, and sequential code avoids a
+//! `tokio::sync::Notify` dependency graph.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -482,10 +480,9 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         }
     }
 
-    // Sequential per-PR upsert so each Depends-On has access to
-    // the predecessor's freshly-known PR number. Python uses
-    // asyncio fan-out + Event coordination; sequential is fine
-    // for typical stack sizes.
+    // Sequential per-PR upsert so each Depends-On has access to the
+    // predecessor's freshly-known PR number — and fine for typical
+    // stack sizes (see the module doc on why this isn't parallelised).
     let mut last_pull_number: Option<u64> = None;
     for (i, entry) in planned.locals.iter_mut().enumerate() {
         let action = entry.change.action;

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 # Install the `mergify` CLI from a GitHub Release.
 #
+# Also drops shell completions and a man page — generated from the
+# installed binary itself — into the detected shell's completion dir
+# and `$XDG_DATA_HOME/man`. Best-effort: a failure there never fails
+# the install.
+#
 # Default usage:
 #
 #   curl -fsSL https://raw.githubusercontent.com/Mergifyio/mergify-cli/main/install.sh | sh
@@ -70,6 +75,72 @@ sha256_check() {
         shasum -a 256 -c "$1"
     else
         die "neither sha256sum nor shasum found — install one and retry"
+    fi
+}
+
+# Generate shell completions and the man page from the freshly
+# installed binary and drop them where the shell and `man` look for
+# them. The binary is its own generator (`mergify completions <shell>`
+# / `mergify _internal man`), so this needs no extra release assets.
+# Best-effort: every step is guarded and silent on failure, because
+# the binary itself is already installed by the time we get here. The
+# caller skips this on Windows, where these conventions don't apply.
+install_extras() {
+    bin_path="$1"
+    data_home="${XDG_DATA_HOME:-${HOME}/.local/share}"
+    config_home="${XDG_CONFIG_HOME:-${HOME}/.config}"
+    note=""
+
+    # Completions go in the directory the detected shell scans by
+    # default. zsh has no such user dir out of the box, so we use
+    # ~/.zfunc and tell the user to put it on $fpath.
+    shell_name=$(basename "${SHELL:-}")
+    case "${shell_name}" in
+        bash)
+            comp_shell="bash"
+            comp_dir="${data_home}/bash-completion/completions"
+            comp_file="mergify"
+            ;;
+        zsh)
+            comp_shell="zsh"
+            comp_dir="${HOME}/.zfunc"
+            comp_file="_mergify"
+            # The backticks are literal text for the user to type, not
+            # a command substitution — keep them unexpanded.
+            # shellcheck disable=SC2016
+            note='add `fpath+=~/.zfunc` to ~/.zshrc if completions do not load in new shells'
+            ;;
+        fish)
+            comp_shell="fish"
+            comp_dir="${config_home}/fish/completions"
+            comp_file="mergify.fish"
+            ;;
+        *)
+            comp_shell=""
+            ;;
+    esac
+
+    printf '\n'
+    if [ -n "${comp_shell}" ]; then
+        if mkdir -p "${comp_dir}" 2> /dev/null \
+            && "${bin_path}" completions "${comp_shell}" > "${tmp}/completion" 2> /dev/null \
+            && install -m 0644 "${tmp}/completion" "${comp_dir}/${comp_file}" 2> /dev/null; then
+            printf 'Installed %s completions -> %s/%s\n' "${comp_shell}" "${comp_dir}" "${comp_file}"
+        fi
+    elif [ -n "${shell_name}" ]; then
+        # Unknown shell (elvish, powershell, …): point at the command.
+        printf 'For %s completions, run:  mergify completions %s\n' "${shell_name}" "${shell_name}"
+    fi
+
+    man_dir="${data_home}/man/man1"
+    if mkdir -p "${man_dir}" 2> /dev/null \
+        && "${bin_path}" _internal man > "${tmp}/mergify.1" 2> /dev/null \
+        && install -m 0644 "${tmp}/mergify.1" "${man_dir}/mergify.1" 2> /dev/null; then
+        printf 'Installed man page -> %s/mergify.1\n' "${man_dir}"
+    fi
+
+    if [ -n "${note}" ]; then
+        printf '\nNote: %s.\n' "${note}"
     fi
 }
 
@@ -180,6 +251,14 @@ main() {
 
     printf '\nmergify installed to %s/%s\n' "${INSTALL_DIR}" "${bin}"
     "${INSTALL_DIR}/${bin}" --version
+
+    # Shell completions and a man page, generated from the binary we
+    # just installed. Windows ships neither convention, so skip the
+    # `.zip` (Windows) targets.
+    case "${ext}" in
+        zip) ;;
+        *)   install_extras "${INSTALL_DIR}/${bin}" ;;
+    esac
 
     case ":${PATH}:" in
         *":${INSTALL_DIR}:"*) ;;


### PR DESCRIPTION
After placing the binary, generate a completion script for the
detected shell ($SHELL) and the man page by invoking the binary's own
`completions <shell>` / `_internal man`, then write them into that
shell's completion dir and $XDG_DATA_HOME/man. zsh lands in ~/.zfunc
with a one-line $fpath hint; an unrecognized shell is pointed at the
command instead of guessing a path.

Best-effort and non-fatal since the binary is already installed, and
skipped on Windows. No new release assets — the binary generates both.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #1671