### PR TITLE
feat(cli): support the git-style help subcommand

### DIFF
--- a/crates/mergify-ci/src/scopes_detect/mod.rs
+++ b/crates/mergify-ci/src/scopes_detect/mod.rs
@@ -262,8 +262,11 @@ fn write_detected_scopes(
     };
     let json = serde_json::to_string(&payload)
         .map_err(|e| CliError::Generic(format!("failed to serialize scopes JSON: {e}")))?;
+    // A failed write is a runtime I/O failure (exit 1), not a
+    // configuration problem (exit 8): the config parsed fine, the
+    // output path is just unwritable. Keep the OS error as the cause.
     std::fs::write(path, json)
-        .map_err(|e| CliError::Configuration(format!("cannot write {}: {e}", path.display())))?;
+        .map_err(|e| CliError::wrap(format!("cannot write {}", path.display()), e))?;
     Ok(())
 }
 
@@ -336,6 +339,25 @@ mod tests {
         let raw = std::fs::read_to_string(&out).unwrap();
         // BTreeSet iteration is sorted; the JSON reflects it.
         assert_eq!(raw, r#"{"scopes":["alpha","zebra"]}"#);
+    }
+
+    #[test]
+    fn write_detected_scopes_io_failure_is_a_runtime_error() {
+        // Writing under a non-existent directory fails with a plain
+        // I/O error. That's a runtime failure (exit 1), not a config
+        // problem (exit 8) — the config itself was fine.
+        let tmp = tempfile::tempdir().unwrap();
+        let unwritable = tmp
+            .path()
+            .join("no")
+            .join("such")
+            .join("dir")
+            .join("scopes.json");
+        let mut set = std::collections::BTreeSet::new();
+        set.insert("backend".to_string());
+        let err = write_detected_scopes(&unwritable, &set).unwrap_err();
+        assert_eq!(err.exit_code(), mergify_core::ExitCode::GenericError);
+        assert!(err.to_string().contains("cannot write"), "got: {err}");
     }
 
     #[test]

--- a/crates/mergify-cli/src/cli_schema.rs
+++ b/crates/mergify-cli/src/cli_schema.rs
@@ -184,7 +184,11 @@ fn command_node(
 
     let commands = cmd
         .get_subcommands()
-        .filter(|sub| !sub.is_hide_set())
+        // Skip `hide`-d commands and clap's synthetic `help`
+        // subcommand — the latter is universal plumbing, not part of
+        // the user-facing reference (same reasoning as the `--help`
+        // arg filter above).
+        .filter(|sub| !sub.is_hide_set() && sub.get_name() != "help")
         .map(|sub| {
             let mut child = path.clone();
             child.push(sub.get_name().to_string());

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -2066,7 +2066,12 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
 
                 match outcome {
                     mergify_stack::commands::checkout::Outcome::NoStackedPrs => {
+                        // An empty result is a not-found state, not a
+                        // success — exit 3 so scripts can tell "checked
+                        // out" from "nothing to check out" (matches
+                        // `stack open`'s empty-stack handling).
                         println!("No stacked pull requests found");
+                        Ok(mergify_core::ExitCode::StackNotFound)
                     }
                     mergify_stack::commands::checkout::Outcome::CheckedOut {
                         chain,
@@ -2089,9 +2094,9 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                                 "Checked out '{local_branch}' tracking {upstream}",
                             );
                         }
+                        Ok(mergify_core::ExitCode::Success)
                     }
                 }
-                Ok(mergify_core::ExitCode::Success)
             }
             NativeCommand::StackSync(opts) => {
                 let token = mergify_core::auth::resolve_token(opts.token.as_deref())?;

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -2577,10 +2577,11 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
 /// Most commands talk to the Mergify API and need a token. Set
 /// `MERGIFY_TOKEN` (or `GITHUB_TOKEN`) to apply it to every command,
 /// or pass `--token` to an individual command — there is no global
-/// `--token` on `mergify` itself. Run `mergify <command> --help` for
-/// detailed help and options on any command.
+/// `--token` on `mergify` itself. Run `mergify <command> --help` (or
+/// the git-style `mergify help <command>`) for detailed help and
+/// options on any command.
 #[derive(Parser)]
-#[command(name = "mergify", disable_help_subcommand = true, version = VERSION)]
+#[command(name = "mergify", version = VERSION)]
 struct CliRoot {
     /// Increase log verbosity: -v info, -vv debug, -vvv trace. Logs
     /// go to stderr so stdout stays clean for piping. `RUST_LOG`
@@ -4629,5 +4630,27 @@ mod tests {
                 )),
             "the replacement subgroup must parse (help-display Err counts as parsed)",
         );
+    }
+
+    #[test]
+    fn git_style_help_subcommand_is_supported() {
+        // `mergify help` and `mergify help <cmd>` must be recognized
+        // (clap surfaces help as a DisplayHelp "error"), not rejected
+        // as an unknown subcommand the way they were while
+        // `disable_help_subcommand` was set.
+        for argv in [
+            &["mergify", "help"][..],
+            &["mergify", "help", "queue"],
+            &["mergify", "help", "stack", "push"],
+        ] {
+            // `CliRoot` isn't `Debug`, so drop the Ok value with
+            // `.err()` before inspecting the error kind.
+            let kind = CliRoot::try_parse_from(argv).err().map(|e| e.kind());
+            assert_eq!(
+                kind,
+                Some(clap::error::ErrorKind::DisplayHelp),
+                "{argv:?} should display help, got {kind:?}",
+            );
+        }
     }
 }

--- a/crates/mergify-cli/src/snapshots/mergify__tests__cli_schema_golden.snap
+++ b/crates/mergify-cli/src/snapshots/mergify__tests__cli_schema_golden.snap
@@ -3760,7 +3760,7 @@ expression: schema
         "usage": "mergify completions [OPTIONS] <SHELL>"
       }
     ],
-    "longAbout": "Mergify command-line interface.\n\nDrive Mergify from your terminal. Validate and simulate your configuration, manage and inspect the merge queue, schedule merge freezes, look at the tests tracked by CI Insights, and create and maintain stacked pull requests.\n\nMost commands talk to the Mergify API and need a token. Set `MERGIFY_TOKEN` (or `GITHUB_TOKEN`) to apply it to every command, or pass `--token` to an individual command — there is no global `--token` on `mergify` itself. Run `mergify <command> --help` for detailed help and options on any command.",
+    "longAbout": "Mergify command-line interface.\n\nDrive Mergify from your terminal. Validate and simulate your configuration, manage and inspect the merge queue, schedule merge freezes, look at the tests tracked by CI Insights, and create and maintain stacked pull requests.\n\nMost commands talk to the Mergify API and need a token. Set `MERGIFY_TOKEN` (or `GITHUB_TOKEN`) to apply it to every command, or pass `--token` to an individual command — there is no global `--token` on `mergify` itself. Run `mergify <command> --help` (or the git-style `mergify help <command>`) for detailed help and options on any command.",
     "name": "mergify",
     "path": [
       "mergify"


### PR DESCRIPTION
`mergify help` and `mergify help <command>` failed with exit 2
("unrecognized subcommand 'help'") because `disable_help_subcommand`
was set, even though every other CLI offers the git-style help verb
alongside `--help`. Drop the flag so clap handles both forms.

Filter clap's synthetic `help` subcommand out of the published CLI
schema, the same way the `--help`/`--version` args are already
excluded — it's universal plumbing, not part of the reference.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #1681