### PR TITLE
chore(deps): bump quick-xml to 0.41 for RUSTSEC-2026-0194 and RUSTSEC-2026-0195

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ iana-time-zone = "0.1"
 jsonschema = { version = "0.46", default-features = false }
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic-messages", "trace"] }
 prost = "0.14"
-quick-xml = "0.40"
+quick-xml = "0.41"
 regex = "1"
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
 self-replace = "1"


### PR DESCRIPTION
## What broke CI

The `cargo-deny` job has been failing on every PR since two new RUSTSEC advisories were published against `quick-xml` 0.40.1 (currently pinned in Cargo.lock, workspace dep `quick-xml = "0.40"` in the root `Cargo.toml`, used by `crates/mergify-ci` for JUnit XML parsing):

- **[RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194)** — Quadratic run time when checking a start tag for duplicate attribute names
- **[RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195)** — Unbounded namespace-declaration allocation in `NsReader` enables memory-exhaustion denial of service

Both advisories list the fix as "Upgrade to >=0.41.0". The downstream `ci-gate` job fails purely because it depends on `cargo-deny`. This is unrelated to any open PR's changes — it's a newly-published advisory against a previously-pinned version.

## The fix

Bumped the workspace `quick-xml` requirement from `"0.40"` to `"0.41"` in the root `Cargo.toml` and ran `cargo update -p quick-xml`, resolving to `quick-xml 0.41.0`. No source changes were needed in `crates/mergify-ci` — the 0.41 API used by the JUnit parser is unchanged.

## Verification

- `cargo test -p mergify-ci` — 174 passed, 0 failed
- `cargo test --workspace` — 291 passed, 1 failed (pre-existing, unrelated, environmental: `mergify-stack` `stack_context::tests::targets_itself_includes_remote_url_and_both_git_commands`)
- `cargo check --workspace` — clean
- `cargo clippy --workspace --all-targets` — clean
- Resolved `quick-xml` version in `Cargo.lock` is `0.41.0`, which meets both advisories' "Upgrade to >=0.41.0" solution
- `git diff --stat` touches only `Cargo.toml` and `Cargo.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)