### PR TITLE
ci: pin the Rust toolchain to 1.97

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,10 +22,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install Rust toolchain
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
-          rustup component add rustfmt clippy --toolchain stable
+        # No version argument: installs the channel + components
+        # pinned in rust-toolchain.toml.
+        run: rustup toolchain install
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
@@ -59,14 +58,17 @@ jobs:
           echo "Declared MSRV: ${msrv}"
           echo "version=${msrv}" >> "${GITHUB_OUTPUT}"
       - name: Install MSRV toolchain
-        run: |
-          rustup toolchain install "${{ steps.msrv.outputs.version }}" --profile minimal
-          rustup default "${{ steps.msrv.outputs.version }}"
+        run: rustup toolchain install "${{ steps.msrv.outputs.version }}" --profile minimal
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: msrv
       - name: cargo check --locked on MSRV
+        # RUSTUP_TOOLCHAIN outranks rust-toolchain.toml (which
+        # outranks `rustup default` — so without this env the job
+        # silently checks the pinned toolchain, not the MSRV).
         run: cargo check --workspace --all-targets --locked
+        env:
+          RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.version }}
 
   # Supply-chain gate: RUSTSEC advisories, license policy, banned /
   # duplicate crates, and source provenance. Policy lives in
@@ -124,9 +126,9 @@ jobs:
         with:
           python-version: 3.14
       - name: Install Rust toolchain
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
+        # No version argument: installs the channel pinned in
+        # rust-toolchain.toml.
+        run: rustup toolchain install
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: smoke-${{ matrix.os }}
@@ -181,9 +183,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Install Rust toolchain
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
+        # No version argument: installs the channel pinned in
+        # rust-toolchain.toml.
+        run: rustup toolchain install
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: install-${{ matrix.os }}
@@ -341,9 +343,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Install Rust toolchain
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
+        # No version argument: installs the channel pinned in
+        # rust-toolchain.toml.
+        run: rustup toolchain install
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: self-update-${{ matrix.os }}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,7 @@
+# Pinned so a new stable release can't break every open PR with new
+# clippy lints on untouched code. Renovate's rust-toolchain manager
+# proposes bumps (after the 7-day minimumReleaseAge); a bump PR that
+# trips new lints fails CI and must fix them in the same PR.
 [toolchain]
-channel = "stable"
+channel = "1.97"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
rust-toolchain.toml tracked `stable`, so every new Rust release
could break all open PRs at once with new clippy lints on untouched
code (as 1.97's question_mark extension just did). Pin the channel:
Renovate's rust-toolchain manager proposes bumps after the 7-day
minimumReleaseAge, and a bump PR that trips new lints fails CI until
they're fixed in that same PR — deliberate upgrades, automated
reminders.

The workflow install steps now install from the pin (`rustup
toolchain install` with no argument). The MSRV job gets an explicit
RUSTUP_TOOLCHAIN: rust-toolchain.toml outranks `rustup default`, so
the job had been silently type-checking with stable instead of the
declared MSRV.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Depends-On: #1714