### PR TITLE
docs: make the README a full CLI-contract reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,8 +219,14 @@ the **root table**, not the crate — that's the single source of truth.
 
 Doc updates ship in the **same** commit/PR as the change, never a follow-up.
 
-1. **README.md** — keep Commands/Usage current with every top-level command
-   (including `self-update` and `completions`).
+1. **README.md** — it documents the CLI contract at group altitude: the
+   top-level command groups, global options, the token/repository/api-url
+   resolution order, environment variables, and exit codes. Per-subcommand
+   detail deliberately lives in `--help` and docs.mergify.com, not here — don't
+   re-add an exhaustive subcommand list. When you change that surface —
+   add/rename/remove a command group, add or alter a global flag or an env
+   fallback, add an exit code — update the matching section in the same PR. The
+   `cli_schema_golden` test guards the schema snapshot, **not** the README prose.
 2. **Skills** (`skills/`) — update the *matching* skill (don't create a
    duplicate). Directory names aren't 1:1 with command groups:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,28 @@
 # Mergify CLI
 
-Command-line tool for [Mergify](https://mergify.com): stacked pull requests,
-CI insights, merge queue, scheduled freezes, and configuration management.
+[![CI](https://github.com/Mergifyio/mergify-cli/actions/workflows/ci.yaml/badge.svg)](https://github.com/Mergifyio/mergify-cli/actions/workflows/ci.yaml)
+[![Latest release](https://img.shields.io/github/v/release/Mergifyio/mergify-cli?logo=github&label=release)](https://github.com/Mergifyio/mergify-cli/releases/latest)
+[![Documentation](https://img.shields.io/badge/docs-mergify.com-7c3aed)](https://docs.mergify.com/cli/)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+
+Drive [Mergify](https://mergify.com) from your terminal and CI pipelines:
+stacked pull requests, the merge queue, CI Insights, scheduled freezes, and
+configuration — all from a single self-contained binary that reuses your
+existing GitHub (`gh`) login.
+
+```shell
+mergify stack push          # turn your local commits into stacked PRs
+mergify queue status        # inspect the merge queue
+mergify ci junit-process report.xml   # upload test results to CI Insights
+```
+
+- **One static binary.** No runtime, no dependencies — drop it on a developer
+  laptop or a CI runner and go.
+- **Zero-config auth.** Picks up `gh auth token` automatically; override with
+  env vars or flags when scripting.
+- **Built for pipelines.** Logs to stderr, structured `--json` output on read
+  commands, and stable [exit codes](#exit-codes) for scripts and runbooks.
+- **Cross-platform.** Linux, macOS (x86_64 + aarch64), and Windows.
 
 ## Installation
 
@@ -38,27 +59,118 @@ Grab the matching archive from the
 
 Verify against `SHA256SUMS` from the same release if you care.
 
-Run `mergify --help` to list commands and `mergify <command> --help` for
-details. See the [CLI docs](https://docs.mergify.com/cli/) for authentication
-and global options (`--token`, `--repository`, `--api-url`).
+## Authentication
+
+Most commands talk to the Mergify and GitHub APIs and need a token. The CLI
+resolves credentials and target repository in this order, so an authenticated
+`gh` is usually all you need:
+
+| What | `--flag` | then env | then |
+| --- | --- | --- | --- |
+| **Token** | `--token` / `-t` | `MERGIFY_TOKEN`, `GITHUB_TOKEN` | `gh auth token` |
+| **Repository** | `--repository` / `-r` | `GITHUB_REPOSITORY` | `git remote` (`origin`) |
+| **API URL** | `--api-url` / `-u` | `MERGIFY_API_URL` | `https://api.mergify.com` |
+
+See the [authentication guide](https://docs.mergify.com/cli/usage) for details.
+
+## Quick start
+
+```shell
+# Stacked pull requests — one PR per commit, kept in sync
+mergify stack setup                # once per repo: install the git hooks the stack needs
+mergify stack push                 # push commits and create/update their PRs
+mergify stack list                 # show the stack and its PR status
+mergify stack sync                 # rebase the stack onto its trunk
+
+# Merge queue
+mergify queue status               # current queue state for the repo
+mergify queue status --json        # same, as machine-readable JSON
+
+# CI Insights — from inside your pipeline
+mergify ci junit-process report.xml --test-language python
+
+# Configuration
+mergify config validate            # check .mergify.yml against the schema
+```
+
+Run `mergify --help` for the full command list and `mergify <command> --help`
+for any command's flags.
 
 ## Commands
 
-- **`mergify stack`** — Create and manage stacked pull requests.
+Every command group maps to a section of the
+[CLI reference](https://docs.mergify.com/cli/).
+
+- **`mergify stack`** — Create and maintain stacked pull requests.
   [Docs](https://docs.mergify.com/stacks/)
-- **`mergify ci`** — Upload JUnit results, evaluate quarantine, detect git
-  refs and CI scopes.
-  [Docs](https://docs.mergify.com/ci-insights/)
-- **`mergify tests`** — Inspect test health and manage quarantine for tests
-  tracked by Mergify CI Insights (`mergify tests show NAME...`,
-  `mergify tests quarantines add NAME`, `mergify tests quarantines remove NAME`).
-  [Docs](https://docs.mergify.com/ci-insights/)
-- **`mergify queue`** — Monitor and manage the Mergify merge queue.
+- **`mergify queue`** — Inspect and control the merge queue.
   [Docs](https://docs.mergify.com/merge-queue/)
-- **`mergify freeze`** — Create and manage scheduled merge freezes.
-  [Docs](https://docs.mergify.com/merge-protections/freeze/)
-- **`mergify config`** — Validate and simulate Mergify configuration.
-  [Docs](https://docs.mergify.com/configuration/file-format/#validating-with-the-cli)
+- **`mergify ci`** — Send JUnit results and pull request scopes from any CI
+  provider. [Docs](https://docs.mergify.com/ci-insights/)
+- **`mergify tests`** — Look up test health and manage the flaky-test
+  quarantine. [Docs](https://docs.mergify.com/ci-insights/)
+- **`mergify freeze`** — Schedule merge freezes for release windows and
+  maintenance. [Docs](https://docs.mergify.com/merge-protections/freeze/)
+- **`mergify config`** — Validate your configuration and simulate actions
+  before you merge. [Docs](https://docs.mergify.com/configuration/file-format/#validating-with-the-cli)
+- **`mergify self-update`** — Update the CLI to the latest release.
+- **`mergify completions <shell>`** — Print a shell completion script
+  ([see below](#shell-completions)).
+
+Run `mergify <command> --help` for a group's subcommands and flags.
+
+## Shell completions
+
+Generate a completion script for your shell — `bash`, `zsh`, `fish`,
+`elvish`, or `powershell`:
+
+```shell
+# zsh — write to a directory on your $fpath
+mergify completions zsh > ~/.zfunc/_mergify
+
+# bash — load in your current session (add to ~/.bashrc to persist)
+source <(mergify completions bash)
+
+# fish
+mergify completions fish > ~/.config/fish/completions/mergify.fish
+```
+
+## Global options
+
+These are accepted on every command:
+
+| Flag | Description |
+| --- | --- |
+| `-v`, `--verbose` | Increase log verbosity: `-v` info, `-vv` debug, `-vvv` trace. Logs go to stderr so stdout stays pipeable. |
+| `--debug` | Shorthand for at least debug-level logging (like `-vv`). |
+| `--color <auto\|always\|never>` | When to colorize terminal output. |
+
+## Environment variables
+
+| Variable | Effect |
+| --- | --- |
+| `MERGIFY_TOKEN`, `GITHUB_TOKEN` | API token (falls back to `gh auth token`). |
+| `GITHUB_REPOSITORY` | Default `owner/repo` when `--repository` is omitted. |
+| `MERGIFY_API_URL` | API base URL (default `https://api.mergify.com`). |
+| `RUST_LOG` | Fine-grained log filtering; overrides `--verbose`. |
+| `NO_COLOR` | Disable colored output. |
+| `MERGIFY_INSTALL_DIR`, `MERGIFY_VERSION` | Install-script target directory / pinned version. |
+
+## Exit codes
+
+Commands return stable exit codes so scripts and runbooks can branch on them:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success. |
+| `1` | Unclassified runtime failure (I/O error, bug, or captured panic). |
+| `2` | Argument parsing / usage error. |
+| `3` | Stack, branch, or commit not found. |
+| `4` | Rebase or merge conflict. |
+| `5` | GitHub API request failed. |
+| `6` | Mergify API request failed. |
+| `7` | CLI invariant violated (e.g. run outside a valid context). |
+| `8` | Configuration missing, unparseable, or failing validation. |
 
 ## AI Agent Skills
 
@@ -79,9 +191,17 @@ Install as a Claude Code plugin:
 /plugin install mergify
 ```
 
+## Documentation
+
+Full reference and guides live at
+**[docs.mergify.com/cli](https://docs.mergify.com/cli/)**.
+
 ## Contributing
 
-Contributions are welcome — open an issue or pull request.
+Contributions are welcome — open an
+[issue](https://github.com/Mergifyio/mergify-cli/issues) or a pull request.
+The workspace is a Rust monorepo; see [AGENTS.md](AGENTS.md) for the crate
+layout, build, and test workflow.
 
 ## License
 


### PR DESCRIPTION
Expand README.md from a flat command list into a group-altitude CLI
reference: command groups, the token/repository/api-url resolution order,
global options, environment variables, exit codes, and shell completions,
plus badges and a quick-start. Per-subcommand detail stays in `--help` and
docs.mergify.com.

Rewrite the AGENTS.md README rule to match: keep the group-altitude contract
current — command groups, global flags, env fallbacks, exit codes — and do
not re-add an exhaustive subcommand list. The cli_schema_golden test guards
the schema snapshot, not the README prose.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>