### PR TITLE
docs: install mergify plugin from the official marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,7 @@ npx skills add Mergifyio/mergify-cli
 Install as a Claude Code plugin:
 
 ```shell
-/plugin marketplace add Mergifyio/mergify-cli
-/plugin install mergify
+/plugin install mergify@claude-plugins-official
 ```
 
 ## Documentation


### PR DESCRIPTION
The mergify plugin is now published on the claude-plugins-official
marketplace, so a single install command is enough. Replace the
two-step "marketplace add" + "install" instructions with the direct
`/plugin install mergify@claude-plugins-official`.