### PR TITLE
feat(stack): make git notes the source of truth for revision history

### DIFF
--- a/crates/mergify-stack/src/commands/push.rs
+++ b/crates/mergify-stack/src/commands/push.rs
@@ -11,13 +11,16 @@
 //! 5. Rebase via [`crate::commands::sync`] (or skip).
 //! 6. Optionally compute change types + replay SHAs for the
 //!    revision-history comment.
-//! 7. `git push --atomic` via [`crate::notes_push`].
-//! 8. Upsert each PR sequentially via [`crate::pr_upsert`] so
+//! 7. Prepare each Update's revision history and write it as a
+//!    git note on the new head commit (`crate::revision_note`),
+//!    so step 8's atomic push carries it.
+//! 8. `git push --atomic` via [`crate::notes_push`].
+//! 9. Upsert each PR sequentially via [`crate::pr_upsert`] so
 //!    each `Depends-On: #<n>` header sees the predecessor's
 //!    freshly-created PR number.
-//! 9. Upsert stack comments + revision-history comments per PR
-//!    via [`crate::comment_upsert`].
-//! 10. Tear down orphan branches.
+//! 10. Upsert stack comments, and render + upsert each prepared
+//!     revision-history comment, per PR via [`crate::comment_upsert`].
+//! 11. Tear down orphan branches.
 //!
 //! PR upserts run sequentially. Async here is incidental — it comes
 //! from reqwest's async-only client, not from a need for concurrency:
@@ -39,7 +42,7 @@ use crate::approvals::{self, RebaseDecision};
 use crate::change_type::{self, ChangeType};
 use crate::changes::Action;
 use crate::commands::sync as sync_cmd;
-use crate::comment_upsert::{self, RevisionInput};
+use crate::comment_upsert;
 use crate::local_commits;
 use crate::notes_push::{self, PushEntry};
 use crate::plan::{self, PlannedChange, PlannedChanges, PlannerOpts};
@@ -48,6 +51,8 @@ use crate::progress::{Mark, Progress};
 use crate::rebase_log;
 use crate::remote_changes;
 use crate::replay;
+use crate::revision_history::RevisionHistoryComment;
+use crate::revision_note;
 use crate::stack_comment::StackEntry;
 use crate::stack_context;
 use crate::trunk;
@@ -323,6 +328,8 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
     let mut change_types: std::collections::HashMap<String, ChangeType> =
         std::collections::HashMap::new();
     let mut deferred_notes: Vec<String> = Vec::new();
+    let mut revision_histories: std::collections::HashMap<String, (u64, RevisionHistoryComment)> =
+        std::collections::HashMap::new();
     if opts.revision_history {
         let updated_pr_numbers: Vec<u64> = planned
             .locals
@@ -360,6 +367,148 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
             let ct =
                 change_type::detect_change_type(Some(&repo_dir), old_sha, &entry.change.commit_sha);
             change_types.insert(entry.change.change_id.clone(), ct);
+        }
+
+        // Build each Update's full revision history BEFORE the push:
+        // the history is written as a git note on the new head commit
+        // so the atomic push below carries it with the branches. The
+        // Mergify engine copies that note onto the merge commit at
+        // merge time, so it must be on the remote before the PR can
+        // merge — writing it after the push would leave a window.
+        let now = Utc::now();
+        for p in &planned.locals {
+            if !matches!(p.change.action, Action::Update) {
+                continue;
+            }
+            let Some(pull) = p.change.pull.as_ref() else {
+                continue;
+            };
+            let Some(number) = pull.get("number").and_then(Value::as_u64) else {
+                continue;
+            };
+            let Some(old_sha) = pull.pointer("/head/sha").and_then(Value::as_str) else {
+                continue;
+            };
+
+            // A marker-carrying note on the local commit is a history
+            // note left by a previous push attempt that failed before
+            // the branch landed. If it records exactly this old→new
+            // transition, reuse it verbatim — rebuilding from the old
+            // head's note would lose the reason the user attached
+            // before the failed attempt — and skip the replay/change-
+            // type work below entirely: the recovered entry already
+            // carries its own replay_sha, and replay uploads objects
+            // to GitHub, so it must not run pointlessly.
+            if crate::revision_history::contains_marker(&p.change.note)
+                && let Some(history) = revision_note::recover_pending(
+                    &p.change.note,
+                    opts.github_server,
+                    opts.user,
+                    opts.repo,
+                    old_sha,
+                    &p.change.commit_sha,
+                )
+            {
+                revision_note::write_note(
+                    Some(&repo_dir),
+                    &p.change.commit_sha,
+                    &revision_note::render(&history, number),
+                )?;
+                revision_histories.insert(p.change.change_id.clone(), (number, history));
+                continue;
+            }
+
+            let ct = change_types
+                .get(&p.change.change_id)
+                .copied()
+                .unwrap_or(ChangeType::Unknown);
+
+            // Replay only when the change is content (not rebase or
+            // unknown) — for rebase/unknown the revision-history
+            // table renders without a compare URL anyway.
+            let replay_sha = if matches!(ct, ChangeType::Content) {
+                replay::replay_for_revision(
+                    opts.client,
+                    Some(&repo_dir),
+                    opts.user,
+                    opts.repo,
+                    old_sha,
+                    &p.change.commit_sha,
+                )
+                .await
+            } else {
+                None
+            };
+
+            // A marker-carrying note on the local commit that didn't
+            // match the recovery check above is stale machine history
+            // (another machine pushed meanwhile, or a different
+            // amend followed the failed attempt) — not a user reason.
+            let reason = if crate::revision_history::contains_marker(&p.change.note) {
+                ""
+            } else {
+                p.change.note.as_str()
+            };
+
+            let history = match revision_note::load_or_seed(
+                opts.client,
+                Some(&repo_dir),
+                opts.github_server,
+                opts.user,
+                opts.repo,
+                number,
+                old_sha,
+            )
+            .await
+            {
+                Ok(Some(mut h)) => {
+                    h.append(
+                        old_sha,
+                        &p.change.commit_sha,
+                        ct,
+                        now,
+                        reason,
+                        replay_sha.as_deref(),
+                    );
+                    h
+                }
+                Ok(None) => RevisionHistoryComment::create_initial(
+                    opts.github_server,
+                    opts.user,
+                    opts.repo,
+                    old_sha,
+                    &p.change.commit_sha,
+                    ct,
+                    now,
+                    reason,
+                    replay_sha.as_deref(),
+                ),
+                Err(e) => {
+                    // A transient failure (e.g. rate limit) fetching
+                    // the migration-seed PR comment must not fall
+                    // back to `create_initial`: that would write a
+                    // fresh 2-entry history and, worse, PATCH over
+                    // the PR comment that was the only remaining
+                    // seed — permanently destroying history a retry
+                    // could otherwise have recovered. Leave this PR's
+                    // history untouched this push (no note write, no
+                    // comment update): it converges on the next push
+                    // once the GET succeeds, since neither the old
+                    // head's note nor the comment changed meanwhile.
+                    deferred_notes.push(format!(
+                        "Could not load previous revision history for #{number}; \
+                         leaving it untouched this push, will retry next push: {e}",
+                    ));
+                    continue;
+                }
+            };
+
+            revision_note::write_note(
+                Some(&repo_dir),
+                &p.change.commit_sha,
+                &revision_note::render(&history, number),
+            )?;
+            revision_histories.insert(p.change.change_id.clone(), (number, history));
         }
     }
 
@@ -578,77 +727,28 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         prog.resolve(cidx, Mark::Done, Some("stack comments updated"));
     }
 
-    // Revision-history comments — only for Updates, and only
-    // when revision_history is enabled.
-    if opts.revision_history {
-        let has_updates = planned
-            .locals
-            .iter()
-            .any(|p| matches!(p.change.action, Action::Update) && p.change.pull.is_some());
-        if has_updates {
-            let ridx = prog.add("queued");
-            prog.run(ridx, "updating revision history", async {
-                let now = Utc::now();
-                for p in &planned.locals {
-                    if !matches!(p.change.action, Action::Update) {
-                        continue;
-                    }
-                    let Some(pull) = p.change.pull.as_ref() else {
-                        continue;
-                    };
-                    let Some(number) = pull.get("number").and_then(Value::as_u64) else {
-                        continue;
-                    };
-                    let Some(old_sha) = pull.pointer("/head/sha").and_then(Value::as_str) else {
-                        continue;
-                    };
-
-                    let ct = change_types
-                        .get(&p.change.change_id)
-                        .copied()
-                        .unwrap_or(ChangeType::Unknown);
-
-                    // Replay only when the change is content (not
-                    // rebase or unknown) — for rebase/unknown the
-                    // revision-history table renders without a
-                    // compare URL anyway.
-                    let replay_sha = if matches!(ct, ChangeType::Content) {
-                        replay::replay_for_revision(
-                            opts.client,
-                            Some(&repo_dir),
-                            opts.user,
-                            opts.repo,
-                            old_sha,
-                            &p.change.commit_sha,
-                        )
-                        .await
-                    } else {
-                        None
-                    };
-
-                    let input = RevisionInput {
-                        pull_number: number,
-                        old_sha,
-                        new_sha: &p.change.commit_sha,
-                        change_type: ct,
-                        reason: &p.change.note,
-                        replay_sha: replay_sha.as_deref(),
-                        timestamp: now,
-                    };
-                    comment_upsert::update_revision_history_for_pull(
-                        opts.client,
-                        opts.user,
-                        opts.repo,
-                        opts.github_server,
-                        &input,
-                    )
-                    .await?;
-                }
-                Ok::<(), CliError>(())
-            })
-            .await?;
-            prog.resolve(ridx, Mark::Done, Some("revision history updated"));
-        }
+    // Revision-history comments — rendered from the histories
+    // prepared (and written as git notes) before the push.
+    if !revision_histories.is_empty() {
+        let ridx = prog.add("queued");
+        prog.run(ridx, "updating revision history", async {
+            for p in &planned.locals {
+                let Some((number, history)) = revision_histories.get(&p.change.change_id) else {
+                    continue;
+                };
+                comment_upsert::upsert_revision_history_comment(
+                    opts.client,
+                    opts.user,
+                    opts.repo,
+                    *number,
+                    &history.body(*number),
+                )
+                .await?;
+            }
+            Ok::<(), CliError>(())
+        })
+        .await?;
+        prog.resolve(ridx, Mark::Done, Some("revision history updated"));
     }
 
     // Orphan-branch teardown — last so we don't yank the rug out

--- a/crates/mergify-stack/src/comment_upsert.rs
+++ b/crates/mergify-stack/src/comment_upsert.rs
@@ -5,21 +5,18 @@
 //!   of a stack" table (see [`crate::stack_comment`]). Skipped
 //!   when the stack has only one PR — a single-row table would
 //!   be noise.
-//! - [`update_revision_history_for_pull`] — the "Revision
-//!   history" table (see [`crate::revision_history`]). On
-//!   every push, parses the existing comment's JSON marker,
-//!   **appends** the new revision row, and `PATCH`es — so
-//!   historic links are preserved verbatim while the new row
-//!   gets fresh rendering.
+//! - [`upsert_revision_history_comment`] — the "Revision
+//!   history" table (see [`crate::revision_history`]). The
+//!   revision-history body is pre-rendered by the push
+//!   orchestrator from the git-notes history (see
+//!   [`crate::revision_note`]); this module only diffs the
+//!   rendered body against the existing comment and writes it.
 //!
 //! Both walk the issue comments once, match on the header
 //! (`StackComment::is_stack_comment` / `RevisionHistoryComment::
 //! is_revision_comment`), then choose between PATCH (existing
 //! found, body changed), no-op (existing found, body unchanged),
-//! and POST (no existing). The revision upserter has a third
-//! branch: header matched but the marker JSON couldn't be parsed
-//! — overwrite with a fresh initial comment so a corrupted
-//! historic comment doesn't permanently block updates.
+//! and POST (no existing).
 //!
 //! Ported from
 //! `mergify_cli/stack/push.py::{_update_comment_for_pull,
@@ -28,13 +25,11 @@
 //! lives in the eventual `stack_push` orchestrator port — these
 //! are pure single-PR helpers.
 
-use chrono::{DateTime, Utc};
 use mergify_core::{CliError, HttpClient};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use url::Url;
 
-use crate::change_type::ChangeType;
 use crate::revision_history::RevisionHistoryComment;
 use crate::stack_comment::{self, StackEntry};
 
@@ -114,124 +109,50 @@ pub async fn update_stack_comment_for_pull(
     Ok(())
 }
 
-/// Inputs to [`update_revision_history_for_pull`] — the per-row
-/// fields the orchestrator resolves before calling. Decoupled
-/// from [`crate::changes::LocalChange`] because `pull_head_sha`,
-/// `reason`, `change_type`, and `replay_sha` are all computed
-/// during the push (not at classifier time).
-#[derive(Debug, Clone)]
-pub struct RevisionInput<'a> {
-    pub pull_number: u64,
-    pub old_sha: &'a str,
-    pub new_sha: &'a str,
-    pub change_type: ChangeType,
-    pub reason: &'a str,
-    pub replay_sha: Option<&'a str>,
-    pub timestamp: DateTime<Utc>,
-}
-
-/// Upsert the revision-history comment for one PR.
+/// Upsert the revision-history comment with a pre-rendered body.
 ///
-/// Three branches:
-///
-/// - **Existing parseable comment** → parse, [`append`] the new
-///   row, render, PATCH if changed. Historic rows render
-///   verbatim so old links stay intact.
-/// - **Existing comment, header matches but marker corrupted** →
-///   PATCH with a fresh 2-row `create_initial` comment.
-///   Recovers from a hand-edited / out-of-schema marker
-///   without leaving a stuck PR.
-/// - **No existing comment** → POST a fresh `create_initial`.
-///
-/// [`append`]: crate::revision_history::RevisionHistoryComment::append
-pub async fn update_revision_history_for_pull(
+/// The body is rendered by the caller from the git-notes history
+/// (the machine source of truth — see [`crate::revision_note`]);
+/// this function never parses comment content. Find our comment
+/// by header → PATCH if the body differs (no-op if identical);
+/// none found → POST.
+pub async fn upsert_revision_history_comment(
     client: &HttpClient,
     user: &str,
     repo: &str,
-    github_server: &str,
-    input: &RevisionInput<'_>,
+    pull_number: u64,
+    new_body: &str,
 ) -> Result<(), CliError> {
-    let path = format!(
-        "/repos/{user}/{repo}/issues/{pull_number}/comments",
-        pull_number = input.pull_number,
-    );
+    let path = format!("/repos/{user}/{repo}/issues/{pull_number}/comments");
     let comments: Vec<Comment> = client.get(&path).await?;
-
-    // Cheap to construct unconditionally — both the
-    // corrupted-marker and no-comment branches need it, and the
-    // common parseable-comment branch ignores it.
-    let fresh = RevisionHistoryComment::create_initial(
-        github_server,
-        user,
-        repo,
-        input.old_sha,
-        input.new_sha,
-        input.change_type,
-        input.timestamp,
-        input.reason,
-        input.replay_sha,
-    );
 
     for comment in &comments {
         if !RevisionHistoryComment::is_revision_comment(&comment.body) {
             continue;
         }
-        match RevisionHistoryComment::parse(&comment.body, github_server, user, repo) {
-            Some(mut parsed) => {
-                parsed.append(
-                    input.old_sha,
-                    input.new_sha,
-                    input.change_type,
-                    input.timestamp,
-                    input.reason,
-                    input.replay_sha,
-                );
-                let new_body = parsed.body(input.pull_number);
-                if comment.body != new_body {
-                    let _: Value = client
-                        .patch(&comment_path(&comment.url)?, &BodyOnly { body: &new_body })
-                        .await?;
-                }
-            }
-            None => {
-                // Header matched but marker corrupted — recover
-                // by overwriting with a fresh initial comment.
-                // Better than leaving the PR with a stuck
-                // unparseable comment.
-                let _: Value = client
-                    .patch(
-                        &comment_path(&comment.url)?,
-                        &BodyOnly {
-                            body: &fresh.body(input.pull_number),
-                        },
-                    )
-                    .await?;
-            }
+        if comment.body != new_body {
+            let _: Value = client
+                .patch(&comment_path(&comment.url)?, &BodyOnly { body: new_body })
+                .await?;
         }
         return Ok(());
     }
 
-    // No existing revision-history comment — POST a fresh one.
-    let _: Value = client
-        .post(
-            &path,
-            &BodyOnly {
-                body: &fresh.body(input.pull_number),
-            },
-        )
-        .await?;
+    let _: Value = client.post(&path, &BodyOnly { body: new_body }).await?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::TimeZone;
+    use chrono::{DateTime, TimeZone, Utc};
     use mergify_core::ApiFlavor;
     use serde_json::json;
     use url::Url;
     use wiremock::matchers::{method, path as wm_path};
     use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+    use crate::change_type::ChangeType;
 
     fn client(server: &MockServer) -> HttpClient {
         HttpClient::new(
@@ -359,56 +280,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn revision_history_creates_when_missing() {
+    async fn revision_comment_posts_when_missing() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(wm_path("/repos/o/r/issues/42/comments"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .expect(1)
             .mount(&server)
             .await;
         Mock::given(method("POST"))
             .and(wm_path("/repos/o/r/issues/42/comments"))
             .respond_with(ResponseTemplate::new(201).set_body_json(json!({})))
+            .expect(1)
             .mount(&server)
             .await;
 
-        let input = RevisionInput {
-            pull_number: 42,
-            old_sha: "aaaaaaaaaaaa",
-            new_sha: "bbbbbbbbbbbb",
-            change_type: ChangeType::Content,
-            reason: "review feedback",
-            replay_sha: None,
-            timestamp: ts(),
-        };
-        update_revision_history_for_pull(
-            &client(&server),
-            "o",
-            "r",
-            "https://api.github.com",
-            &input,
-        )
-        .await
-        .unwrap();
-
-        let reqs = server.received_requests().await.unwrap();
-        let post = reqs.iter().find(|r| r.method.as_str() == "POST").unwrap();
-        let body = request_body(post);
-        let body_str = body["body"].as_str().unwrap();
-        assert!(body_str.starts_with("### Revision history\n"));
-        // First push → initial 2-row comment: synthetic "initial"
-        // row + the actual revision.
-        assert!(body_str.contains("| 1 | initial |"));
-        assert!(body_str.contains("| 2 | content |"));
-    }
-
-    #[tokio::test]
-    async fn revision_history_appends_to_existing_parseable_comment() {
-        // Seed the API with a real 2-row comment produced by
-        // `create_initial`. The upserter must parse it, append
-        // the new row, and PATCH — historic row 1 + 2 stay
-        // verbatim, fresh row 3 gets added.
-        let seed = RevisionHistoryComment::create_initial(
+        let body = RevisionHistoryComment::create_initial(
             "https://api.github.com",
             "o",
             "r",
@@ -416,106 +303,77 @@ mod tests {
             "bbbbbbbbbbbb",
             ChangeType::Content,
             ts(),
-            "first push",
+            "review feedback",
             None,
-        );
-        let seed_body = seed.body(42);
+        )
+        .body(42);
+        upsert_revision_history_comment(&client(&server), "o", "r", 42, &body)
+            .await
+            .unwrap();
 
+        let reqs = server.received_requests().await.unwrap();
+        let post = reqs.iter().find(|r| r.method.as_str() == "POST").unwrap();
+        let sent = request_body(post);
+        assert_eq!(sent["body"].as_str().unwrap(), body);
+    }
+
+    #[tokio::test]
+    async fn revision_comment_patches_when_body_differs() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(wm_path("/repos/o/r/issues/42/comments"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!([
                 {
                     "url": format!("{}/repos/o/r/issues/comments/200", server.uri()),
-                    "body": seed_body,
+                    "body": "### Revision history\n\nSTALE",
                 },
             ])))
+            .expect(1)
             .mount(&server)
             .await;
         Mock::given(method("PATCH"))
             .and(wm_path("/repos/o/r/issues/comments/200"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .expect(1)
             .mount(&server)
             .await;
 
-        let input = RevisionInput {
-            pull_number: 42,
-            old_sha: "bbbbbbbbbbbb",
-            new_sha: "cccccccccccc",
-            change_type: ChangeType::Rebase,
-            reason: "",
-            replay_sha: None,
-            timestamp: ts(),
-        };
-        update_revision_history_for_pull(
+        upsert_revision_history_comment(
             &client(&server),
             "o",
             "r",
-            "https://api.github.com",
-            &input,
+            42,
+            "### Revision history\n\nNEW",
         )
         .await
         .unwrap();
-
-        let reqs = server.received_requests().await.unwrap();
-        let patch = reqs.iter().find(|r| r.method.as_str() == "PATCH").unwrap();
-        let body = request_body(patch);
-        let body_str = body["body"].as_str().unwrap();
-        assert!(body_str.contains("| 1 | initial |"));
-        assert!(body_str.contains("| 2 | content |"));
-        // New rebase row appended.
-        assert!(body_str.contains("| 3 | rebase |"));
     }
 
     #[tokio::test]
-    async fn revision_history_overwrites_when_existing_marker_corrupted() {
-        // The header matches but the marker JSON is junk —
-        // parse() returns None. Recovery path: PATCH with a
-        // fresh initial 2-row comment so the next push has a
-        // clean slate.
+    async fn revision_comment_noops_when_body_identical() {
+        // Same body → neither PATCH nor POST. Only the GET runs; any
+        // write request would 404 against the mock server and fail.
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(wm_path("/repos/o/r/issues/42/comments"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!([
                 {
-                    "url": format!("{}/repos/o/r/issues/comments/300", server.uri()),
-                    "body": "### Revision history\n\n<!-- mergify-revision-data: not-json -->",
+                    "url": format!("{}/repos/o/r/issues/comments/200", server.uri()),
+                    "body": "### Revision history\n\nSAME",
                 },
             ])))
-            .mount(&server)
-            .await;
-        Mock::given(method("PATCH"))
-            .and(wm_path("/repos/o/r/issues/comments/300"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .expect(1)
             .mount(&server)
             .await;
 
-        let input = RevisionInput {
-            pull_number: 42,
-            old_sha: "aaaaaaaaaaaa",
-            new_sha: "bbbbbbbbbbbb",
-            change_type: ChangeType::Content,
-            reason: "recover",
-            replay_sha: None,
-            timestamp: ts(),
-        };
-        update_revision_history_for_pull(
+        upsert_revision_history_comment(
             &client(&server),
             "o",
             "r",
-            "https://api.github.com",
-            &input,
+            42,
+            "### Revision history\n\nSAME",
         )
         .await
         .unwrap();
-
-        let reqs = server.received_requests().await.unwrap();
-        let patch = reqs.iter().find(|r| r.method.as_str() == "PATCH").unwrap();
-        let body = request_body(patch);
-        let body_str = body["body"].as_str().unwrap();
-        // Fresh `create_initial` shape, not an append.
-        assert!(body_str.contains("| 1 | initial |"));
-        assert!(body_str.contains("| 2 | content |"));
-        assert!(!body_str.contains("| 3 |"));
     }
 }

--- a/crates/mergify-stack/src/notes_push.rs
+++ b/crates/mergify-stack/src/notes_push.rs
@@ -102,9 +102,11 @@ fn merge_remote_notes(repo_dir: Option<&Path>, remote: &str) -> Result<(), CliEr
         &["fetch", remote, "--no-write-fetch-head", &refspec],
     )?;
     // `notes merge --strategy=union` keeps both sides verbatim
-    // when they diverge — for the stack-notes ref the values are
-    // amend reasons keyed by SHA, so a union is exactly the
-    // right merge.
+    // when they diverge. Stack notes are either plain amend
+    // reasons or full history notes keyed by SHA; a union may
+    // concatenate two divergent history notes, which
+    // `revision_note::parse` tolerates (it keeps the longest
+    // marker payload) and the next push rewrites cleanly.
     let notes_ref_arg = format!("--ref={STACK_NOTES_REF}");
     let result = run_git_silent(
         repo_dir,

--- a/crates/mergify-stack/src/revision_note.rs
+++ b/crates/mergify-stack/src/revision_note.rs
@@ -84,6 +84,31 @@ pub fn parse(
     best.map(|entries| RevisionHistoryComment::from_entries(github_server, user, repo, entries))
 }
 
+/// Recover the history a previous (failed) push attempt already
+/// wrote on the local head commit. Returns it only when its last
+/// entry records exactly the `old_sha` → `new_sha` transition the
+/// current push is about to append — anything else (another
+/// machine pushed meanwhile, a different amend) means the note is
+/// stale and the caller must rebuild from the old head's note.
+/// Keeping the recovered entry (reason, timestamp, and all) makes
+/// retries idempotent instead of appending a blank-reason
+/// duplicate.
+#[must_use]
+pub fn recover_pending(
+    note_text: &str,
+    github_server: &str,
+    user: &str,
+    repo: &str,
+    old_sha: &str,
+    new_sha: &str,
+) -> Option<RevisionHistoryComment> {
+    parse(note_text, github_server, user, repo).filter(|h| {
+        h.entries
+            .last()
+            .is_some_and(|e| e.old_sha.as_deref() == Some(old_sha) && e.new_sha == new_sha)
+    })
+}
+
 /// Read the raw note text on `sha` from the stack notes ref.
 /// `None` covers both "no note" and "git failed" — the caller
 /// treats both as "no previous history here".
@@ -257,6 +282,59 @@ mod tests {
         );
         let parsed = parse(&note, GH, "o", "r").expect("valid marker still found");
         assert_eq!(parsed.entries.len(), 3);
+    }
+
+    #[test]
+    fn recover_pending_matches_last_entry_transition() {
+        let history = sample_history();
+        let note = render(&history, 42);
+        let last = history.entries.last().unwrap();
+        let recovered = recover_pending(
+            &note,
+            GH,
+            "o",
+            "r",
+            last.old_sha.as_deref().unwrap(),
+            &last.new_sha,
+        )
+        .expect("recovers matching pending history");
+        assert_eq!(recovered.entries, history.entries);
+    }
+
+    #[test]
+    fn recover_pending_rejects_mismatched_last_entry() {
+        let history = sample_history();
+        let note = render(&history, 42);
+        let last = history.entries.last().unwrap();
+        // A different new_sha than what's recorded means another
+        // push (or amend) happened since this note was written —
+        // the note is stale and must not be reused.
+        assert!(
+            recover_pending(
+                &note,
+                GH,
+                "o",
+                "r",
+                last.old_sha.as_deref().unwrap(),
+                "ffffffffffffffffffffffffffffffffffffffff",
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn recover_pending_rejects_plain_reason() {
+        assert!(
+            recover_pending(
+                "fixed a typo in the docs",
+                GH,
+                "o",
+                "r",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            )
+            .is_none()
+        );
     }
 
     // --- git IO ---

--- a/skills/mergify-stack/SKILL.md
+++ b/skills/mergify-stack/SKILL.md
@@ -92,9 +92,9 @@ Use `mergify stack list` to see which commits have been pushed, which PRs they m
 
 `mergify stack note` records *why* a commit was amended. The note travels with the stack:
 
-- Stored locally under `refs/notes/mergify/stack` against the commit SHA.
-- Pushed automatically by `mergify stack push` (alongside the commit refspecs, with `--force-with-lease`).
-- Surfaced in the PR's **Revision history** comment as the `Reason` column of the markdown table, and embedded in the `<!-- mergify-revision-data: {...} -->` JSON marker (key `reason`) so it can be parsed programmatically.
+- The reason is stored locally under `refs/notes/mergify/stack` against the commit SHA.
+- On `mergify stack push`, the reason is consumed into the change's revision history; the note on the pushed head commit is replaced by the **full revision history** (human digest + the `<!-- mergify-revision-data: {...} -->` JSON marker). Git notes — not the PR comment — are the machine-readable source of truth; the PR's "Revision history" comment is rendered from them.
+- At merge time, Mergify copies the head commit's history note onto the merge/squash commit, so `git log --notes=mergify/stack` on the base branch shows why each change was revised.
 
 **When to attach a note** — any time you amend or rewrite a commit that already has a PR open (i.e. it has been pushed at least once). The note answers "why is this revision different?" so the reviewer doesn't have to diff old vs new SHAs to find out.
 


### PR DESCRIPTION
On push, each updated change's full revision history (digest +
mergify-revision-data marker) is written as the git note on the new
head commit before the atomic push, replacing the plain amend-reason
note it consumes. The previous history is read from the old remote
head's note — falling back to parsing the PR comment once as a
migration seed — and the PR's Revision history comment is now a pure
rendering of that data. This lets the Mergify engine copy the note
onto the merge commit at merge time, keeping the history reachable
from the base branch after the stacked branches are deleted.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Depends-On: #1712