### PR TITLE
fix(config): surface an invalid simulate config as a config error

### DIFF
--- a/crates/mergify-cli/tests/live_smoke.rs
+++ b/crates/mergify-cli/tests/live_smoke.rs
@@ -397,9 +397,9 @@ fn queue_show_not_in_queue() {
     //
     // Calls with a PR number that is almost certainly not in the
     // queue (the test repo has far fewer than this many PRs).
-    // Both Python and Rust special-case 404 with the same
-    // user-facing message and `MERGIFY_API_ERROR` exit code (6)
-    // — that contract is what this test pins.
+    // A not-queued PR is a normal queryable state, so the command
+    // reports it on stdout and exits 0 — that contract is what this
+    // test pins.
     //
     // Testing the 404 path (instead of a real queued PR) makes
     // the test independent of whether PR #1 happens to be queued
@@ -421,17 +421,17 @@ fn queue_show_not_in_queue() {
     ]);
     assert_eq!(
         result.returncode,
-        6,
-        "expected MERGIFY_API_ERROR (6), got {}{}",
+        0,
+        "expected a not-queued PR to exit 0, got {}{}",
         result.returncode,
         result.context()
     );
     assert!(
         result
-            .combined()
+            .stdout
             .to_lowercase()
             .contains("not in the merge queue"),
-        "expected 'not in the merge queue' message{}",
+        "expected 'not in the merge queue' message on stdout{}",
         result.context()
     );
 }

--- a/crates/mergify-config/src/simulate.rs
+++ b/crates/mergify-config/src/simulate.rs
@@ -65,12 +65,18 @@ pub async fn run(opts: SimulateOptions<'_>, output: &mut dyn Output) -> Result<(
         "/v1/repos/{}/pulls/{}/simulator",
         opts.pull_request.repository, opts.pull_request.pull_number,
     );
+    // The simulator answers a schema-invalid config with HTTP 422.
+    // That's a problem with the *local* config, not a Mergify API
+    // failure, so surface it as a configuration error (exit 8) —
+    // matching what `config validate` returns for the same fixture —
+    // rather than the generic Mergify API code (exit 6).
     let response: SimulatorResponse = client
-        .post(
+        .post_classifying(
             &path,
             &SimulatorRequest {
                 mergify_yml: &mergify_yml,
             },
+            |status, message| (status == 422).then(|| CliError::Configuration(message.to_string())),
         )
         .await?;
 
@@ -154,6 +160,54 @@ mod tests {
         assert!(
             stdout_str.contains("All conditions pass."),
             "expected summary in output: {stdout_str:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn run_maps_simulator_422_to_configuration_error() {
+        // A schema-invalid config makes the simulator answer 422.
+        // That's a local-config problem, so it must surface as a
+        // configuration error (exit 8), not a Mergify API error.
+        let server = MockServer::start().await;
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join(".mergify.yml");
+        fs::write(&config_path, "pull_request_rules: not-a-list\n").unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/v1/repos/owner/repo/pulls/42/simulator"))
+            .respond_with(
+                ResponseTemplate::new(422)
+                    .set_body_json(serde_json::json!({"detail": "invalid configuration"})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let pull_request = PullRequestRef {
+            host: "github.com".into(),
+            repository: "owner/repo".into(),
+            pull_number: 42,
+        };
+        let api_url = server.uri();
+
+        let mut cap = Captured::human();
+        let err = run(
+            SimulateOptions {
+                pull_request: &pull_request,
+                config_file: Some(&config_path),
+                token: Some("test-token"),
+                api_url: Some(&api_url),
+            },
+            &mut cap.output,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, CliError::Configuration(_)), "got {err:?}");
+        assert_eq!(err.exit_code(), mergify_core::ExitCode::ConfigurationError,);
+        assert!(
+            err.to_string().contains("invalid configuration"),
+            "got {err}",
         );
     }
 }

--- a/crates/mergify-core/src/http.rs
+++ b/crates/mergify-core/src/http.rs
@@ -67,6 +67,13 @@ pub enum DeleteOutcome {
     NotFound,
 }
 
+/// Caller hook to remap a terminal non-2xx HTTP status to a domain
+/// error before the default flavor mapping. Receives the status as a
+/// `u16` (command crates never import `reqwest`) and the rendered
+/// error message; returning `Some` overrides the error. `config
+/// simulate` uses it to map the simulator's 422 to a config error.
+type ErrorClassifier<'a> = &'a (dyn Fn(u16, &str) -> Option<CliError> + Send + Sync);
+
 /// Retry policy for transient failures. Only 5xx responses and
 /// connect/timeout errors are retried; 4xx responses are never
 /// retried — those are caller errors and retrying would hide bugs.
@@ -197,6 +204,29 @@ impl Client {
         self.decode_json(resp).await
     }
 
+    /// POST `body` as JSON to `path` and deserialize the JSON response
+    /// as `T`, like [`Self::post`], but consult `classify` on a
+    /// terminal non-2xx response before the default flavor mapping:
+    /// returning `Some(err)` overrides the error. `config simulate`
+    /// uses this to surface the simulator's 422 — an unprocessable
+    /// local config — as a [`CliError::Configuration`] (exit 8)
+    /// rather than a Mergify API failure (exit 6). The classifier
+    /// receives the HTTP status as a `u16` (command crates never
+    /// import `reqwest`) and the rendered error message.
+    pub async fn post_classifying<B: Serialize + ?Sized, T: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &B,
+        classify: impl Fn(u16, &str) -> Option<CliError> + Send + Sync,
+    ) -> Result<T, CliError> {
+        let url = self.join(path)?;
+        let resp = self
+            .execute_with_retry(self.inner.post(url).json(body), false, Some(&classify))
+            .await?
+            .expect("execute_with_retry returned None despite tolerate_not_found=false");
+        self.decode_json(resp).await
+    }
+
     /// POST `body` as JSON to `path` and discard the response body.
     /// Use when the endpoint returns an empty body (or any body the
     /// caller does not care about) on success — `post::<Value>` would
@@ -289,6 +319,7 @@ impl Client {
         &self,
         builder: reqwest::RequestBuilder,
         tolerate_not_found: bool,
+        classify_error: Option<ErrorClassifier<'_>>,
     ) -> Result<Option<reqwest::Response>, CliError> {
         let mut backoff = self.retry.initial_backoff;
         let mut last_message = String::from("HTTP request failed without response");
@@ -352,6 +383,14 @@ impl Client {
                         backoff *= 2;
                         continue;
                     }
+                    // Terminal non-2xx: let the caller remap specific
+                    // statuses (e.g. simulate's 422 → config error)
+                    // before the default flavor mapping.
+                    if let Some(classify) = classify_error
+                        && let Some(mapped) = classify(status.as_u16(), &last_message)
+                    {
+                        return Err(mapped);
+                    }
                     return Err(self.api_error(last_message));
                 }
                 Err(e) if is_transient(&e) && attempt + 1 < self.retry.max_attempts => {
@@ -382,7 +421,7 @@ impl Client {
         // `tolerate_not_found = false` means the driver never
         // returns `None`; `Option::expect` documents that invariant.
         Ok(self
-            .execute_with_retry(builder, false)
+            .execute_with_retry(builder, false, None)
             .await?
             .expect("execute_with_retry returned None despite tolerate_not_found=false"))
     }
@@ -393,7 +432,7 @@ impl Client {
         &self,
         builder: reqwest::RequestBuilder,
     ) -> Result<Option<reqwest::Response>, CliError> {
-        self.execute_with_retry(builder, true).await
+        self.execute_with_retry(builder, true, None).await
     }
 
     /// Send a request that cares only about the HTTP status.
@@ -403,7 +442,7 @@ impl Client {
         &self,
         builder: reqwest::RequestBuilder,
     ) -> Result<DeleteOutcome, CliError> {
-        match self.execute_with_retry(builder, true).await? {
+        match self.execute_with_retry(builder, true, None).await? {
             Some(_) => Ok(DeleteOutcome::Deleted),
             None => Ok(DeleteOutcome::NotFound),
         }
@@ -684,6 +723,54 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, CliError::MergifyApi(_)));
         assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
+    async fn post_classifying_remaps_matched_status() {
+        // The classifier turns the simulator's 422 into a config
+        // error (exit 8) instead of the default Mergify API error.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/simulate"))
+            .respond_with(
+                ResponseTemplate::new(422)
+                    .set_body_json(serde_json::json!({"detail": "bad config"})),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = fast_client(&server, ApiFlavor::Mergify);
+        let err = client
+            .post_classifying::<_, Foo>("/simulate", &Foo { bar: 1 }, |status, msg| {
+                (status == 422).then(|| CliError::Configuration(msg.to_string()))
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CliError::Configuration(_)), "got {err:?}");
+        assert!(err.to_string().contains("bad config"), "got {err}");
+    }
+
+    #[tokio::test]
+    async fn post_classifying_falls_back_when_status_unmatched() {
+        // A status the classifier ignores keeps the default flavor
+        // mapping (Mergify API error here).
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/simulate"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("nope"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = fast_client(&server, ApiFlavor::Mergify);
+        let err = client
+            .post_classifying::<_, Foo>("/simulate", &Foo { bar: 1 }, |status, msg| {
+                (status == 422).then(|| CliError::Configuration(msg.to_string()))
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CliError::MergifyApi(_)), "got {err:?}");
     }
 
     #[tokio::test]

--- a/crates/mergify-queue/src/show.rs
+++ b/crates/mergify-queue/src/show.rs
@@ -14,15 +14,15 @@
 //!   a tree.
 //!
 //! 404 responses are special-cased: the API returns 404 for "PR is
-//! not currently in the merge queue", which is a routine caller
-//! branch rather than a server failure. The command returns a
-//! [`CliError::MergifyApi`] whose message is `PR #N is not in the
-//! merge queue`; the binary's top-level handler prints it to
-//! stderr as `mergify: PR #N is not in the merge queue` (the
-//! `mergify: ` prefix is the binary's standard error envelope)
-//! and exits with the Mergify-API error code. Live smoke tests
-//! assert against the substring, which is stable across the
-//! Python and Rust implementations.
+//! not currently in the merge queue", which is a routine queryable
+//! state rather than a server failure. The command reports it on
+//! stdout and exits 0 — a not-queued PR is a normal answer, not an
+//! error a script should branch on as an API failure. Under `--json`
+//! the not-queued state is a `{"number": N, "queued": false}`
+//! document so pipeline consumers always get parseable output; in
+//! human mode it is the line `PR #N is not in the merge queue`. Live
+//! smoke tests assert against that substring, which is stable across
+//! the Python and Rust implementations.
 
 use std::io::Write;
 
@@ -119,10 +119,8 @@ pub async fn run(opts: ShowOptions<'_>, output: &mut dyn Output) -> Result<(), C
 
     let raw: Option<serde_json::Value> = client.get_if_exists(&path).await?;
     let Some(raw) = raw else {
-        return Err(CliError::MergifyApi(format!(
-            "PR #{n} is not in the merge queue",
-            n = opts.pr_number,
-        )));
+        emit_not_queued(output, opts.pr_number, opts.output_json)?;
+        return Ok(());
     };
 
     if opts.output_json {
@@ -133,6 +131,28 @@ pub async fn run(opts: ShowOptions<'_>, output: &mut dyn Output) -> Result<(), C
     let view: PullView = serde_json::from_value(raw)
         .map_err(|e| CliError::Generic(format!("decode merge queue pull response: {e}")))?;
     emit_human(output, &view, opts.verbose)?;
+    Ok(())
+}
+
+/// Emit the "PR is not in the merge queue" state. This is a normal
+/// answer, not a failure, so the command exits 0 — see the module
+/// docs. Under `--json` we emit a `{number, queued: false}` document
+/// (a machine consumer always gets parseable output); in human mode
+/// a single notice line. The wording is load-bearing: live smoke
+/// tests assert on the "is not in the merge queue" substring.
+fn emit_not_queued(
+    output: &mut dyn Output,
+    pr_number: u64,
+    output_json: bool,
+) -> Result<(), CliError> {
+    if output_json {
+        let payload = serde_json::json!({ "number": pr_number, "queued": false });
+        output.emit_json_value(&payload)?;
+    } else {
+        output.emit(&(), &mut |w: &mut dyn Write| {
+            writeln!(w, "PR #{pr_number} is not in the merge queue")
+        })?;
+    }
     Ok(())
 }
 
@@ -657,7 +677,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_404_is_not_in_queue() {
+    async fn run_404_human_is_not_in_queue_and_succeeds() {
+        // A not-queued PR is a normal queryable state, not an API
+        // failure: human mode prints the notice to stdout and the
+        // command returns Ok (exit 0).
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/v1/repos/owner/repo/merge-queue/pull/999"))
@@ -668,7 +691,7 @@ mod tests {
 
         let mut cap = Captured::human();
         let api_url = server.uri();
-        let err = run(
+        run(
             ShowOptions {
                 repository: Some("owner/repo"),
                 token: Some("t"),
@@ -680,17 +703,49 @@ mod tests {
             &mut cap.output,
         )
         .await
-        .unwrap_err();
+        .unwrap();
 
+        let stdout = cap.stdout();
         assert!(
-            matches!(err, CliError::MergifyApi(_)),
-            "expected MergifyApi, got {err:?}",
+            stdout.contains("PR #999 is not in the merge queue"),
+            "got: {stdout:?}",
         );
-        assert_eq!(err.exit_code(), mergify_core::ExitCode::MergifyApiError);
-        assert!(
-            err.to_string().contains("not in the merge queue"),
-            "got: {err}"
-        );
+    }
+
+    #[tokio::test]
+    async fn run_404_json_emits_not_queued_document() {
+        // Under `--json`, the not-queued state is a parseable
+        // `{number, queued: false}` document on stdout (exit 0), so
+        // pipeline consumers never get empty output for the common
+        // case.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/repos/owner/repo/merge-queue/pull/999"))
+            .respond_with(ResponseTemplate::new(404))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut cap = Captured::new(OutputMode::Json);
+        let api_url = server.uri();
+        run(
+            ShowOptions {
+                repository: Some("owner/repo"),
+                token: Some("t"),
+                api_url: Some(&api_url),
+                pr_number: 999,
+                verbose: false,
+                output_json: true,
+            },
+            &mut cap.output,
+        )
+        .await
+        .unwrap();
+
+        let stdout = cap.stdout();
+        let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        assert_eq!(parsed["number"], json!(999));
+        assert_eq!(parsed["queued"], json!(false));
     }
 
     #[tokio::test]


### PR DESCRIPTION
A schema-invalid config uploaded by `config simulate` came back as
the simulator's HTTP 422 and was reported as a Mergify API failure
(exit 6) — even though the same fixture fails `config validate`
client-side with exit 8. The drift meant a local-config problem
looked like a service problem to scripts.

Add `HttpClient::post_classifying`, which lets a caller remap a
terminal status before the default flavor mapping, and use it in
`simulate` to map the simulator's 422 to a configuration error
(exit 8).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #1678