### PR TITLE
feat(install): print how to enable shell completions

### DIFF
--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -727,7 +727,7 @@ fn quarantine_get_opts(args: TestsQuarantineGetCliArgs) -> TestsQuarantineGetOpt
 
 #[allow(clippy::too_many_lines)] // mostly mechanical match arms
 fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
-    let _ = parsed.debug; // global flag — consulted by command impls, not here
+    let _ = parsed.debug; // already consumed by init_tracing(); ignored during dispatch
     match parsed.command {
         Subcommands::Stack(StackArgs { command }) => match command {
             StackSubcommand::New(cli) => Dispatch::Native(NativeCommand::StackNew(cli.into())),
@@ -744,10 +744,9 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
             StackSubcommand::Move(cli) => Dispatch::Native(NativeCommand::StackMove(cli.into())),
             StackSubcommand::Squash(cli) => match StackSquashOpts::try_from(cli) {
                 Ok(opts) => Dispatch::Native(NativeCommand::StackSquash(opts)),
-                Err(msg) => {
-                    eprintln!("error: {msg}");
-                    std::process::exit(2);
-                }
+                Err(msg) => CliRoot::command()
+                    .error(clap::error::ErrorKind::ValueValidation, msg)
+                    .exit(),
             },
             StackSubcommand::Checkout(cli) => {
                 Dispatch::Native(NativeCommand::StackCheckout(cli.into()))

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 # Install the `mergify` CLI from a GitHub Release.
 #
+# After installing, prints the commands to enable shell completions
+# for the detected shell. It does not write them itself — matching
+# rustup/starship, the installer drops a single binary and leaves the
+# user's shell dirs untouched.
+#
 # Default usage:
 #
 #   curl -fsSL https://raw.githubusercontent.com/Mergifyio/mergify-cli/main/install.sh | sh
@@ -71,6 +76,35 @@ sha256_check() {
     else
         die "neither sha256sum nor shasum found — install one and retry"
     fi
+}
+
+# Print the commands to enable tab completion for the detected shell.
+# We print rather than write: matching rustup/starship, the installer
+# stays a single binary drop and never touches the user's shell dirs.
+# Auto-writing is also unreliable — ~/.zfunc is off zsh's $fpath by
+# default — so the user runs `mergify completions <shell>` themselves.
+print_completion_hint() {
+    shell_name=$(basename "${SHELL:-}")
+    case "${shell_name}" in
+        bash)
+            printf '\nTo enable shell completions for bash:\n'
+            printf '  mkdir -p ~/.local/share/bash-completion/completions\n'
+            printf '  mergify completions bash > ~/.local/share/bash-completion/completions/mergify\n'
+            ;;
+        zsh)
+            printf '\nTo enable shell completions for zsh:\n'
+            printf '  mkdir -p ~/.zfunc && mergify completions zsh > ~/.zfunc/_mergify\n'
+            printf '  # then add to ~/.zshrc:  fpath+=~/.zfunc; autoload -Uz compinit; compinit\n'
+            ;;
+        fish)
+            printf '\nTo enable shell completions for fish:\n'
+            printf '  mergify completions fish > ~/.config/fish/completions/mergify.fish\n'
+            ;;
+        *)
+            printf '\nTo enable shell completions:\n'
+            printf '  mergify completions <bash|zsh|fish|elvish|powershell>\n'
+            ;;
+    esac
 }
 
 main() {
@@ -189,6 +223,8 @@ main() {
            # shellcheck disable=SC2016
            printf 'Add it to your shell config:  export PATH="%s:$PATH"\n' "${INSTALL_DIR}" ;;
     esac
+
+    print_completion_hint
 }
 
 main "$@"


### PR DESCRIPTION
After dropping the binary, print the exact command to enable tab
completion for the detected shell ($SHELL): bash, zsh, and fish each
get a ready-to-paste line; any other shell is pointed at `mergify
completions`. The installer writes nothing into the user's shell dirs.

A curl|sh installer that ships a single binary leaves shell config to
the user, as rustup and starship do; writing completion files from it
is both surprising and unreliable — ~/.zfunc is off zsh's $fpath by
default. Man-page generation stays available via the binary for real
packaging.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #1671