### PR TITLE
fix(stack): lease the notes-ref push on the fetched remote SHA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,10 +22,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install Rust toolchain
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
-          rustup component add rustfmt clippy --toolchain stable
+        # No version argument: installs the channel + components
+        # pinned in rust-toolchain.toml.
+        run: rustup toolchain install
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
@@ -59,14 +58,17 @@ jobs:
           echo "Declared MSRV: ${msrv}"
           echo "version=${msrv}" >> "${GITHUB_OUTPUT}"
       - name: Install MSRV toolchain
-        run: |
-          rustup toolchain install "${{ steps.msrv.outputs.version }}" --profile minimal
-          rustup default "${{ steps.msrv.outputs.version }}"
+        run: rustup toolchain install "${{ steps.msrv.outputs.version }}" --profile minimal
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: msrv
       - name: cargo check --locked on MSRV
+        # RUSTUP_TOOLCHAIN outranks rust-toolchain.toml (which
+        # outranks `rustup default` — so without this env the job
+        # silently checks the pinned toolchain, not the MSRV).
         run: cargo check --workspace --all-targets --locked
+        env:
+          RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.version }}
 
   # Supply-chain gate: RUSTSEC advisories, license policy, banned /
   # duplicate crates, and source provenance. Policy lives in
@@ -124,9 +126,9 @@ jobs:
         with:
           python-version: 3.14
       - name: Install Rust toolchain
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
+        # No version argument: installs the channel pinned in
+        # rust-toolchain.toml.
+        run: rustup toolchain install
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: smoke-${{ matrix.os }}
@@ -181,9 +183,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Install Rust toolchain
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
+        # No version argument: installs the channel pinned in
+        # rust-toolchain.toml.
+        run: rustup toolchain install
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: install-${{ matrix.os }}
@@ -341,9 +343,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Install Rust toolchain
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
+        # No version argument: installs the channel pinned in
+        # rust-toolchain.toml.
+        run: rustup toolchain install
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: self-update-${{ matrix.os }}

--- a/crates/mergify-core/src/auth.rs
+++ b/crates/mergify-core/src/auth.rs
@@ -138,16 +138,16 @@ fn git_remote_origin_url() -> Option<String> {
 fn parse_slug(url: &str) -> Option<String> {
     let url = url.trim();
 
-    // SSH form: `git@host:owner/repo[.git]` — no scheme, the
-    // delimiter between user@host and path is `:`. We detect this
-    // by checking for `@…:` before the first `/`.
+    // A scheme (`://`) means an HTTPS-style URL: the slug is the
+    // path after the host. Anything without a scheme is treated
+    // as the SSH form `git@host:owner/repo[.git]`: the slug is
+    // whatever follows the first `:`.
     let path = if let Some(scheme_end) = url.find("://") {
         let after_scheme = &url[scheme_end + 3..];
         after_scheme.split_once('/')?.1.to_string()
-    } else if let Some(colon) = url.find(':') {
-        url[colon + 1..].to_string()
     } else {
-        return None;
+        let colon = url.find(':')?;
+        url[colon + 1..].to_string()
     };
 
     let path = path.trim_end_matches('/').trim_start_matches('/');

--- a/crates/mergify-stack/src/commands/push.rs
+++ b/crates/mergify-stack/src/commands/push.rs
@@ -44,7 +44,7 @@ use crate::changes::Action;
 use crate::commands::sync as sync_cmd;
 use crate::comment_upsert;
 use crate::local_commits;
-use crate::notes_push::{self, PushEntry};
+use crate::notes_push::{self, NotesLease, PushEntry};
 use crate::plan::{self, PlannedChange, PlannedChanges, PlannerOpts};
 use crate::pr_upsert::{self, PrUpsertInput, StaleBase};
 use crate::progress::{Mark, Progress};
@@ -157,14 +157,14 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
 
     // The trunk + notes fetch is synchronous git; run it on a
     // blocking thread so the spinner keeps ticking smoothly across it.
-    let notes_ref_fetched = {
+    let notes_lease = {
         let repo = repo_dir.clone();
         let remote = remote.to_string();
         let base = base_branch.to_string();
         prog.run(
             pf,
             "fetching trunk",
-            spawn_git_blocking("git fetch", move || -> Result<bool, CliError> {
+            spawn_git_blocking("git fetch", move || -> Result<NotesLease, CliError> {
                 run_git_silent(Some(&repo), &["fetch", &remote, &base])?;
                 notes_push::fetch_notes_ref(Some(&repo), &remote)
             }),
@@ -573,17 +573,25 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         let repo = repo_dir.clone();
         let remote_owned = remote.to_string();
         let no_verify = opts.no_verify;
+        let push_notes_lease = notes_lease.clone();
         let push = spawn_git_blocking("git push", move || {
             notes_push::push_branches(
                 Some(&repo),
                 &remote_owned,
                 &push_entries,
                 no_verify,
-                notes_ref_fetched,
+                &push_notes_lease,
             )
         });
         prog.run_optional(publishing, format!("pushing {pushed} branch(es)"), push)
             .await?;
+    }
+    if pushed > 0 && matches!(notes_lease, NotesLease::Unknown) {
+        deferred_notes.push(
+            "Could not determine the remote notes state; stack notes were not \
+             pushed and will catch up on the next push."
+                .to_string(),
+        );
     }
     if let Some(idx) = publishing {
         prog.resolve(

--- a/crates/mergify-stack/src/commands/push.rs
+++ b/crates/mergify-stack/src/commands/push.rs
@@ -11,13 +11,16 @@
 //! 5. Rebase via [`crate::commands::sync`] (or skip).
 //! 6. Optionally compute change types + replay SHAs for the
 //!    revision-history comment.
-//! 7. `git push --atomic` via [`crate::notes_push`].
-//! 8. Upsert each PR sequentially via [`crate::pr_upsert`] so
+//! 7. Prepare each Update's revision history and write it as a
+//!    git note on the new head commit (`crate::revision_note`),
+//!    so step 8's atomic push carries it.
+//! 8. `git push --atomic` via [`crate::notes_push`].
+//! 9. Upsert each PR sequentially via [`crate::pr_upsert`] so
 //!    each `Depends-On: #<n>` header sees the predecessor's
 //!    freshly-created PR number.
-//! 9. Upsert stack comments + revision-history comments per PR
-//!    via [`crate::comment_upsert`].
-//! 10. Tear down orphan branches.
+//! 10. Upsert stack comments, and render + upsert each prepared
+//!     revision-history comment, per PR via [`crate::comment_upsert`].
+//! 11. Tear down orphan branches.
 //!
 //! PR upserts run sequentially. Async here is incidental — it comes
 //! from reqwest's async-only client, not from a need for concurrency:
@@ -39,7 +42,7 @@ use crate::approvals::{self, RebaseDecision};
 use crate::change_type::{self, ChangeType};
 use crate::changes::Action;
 use crate::commands::sync as sync_cmd;
-use crate::comment_upsert::{self, RevisionInput};
+use crate::comment_upsert;
 use crate::local_commits;
 use crate::notes_push::{self, PushEntry};
 use crate::plan::{self, PlannedChange, PlannedChanges, PlannerOpts};
@@ -48,6 +51,8 @@ use crate::progress::{Mark, Progress};
 use crate::rebase_log;
 use crate::remote_changes;
 use crate::replay;
+use crate::revision_history::RevisionHistoryComment;
+use crate::revision_note;
 use crate::stack_comment::StackEntry;
 use crate::stack_context;
 use crate::trunk;
@@ -323,6 +328,8 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
     let mut change_types: std::collections::HashMap<String, ChangeType> =
         std::collections::HashMap::new();
     let mut deferred_notes: Vec<String> = Vec::new();
+    let mut revision_histories: std::collections::HashMap<String, (u64, RevisionHistoryComment)> =
+        std::collections::HashMap::new();
     if opts.revision_history {
         let updated_pr_numbers: Vec<u64> = planned
             .locals
@@ -360,6 +367,148 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
             let ct =
                 change_type::detect_change_type(Some(&repo_dir), old_sha, &entry.change.commit_sha);
             change_types.insert(entry.change.change_id.clone(), ct);
+        }
+
+        // Build each Update's full revision history BEFORE the push:
+        // the history is written as a git note on the new head commit
+        // so the atomic push below carries it with the branches. The
+        // Mergify engine copies that note onto the merge commit at
+        // merge time, so it must be on the remote before the PR can
+        // merge — writing it after the push would leave a window.
+        let now = Utc::now();
+        for p in &planned.locals {
+            if !matches!(p.change.action, Action::Update) {
+                continue;
+            }
+            let Some(pull) = p.change.pull.as_ref() else {
+                continue;
+            };
+            let Some(number) = pull.get("number").and_then(Value::as_u64) else {
+                continue;
+            };
+            let Some(old_sha) = pull.pointer("/head/sha").and_then(Value::as_str) else {
+                continue;
+            };
+
+            // A marker-carrying note on the local commit is a history
+            // note left by a previous push attempt that failed before
+            // the branch landed. If it records exactly this old→new
+            // transition, reuse it verbatim — rebuilding from the old
+            // head's note would lose the reason the user attached
+            // before the failed attempt — and skip the replay/change-
+            // type work below entirely: the recovered entry already
+            // carries its own replay_sha, and replay uploads objects
+            // to GitHub, so it must not run pointlessly.
+            if crate::revision_history::contains_marker(&p.change.note)
+                && let Some(history) = revision_note::recover_pending(
+                    &p.change.note,
+                    opts.github_server,
+                    opts.user,
+                    opts.repo,
+                    old_sha,
+                    &p.change.commit_sha,
+                )
+            {
+                revision_note::write_note(
+                    Some(&repo_dir),
+                    &p.change.commit_sha,
+                    &revision_note::render(&history, number),
+                )?;
+                revision_histories.insert(p.change.change_id.clone(), (number, history));
+                continue;
+            }
+
+            let ct = change_types
+                .get(&p.change.change_id)
+                .copied()
+                .unwrap_or(ChangeType::Unknown);
+
+            // Replay only when the change is content (not rebase or
+            // unknown) — for rebase/unknown the revision-history
+            // table renders without a compare URL anyway.
+            let replay_sha = if matches!(ct, ChangeType::Content) {
+                replay::replay_for_revision(
+                    opts.client,
+                    Some(&repo_dir),
+                    opts.user,
+                    opts.repo,
+                    old_sha,
+                    &p.change.commit_sha,
+                )
+                .await
+            } else {
+                None
+            };
+
+            // A marker-carrying note on the local commit that didn't
+            // match the recovery check above is stale machine history
+            // (another machine pushed meanwhile, or a different
+            // amend followed the failed attempt) — not a user reason.
+            let reason = if crate::revision_history::contains_marker(&p.change.note) {
+                ""
+            } else {
+                p.change.note.as_str()
+            };
+
+            let history = match revision_note::load_or_seed(
+                opts.client,
+                Some(&repo_dir),
+                opts.github_server,
+                opts.user,
+                opts.repo,
+                number,
+                old_sha,
+            )
+            .await
+            {
+                Ok(Some(mut h)) => {
+                    h.append(
+                        old_sha,
+                        &p.change.commit_sha,
+                        ct,
+                        now,
+                        reason,
+                        replay_sha.as_deref(),
+                    );
+                    h
+                }
+                Ok(None) => RevisionHistoryComment::create_initial(
+                    opts.github_server,
+                    opts.user,
+                    opts.repo,
+                    old_sha,
+                    &p.change.commit_sha,
+                    ct,
+                    now,
+                    reason,
+                    replay_sha.as_deref(),
+                ),
+                Err(e) => {
+                    // A transient failure (e.g. rate limit) fetching
+                    // the migration-seed PR comment must not fall
+                    // back to `create_initial`: that would write a
+                    // fresh 2-entry history and, worse, PATCH over
+                    // the PR comment that was the only remaining
+                    // seed — permanently destroying history a retry
+                    // could otherwise have recovered. Leave this PR's
+                    // history untouched this push (no note write, no
+                    // comment update): it converges on the next push
+                    // once the GET succeeds, since neither the old
+                    // head's note nor the comment changed meanwhile.
+                    deferred_notes.push(format!(
+                        "Could not load previous revision history for #{number}; \
+                         leaving it untouched this push, will retry next push: {e}",
+                    ));
+                    continue;
+                }
+            };
+
+            revision_note::write_note(
+                Some(&repo_dir),
+                &p.change.commit_sha,
+                &revision_note::render(&history, number),
+            )?;
+            revision_histories.insert(p.change.change_id.clone(), (number, history));
         }
     }
 
@@ -578,77 +727,28 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         prog.resolve(cidx, Mark::Done, Some("stack comments updated"));
     }
 
-    // Revision-history comments — only for Updates, and only
-    // when revision_history is enabled.
-    if opts.revision_history {
-        let has_updates = planned
-            .locals
-            .iter()
-            .any(|p| matches!(p.change.action, Action::Update) && p.change.pull.is_some());
-        if has_updates {
-            let ridx = prog.add("queued");
-            prog.run(ridx, "updating revision history", async {
-                let now = Utc::now();
-                for p in &planned.locals {
-                    if !matches!(p.change.action, Action::Update) {
-                        continue;
-                    }
-                    let Some(pull) = p.change.pull.as_ref() else {
-                        continue;
-                    };
-                    let Some(number) = pull.get("number").and_then(Value::as_u64) else {
-                        continue;
-                    };
-                    let Some(old_sha) = pull.pointer("/head/sha").and_then(Value::as_str) else {
-                        continue;
-                    };
-
-                    let ct = change_types
-                        .get(&p.change.change_id)
-                        .copied()
-                        .unwrap_or(ChangeType::Unknown);
-
-                    // Replay only when the change is content (not
-                    // rebase or unknown) — for rebase/unknown the
-                    // revision-history table renders without a
-                    // compare URL anyway.
-                    let replay_sha = if matches!(ct, ChangeType::Content) {
-                        replay::replay_for_revision(
-                            opts.client,
-                            Some(&repo_dir),
-                            opts.user,
-                            opts.repo,
-                            old_sha,
-                            &p.change.commit_sha,
-                        )
-                        .await
-                    } else {
-                        None
-                    };
-
-                    let input = RevisionInput {
-                        pull_number: number,
-                        old_sha,
-                        new_sha: &p.change.commit_sha,
-                        change_type: ct,
-                        reason: &p.change.note,
-                        replay_sha: replay_sha.as_deref(),
-                        timestamp: now,
-                    };
-                    comment_upsert::update_revision_history_for_pull(
-                        opts.client,
-                        opts.user,
-                        opts.repo,
-                        opts.github_server,
-                        &input,
-                    )
-                    .await?;
-                }
-                Ok::<(), CliError>(())
-            })
-            .await?;
-            prog.resolve(ridx, Mark::Done, Some("revision history updated"));
-        }
+    // Revision-history comments — rendered from the histories
+    // prepared (and written as git notes) before the push.
+    if !revision_histories.is_empty() {
+        let ridx = prog.add("queued");
+        prog.run(ridx, "updating revision history", async {
+            for p in &planned.locals {
+                let Some((number, history)) = revision_histories.get(&p.change.change_id) else {
+                    continue;
+                };
+                comment_upsert::upsert_revision_history_comment(
+                    opts.client,
+                    opts.user,
+                    opts.repo,
+                    *number,
+                    &history.body(*number),
+                )
+                .await?;
+            }
+            Ok::<(), CliError>(())
+        })
+        .await?;
+        prog.resolve(ridx, Mark::Done, Some("revision history updated"));
     }
 
     // Orphan-branch teardown — last so we don't yank the rug out

--- a/crates/mergify-stack/src/comment_upsert.rs
+++ b/crates/mergify-stack/src/comment_upsert.rs
@@ -5,21 +5,18 @@
 //!   of a stack" table (see [`crate::stack_comment`]). Skipped
 //!   when the stack has only one PR — a single-row table would
 //!   be noise.
-//! - [`update_revision_history_for_pull`] — the "Revision
-//!   history" table (see [`crate::revision_history`]). On
-//!   every push, parses the existing comment's JSON marker,
-//!   **appends** the new revision row, and `PATCH`es — so
-//!   historic links are preserved verbatim while the new row
-//!   gets fresh rendering.
+//! - [`upsert_revision_history_comment`] — the "Revision
+//!   history" table (see [`crate::revision_history`]). The
+//!   revision-history body is pre-rendered by the push
+//!   orchestrator from the git-notes history (see
+//!   [`crate::revision_note`]); this module only diffs the
+//!   rendered body against the existing comment and writes it.
 //!
 //! Both walk the issue comments once, match on the header
 //! (`StackComment::is_stack_comment` / `RevisionHistoryComment::
 //! is_revision_comment`), then choose between PATCH (existing
 //! found, body changed), no-op (existing found, body unchanged),
-//! and POST (no existing). The revision upserter has a third
-//! branch: header matched but the marker JSON couldn't be parsed
-//! — overwrite with a fresh initial comment so a corrupted
-//! historic comment doesn't permanently block updates.
+//! and POST (no existing).
 //!
 //! Ported from
 //! `mergify_cli/stack/push.py::{_update_comment_for_pull,
@@ -28,13 +25,11 @@
 //! lives in the eventual `stack_push` orchestrator port — these
 //! are pure single-PR helpers.
 
-use chrono::{DateTime, Utc};
 use mergify_core::{CliError, HttpClient};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use url::Url;
 
-use crate::change_type::ChangeType;
 use crate::revision_history::RevisionHistoryComment;
 use crate::stack_comment::{self, StackEntry};
 
@@ -114,124 +109,50 @@ pub async fn update_stack_comment_for_pull(
     Ok(())
 }
 
-/// Inputs to [`update_revision_history_for_pull`] — the per-row
-/// fields the orchestrator resolves before calling. Decoupled
-/// from [`crate::changes::LocalChange`] because `pull_head_sha`,
-/// `reason`, `change_type`, and `replay_sha` are all computed
-/// during the push (not at classifier time).
-#[derive(Debug, Clone)]
-pub struct RevisionInput<'a> {
-    pub pull_number: u64,
-    pub old_sha: &'a str,
-    pub new_sha: &'a str,
-    pub change_type: ChangeType,
-    pub reason: &'a str,
-    pub replay_sha: Option<&'a str>,
-    pub timestamp: DateTime<Utc>,
-}
-
-/// Upsert the revision-history comment for one PR.
+/// Upsert the revision-history comment with a pre-rendered body.
 ///
-/// Three branches:
-///
-/// - **Existing parseable comment** → parse, [`append`] the new
-///   row, render, PATCH if changed. Historic rows render
-///   verbatim so old links stay intact.
-/// - **Existing comment, header matches but marker corrupted** →
-///   PATCH with a fresh 2-row `create_initial` comment.
-///   Recovers from a hand-edited / out-of-schema marker
-///   without leaving a stuck PR.
-/// - **No existing comment** → POST a fresh `create_initial`.
-///
-/// [`append`]: crate::revision_history::RevisionHistoryComment::append
-pub async fn update_revision_history_for_pull(
+/// The body is rendered by the caller from the git-notes history
+/// (the machine source of truth — see [`crate::revision_note`]);
+/// this function never parses comment content. Find our comment
+/// by header → PATCH if the body differs (no-op if identical);
+/// none found → POST.
+pub async fn upsert_revision_history_comment(
     client: &HttpClient,
     user: &str,
     repo: &str,
-    github_server: &str,
-    input: &RevisionInput<'_>,
+    pull_number: u64,
+    new_body: &str,
 ) -> Result<(), CliError> {
-    let path = format!(
-        "/repos/{user}/{repo}/issues/{pull_number}/comments",
-        pull_number = input.pull_number,
-    );
+    let path = format!("/repos/{user}/{repo}/issues/{pull_number}/comments");
     let comments: Vec<Comment> = client.get(&path).await?;
-
-    // Cheap to construct unconditionally — both the
-    // corrupted-marker and no-comment branches need it, and the
-    // common parseable-comment branch ignores it.
-    let fresh = RevisionHistoryComment::create_initial(
-        github_server,
-        user,
-        repo,
-        input.old_sha,
-        input.new_sha,
-        input.change_type,
-        input.timestamp,
-        input.reason,
-        input.replay_sha,
-    );
 
     for comment in &comments {
         if !RevisionHistoryComment::is_revision_comment(&comment.body) {
             continue;
         }
-        match RevisionHistoryComment::parse(&comment.body, github_server, user, repo) {
-            Some(mut parsed) => {
-                parsed.append(
-                    input.old_sha,
-                    input.new_sha,
-                    input.change_type,
-                    input.timestamp,
-                    input.reason,
-                    input.replay_sha,
-                );
-                let new_body = parsed.body(input.pull_number);
-                if comment.body != new_body {
-                    let _: Value = client
-                        .patch(&comment_path(&comment.url)?, &BodyOnly { body: &new_body })
-                        .await?;
-                }
-            }
-            None => {
-                // Header matched but marker corrupted — recover
-                // by overwriting with a fresh initial comment.
-                // Better than leaving the PR with a stuck
-                // unparseable comment.
-                let _: Value = client
-                    .patch(
-                        &comment_path(&comment.url)?,
-                        &BodyOnly {
-                            body: &fresh.body(input.pull_number),
-                        },
-                    )
-                    .await?;
-            }
+        if comment.body != new_body {
+            let _: Value = client
+                .patch(&comment_path(&comment.url)?, &BodyOnly { body: new_body })
+                .await?;
         }
         return Ok(());
     }
 
-    // No existing revision-history comment — POST a fresh one.
-    let _: Value = client
-        .post(
-            &path,
-            &BodyOnly {
-                body: &fresh.body(input.pull_number),
-            },
-        )
-        .await?;
+    let _: Value = client.post(&path, &BodyOnly { body: new_body }).await?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::TimeZone;
+    use chrono::{DateTime, TimeZone, Utc};
     use mergify_core::ApiFlavor;
     use serde_json::json;
     use url::Url;
     use wiremock::matchers::{method, path as wm_path};
     use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+    use crate::change_type::ChangeType;
 
     fn client(server: &MockServer) -> HttpClient {
         HttpClient::new(
@@ -359,56 +280,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn revision_history_creates_when_missing() {
+    async fn revision_comment_posts_when_missing() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(wm_path("/repos/o/r/issues/42/comments"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .expect(1)
             .mount(&server)
             .await;
         Mock::given(method("POST"))
             .and(wm_path("/repos/o/r/issues/42/comments"))
             .respond_with(ResponseTemplate::new(201).set_body_json(json!({})))
+            .expect(1)
             .mount(&server)
             .await;
 
-        let input = RevisionInput {
-            pull_number: 42,
-            old_sha: "aaaaaaaaaaaa",
-            new_sha: "bbbbbbbbbbbb",
-            change_type: ChangeType::Content,
-            reason: "review feedback",
-            replay_sha: None,
-            timestamp: ts(),
-        };
-        update_revision_history_for_pull(
-            &client(&server),
-            "o",
-            "r",
-            "https://api.github.com",
-            &input,
-        )
-        .await
-        .unwrap();
-
-        let reqs = server.received_requests().await.unwrap();
-        let post = reqs.iter().find(|r| r.method.as_str() == "POST").unwrap();
-        let body = request_body(post);
-        let body_str = body["body"].as_str().unwrap();
-        assert!(body_str.starts_with("### Revision history\n"));
-        // First push → initial 2-row comment: synthetic "initial"
-        // row + the actual revision.
-        assert!(body_str.contains("| 1 | initial |"));
-        assert!(body_str.contains("| 2 | content |"));
-    }
-
-    #[tokio::test]
-    async fn revision_history_appends_to_existing_parseable_comment() {
-        // Seed the API with a real 2-row comment produced by
-        // `create_initial`. The upserter must parse it, append
-        // the new row, and PATCH — historic row 1 + 2 stay
-        // verbatim, fresh row 3 gets added.
-        let seed = RevisionHistoryComment::create_initial(
+        let body = RevisionHistoryComment::create_initial(
             "https://api.github.com",
             "o",
             "r",
@@ -416,106 +303,77 @@ mod tests {
             "bbbbbbbbbbbb",
             ChangeType::Content,
             ts(),
-            "first push",
+            "review feedback",
             None,
-        );
-        let seed_body = seed.body(42);
+        )
+        .body(42);
+        upsert_revision_history_comment(&client(&server), "o", "r", 42, &body)
+            .await
+            .unwrap();
 
+        let reqs = server.received_requests().await.unwrap();
+        let post = reqs.iter().find(|r| r.method.as_str() == "POST").unwrap();
+        let sent = request_body(post);
+        assert_eq!(sent["body"].as_str().unwrap(), body);
+    }
+
+    #[tokio::test]
+    async fn revision_comment_patches_when_body_differs() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(wm_path("/repos/o/r/issues/42/comments"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!([
                 {
                     "url": format!("{}/repos/o/r/issues/comments/200", server.uri()),
-                    "body": seed_body,
+                    "body": "### Revision history\n\nSTALE",
                 },
             ])))
+            .expect(1)
             .mount(&server)
             .await;
         Mock::given(method("PATCH"))
             .and(wm_path("/repos/o/r/issues/comments/200"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .expect(1)
             .mount(&server)
             .await;
 
-        let input = RevisionInput {
-            pull_number: 42,
-            old_sha: "bbbbbbbbbbbb",
-            new_sha: "cccccccccccc",
-            change_type: ChangeType::Rebase,
-            reason: "",
-            replay_sha: None,
-            timestamp: ts(),
-        };
-        update_revision_history_for_pull(
+        upsert_revision_history_comment(
             &client(&server),
             "o",
             "r",
-            "https://api.github.com",
-            &input,
+            42,
+            "### Revision history\n\nNEW",
         )
         .await
         .unwrap();
-
-        let reqs = server.received_requests().await.unwrap();
-        let patch = reqs.iter().find(|r| r.method.as_str() == "PATCH").unwrap();
-        let body = request_body(patch);
-        let body_str = body["body"].as_str().unwrap();
-        assert!(body_str.contains("| 1 | initial |"));
-        assert!(body_str.contains("| 2 | content |"));
-        // New rebase row appended.
-        assert!(body_str.contains("| 3 | rebase |"));
     }
 
     #[tokio::test]
-    async fn revision_history_overwrites_when_existing_marker_corrupted() {
-        // The header matches but the marker JSON is junk —
-        // parse() returns None. Recovery path: PATCH with a
-        // fresh initial 2-row comment so the next push has a
-        // clean slate.
+    async fn revision_comment_noops_when_body_identical() {
+        // Same body → neither PATCH nor POST. Only the GET runs; any
+        // write request would 404 against the mock server and fail.
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(wm_path("/repos/o/r/issues/42/comments"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!([
                 {
-                    "url": format!("{}/repos/o/r/issues/comments/300", server.uri()),
-                    "body": "### Revision history\n\n<!-- mergify-revision-data: not-json -->",
+                    "url": format!("{}/repos/o/r/issues/comments/200", server.uri()),
+                    "body": "### Revision history\n\nSAME",
                 },
             ])))
-            .mount(&server)
-            .await;
-        Mock::given(method("PATCH"))
-            .and(wm_path("/repos/o/r/issues/comments/300"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .expect(1)
             .mount(&server)
             .await;
 
-        let input = RevisionInput {
-            pull_number: 42,
-            old_sha: "aaaaaaaaaaaa",
-            new_sha: "bbbbbbbbbbbb",
-            change_type: ChangeType::Content,
-            reason: "recover",
-            replay_sha: None,
-            timestamp: ts(),
-        };
-        update_revision_history_for_pull(
+        upsert_revision_history_comment(
             &client(&server),
             "o",
             "r",
-            "https://api.github.com",
-            &input,
+            42,
+            "### Revision history\n\nSAME",
         )
         .await
         .unwrap();
-
-        let reqs = server.received_requests().await.unwrap();
-        let patch = reqs.iter().find(|r| r.method.as_str() == "PATCH").unwrap();
-        let body = request_body(patch);
-        let body_str = body["body"].as_str().unwrap();
-        // Fresh `create_initial` shape, not an append.
-        assert!(body_str.contains("| 1 | initial |"));
-        assert!(body_str.contains("| 2 | content |"));
-        assert!(!body_str.contains("| 3 |"));
     }
 }

--- a/crates/mergify-stack/src/lib.rs
+++ b/crates/mergify-stack/src/lib.rs
@@ -72,6 +72,13 @@
 //!   per-PR upserts sequentially (typical 2–5 PR stacks make
 //!   the latency difference negligible vs. the GitHub round-
 //!   trip cost).
+//! - [`revision_note`] — the git-notes revision-history format
+//!   (human digest + the same `mergify-revision-data` marker the
+//!   PR comment carries), its `git notes` IO, and the
+//!   note-first/comment-seed read path. The machine source of
+//!   truth for a change's revision history, replacing the plain
+//!   amend-reason note `mergify stack note` wrote on the same
+//!   commit.
 
 pub mod approvals;
 pub mod change_id;
@@ -93,6 +100,7 @@ pub mod rebase_todo;
 pub mod remote_changes;
 pub mod replay;
 pub mod revision_history;
+pub mod revision_note;
 pub mod slug;
 pub mod stack_comment;
 pub mod stack_context;

--- a/crates/mergify-stack/src/notes_push.rs
+++ b/crates/mergify-stack/src/notes_push.rs
@@ -102,9 +102,11 @@ fn merge_remote_notes(repo_dir: Option<&Path>, remote: &str) -> Result<(), CliEr
         &["fetch", remote, "--no-write-fetch-head", &refspec],
     )?;
     // `notes merge --strategy=union` keeps both sides verbatim
-    // when they diverge — for the stack-notes ref the values are
-    // amend reasons keyed by SHA, so a union is exactly the
-    // right merge.
+    // when they diverge. Stack notes are either plain amend
+    // reasons or full history notes keyed by SHA; a union may
+    // concatenate two divergent history notes, which
+    // `revision_note::parse` tolerates (it keeps the longest
+    // marker payload) and the next push rewrites cleanly.
     let notes_ref_arg = format!("--ref={STACK_NOTES_REF}");
     let result = run_git_silent(
         repo_dir,

--- a/crates/mergify-stack/src/notes_push.rs
+++ b/crates/mergify-stack/src/notes_push.rs
@@ -1,16 +1,23 @@
 //! Git-level operations the `stack push` orchestrator runs before
 //! and during the actual `git push`:
 //!
-//! - [`fetch_notes_ref`] — make sure `refs/notes/mergify/stack`
-//!   exists locally before the push so the
-//!   `--force-with-lease=<notes-ref>:<sha>` arg has a SHA to
-//!   anchor on. Unifies the "first push" (ref missing both
-//!   locally and remotely) and "follow-up push" (local notes
-//!   from `stack note`, remote notes from prior pushes — merge
-//!   them union-style) paths into one call.
+//! - [`fetch_notes_ref`] — learn the remote's current state of
+//!   `refs/notes/mergify/stack` before the push, returning a
+//!   [`NotesLease`] that anchors the notes push's
+//!   `--force-with-lease` (so a concurrent notes push landing
+//!   between our fetch and our push is rejected instead of
+//!   silently clobbered). Unifies the "first push" (ref missing
+//!   both locally and remotely) and "follow-up push" (local
+//!   notes from `stack note`, remote notes from prior pushes —
+//!   merge them union-style) paths into one call.
 //! - [`push_branches`] — the actual `git push --atomic
 //!   --force-with-lease …` that lands every create/update from
-//!   the planned changes plus the notes ref in one shot.
+//!   the planned changes plus the notes ref in one shot. Because
+//!   the notes ref rides along in the same `--atomic` push as the
+//!   branches, a stale notes lease fails the *whole* push —
+//!   branches included. That's intentional, not a rough edge: the
+//!   caller's retry re-fetches (getting a fresh [`NotesLease`])
+//!   and union-merges before trying again, so nothing is lost.
 //!
 //! Ported from `mergify_cli/stack/push.py` —
 //! `_merge_remote_notes`, `fetch_notes_ref`, `push_branches`.
@@ -50,32 +57,51 @@ pub struct PushEntry {
     pub pull_head_sha: Option<String>,
 }
 
-/// Make `refs/notes/mergify/stack` reachable locally before the
-/// next push.
-///
-/// Returns `true` when the local ref is now present (either it
-/// pre-existed, or we successfully fetched it). Returns `false`
-/// only on the first push of a stack — the ref doesn't exist
-/// anywhere yet. The caller uses the boolean to decide whether
-/// the push can attach a `--force-with-lease` to the notes ref
-/// (it can't on first push because there's no SHA to lease on).
+/// What we learned about the remote `refs/notes/mergify/stack`
+/// while fetching — the lease anchor for the notes push.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NotesLease {
+    /// Remote ref seen at this SHA: lease the push on it, so a
+    /// concurrent notes push between our fetch and our push is
+    /// rejected instead of clobbered.
+    RemoteAt(String),
+    /// Remote ref doesn't exist: lease on "ref must not exist".
+    RemoteAbsent,
+    /// Transient failure talking to the remote — its state is
+    /// unknown, so no safe lease exists. The notes refspec is
+    /// left out of the push entirely; branches still land and
+    /// the notes catch up on the next push.
+    Unknown,
+}
+
+/// Learn the remote's current state of `refs/notes/mergify/stack`
+/// so the next push can lease its own notes push on it — see
+/// [`NotesLease`].
 ///
 /// When the ref already exists locally (e.g. from a prior
-/// `stack note`), we union-merge the remote into it so unpushed
-/// local notes survive but the lease SHA stays current. Merge
-/// failures are swallowed so a transient remote hiccup doesn't
-/// block the surrounding push.
-pub fn fetch_notes_ref(repo_dir: Option<&Path>, remote: &str) -> Result<bool, CliError> {
-    // Ref exists locally → merge the remote in (best-effort) and
-    // we're done.
+/// `stack note`), we fetch the remote's copy into a temp ref,
+/// capture its SHA as the lease anchor *before* touching anything
+/// else, then union-merge it into the local ref so unpushed local
+/// notes survive. The merge itself is best-effort — its failure is
+/// swallowed so a transient remote hiccup doesn't block the
+/// surrounding push — but a lease was already captured either way.
+///
+/// When the ref is missing locally, we fetch it directly: success
+/// captures the newly-landed ref's SHA as `RemoteAt`; `couldn't
+/// find remote ref` means "first push of the stack", which maps to
+/// `RemoteAbsent`; any other failure propagates as `Err` so the
+/// user sees what went wrong (network, auth, …) — unchanged from
+/// before this function returned a lease type.
+pub fn fetch_notes_ref(repo_dir: Option<&Path>, remote: &str) -> Result<NotesLease, CliError> {
+    // Ref exists locally → fetch-and-merge the remote in, capturing
+    // whatever lease that path can construct.
     if run_git_silent(repo_dir, &["rev-parse", "--verify", STACK_NOTES_REF]).is_ok() {
-        let _ = merge_remote_notes(repo_dir, remote);
-        return Ok(true);
+        return Ok(fetch_and_merge_remote_notes(repo_dir, remote));
     }
 
     // Ref missing locally → try to fetch it. `couldn't find
     // remote ref` means "first push of the stack", which is a
-    // benign Ok(false). Any other failure propagates so the
+    // benign `RemoteAbsent`. Any other failure propagates so the
     // user sees what went wrong (network, auth, …).
     let refspec = format!("{STACK_NOTES_REF}:{STACK_NOTES_REF}");
     let output = git_cmd(repo_dir)
@@ -83,11 +109,15 @@ pub fn fetch_notes_ref(repo_dir: Option<&Path>, remote: &str) -> Result<bool, Cl
         .output()
         .map_err(|e| CliError::Generic(format!("failed to spawn `git fetch`: {e}")))?;
     if output.status.success() {
-        return Ok(true);
+        // Capture immediately — nothing else writes to the ref on
+        // this path, but the lease must reflect exactly what the
+        // fetch just landed.
+        let sha = run_git_capture(repo_dir, &["rev-parse", "--verify", STACK_NOTES_REF])?;
+        return Ok(NotesLease::RemoteAt(sha));
     }
     let stderr = String::from_utf8_lossy(&output.stderr);
     if stderr.contains("couldn't find remote ref") {
-        return Ok(false);
+        return Ok(NotesLease::RemoteAbsent);
     }
     Err(CliError::Generic(format!(
         "`git fetch {remote} {refspec}` failed: {}",
@@ -95,12 +125,36 @@ pub fn fetch_notes_ref(repo_dir: Option<&Path>, remote: &str) -> Result<bool, Cl
     )))
 }
 
-fn merge_remote_notes(repo_dir: Option<&Path>, remote: &str) -> Result<(), CliError> {
+/// The "local notes ref already exists" path of [`fetch_notes_ref`]:
+/// fetch the remote's copy into [`NOTES_INCOMING_REF`], capture its
+/// SHA as the lease anchor, then union-merge it into the local ref.
+///
+/// Never errors — a transient fetch failure (network, auth, remote
+/// gone) yields `NotesLease::Unknown` rather than blocking the
+/// surrounding push, which only needs *a* branch push to succeed.
+fn fetch_and_merge_remote_notes(repo_dir: Option<&Path>, remote: &str) -> NotesLease {
     let refspec = format!("+{STACK_NOTES_REF}:{NOTES_INCOMING_REF}");
-    run_git_silent(
-        repo_dir,
-        &["fetch", remote, "--no-write-fetch-head", &refspec],
-    )?;
+    let Ok(output) = git_cmd(repo_dir)
+        .args(["fetch", remote, "--no-write-fetch-head", &refspec])
+        .output()
+    else {
+        return NotesLease::Unknown;
+    };
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return if stderr.contains("couldn't find remote ref") {
+            NotesLease::RemoteAbsent
+        } else {
+            NotesLease::Unknown
+        };
+    }
+
+    // Capture the remote SHA *before* the union-merge below writes
+    // to the local ref — the lease must anchor on exactly what the
+    // remote had at fetch time.
+    let lease = run_git_capture(repo_dir, &["rev-parse", "--verify", NOTES_INCOMING_REF])
+        .map_or(NotesLease::Unknown, NotesLease::RemoteAt);
+
     // `notes merge --strategy=union` keeps both sides verbatim
     // when they diverge. Stack notes are either plain amend
     // reasons or full history notes keyed by SHA; a union may
@@ -108,7 +162,7 @@ fn merge_remote_notes(repo_dir: Option<&Path>, remote: &str) -> Result<(), CliEr
     // `revision_note::parse` tolerates (it keeps the longest
     // marker payload) and the next push rewrites cleanly.
     let notes_ref_arg = format!("--ref={STACK_NOTES_REF}");
-    let result = run_git_silent(
+    let _ = run_git_silent(
         repo_dir,
         &[
             "notes",
@@ -122,17 +176,23 @@ fn merge_remote_notes(repo_dir: Option<&Path>, remote: &str) -> Result<(), CliEr
     // wraps this in try/finally so we can't leave a dangling
     // `refs/notes/mergify/stack-incoming` behind.
     let _ = run_git_silent(repo_dir, &["update-ref", "-d", NOTES_INCOMING_REF]);
-    result
+
+    lease
 }
 
 /// `git push --atomic [--no-verify] --force-with-lease=… …` —
 /// land every Create/Update entry plus the notes ref in one
 /// atomic push.
 ///
-/// `notes_ref_fetched` mirrors the boolean from [`fetch_notes_ref`]:
-/// when `true` we can attach a `--force-with-lease=<notes-ref>:<sha>`
-/// anchor; when `false` (first push) we can't, but we still
-/// include the notes-ref refspec so the initial state lands.
+/// `notes_lease` is the [`NotesLease`] [`fetch_notes_ref`] returned
+/// during pre-flight:
+/// - `RemoteAt(sha)` leases the notes refspec on that SHA.
+/// - `RemoteAbsent` leases on the empty string ("ref must not
+///   exist"), protecting the create race too.
+/// - `Unknown` (the remote's state couldn't be determined) drops
+///   the notes lease *and* the notes refspec from this push
+///   entirely, rather than force-pushing blind — branches still
+///   land, and the notes catch up on the next push.
 ///
 /// `MERGIFY_STACK_PUSH=1` is exported across the push call so
 /// the pre-push hook can tell user pushes apart from CLI pushes
@@ -143,7 +203,7 @@ pub fn push_branches(
     remote: &str,
     entries: &[PushEntry],
     no_verify: bool,
-    notes_ref_fetched: bool,
+    notes_lease: &NotesLease,
 ) -> Result<(), CliError> {
     if entries.is_empty() {
         return Ok(());
@@ -168,16 +228,26 @@ pub fn push_branches(
     }
 
     // Notes ref lease + refspec only when the local notes ref
-    // exists — there's nothing to push otherwise. The lease is
-    // skipped on first push (notes_ref_fetched == false) because
-    // there's no remote SHA to anchor on; the refspec stays so
-    // the initial notes state lands.
+    // exists — there's nothing to push otherwise. When the lease
+    // is `Unknown` (remote state couldn't be determined at fetch
+    // time), skip the notes refspec entirely rather than force-
+    // push blind: branches still land, and the notes catch up on
+    // the next push.
     let notes_local_sha =
         run_git_capture(repo_dir, &["rev-parse", "--verify", STACK_NOTES_REF]).ok();
-    if let Some(sha) = notes_local_sha.as_deref()
-        && notes_ref_fetched
-    {
-        args.push(format!("--force-with-lease={STACK_NOTES_REF}:{sha}"));
+    let mut include_notes_refspec = false;
+    if notes_local_sha.is_some() {
+        match notes_lease {
+            NotesLease::RemoteAt(sha) => {
+                args.push(format!("--force-with-lease={STACK_NOTES_REF}:{sha}"));
+                include_notes_refspec = true;
+            }
+            NotesLease::RemoteAbsent => {
+                args.push(format!("--force-with-lease={STACK_NOTES_REF}:"));
+                include_notes_refspec = true;
+            }
+            NotesLease::Unknown => {}
+        }
     }
 
     args.push(remote.to_string());
@@ -187,11 +257,12 @@ pub fn push_branches(
             entry.commit_sha, entry.dest_branch,
         ));
     }
-    if notes_local_sha.is_some() {
-        // Leading `+` forces the push even when the remote
-        // diverged — paired with `--force-with-lease` above for
-        // the actual safety.
-        args.push(format!("+{STACK_NOTES_REF}:{STACK_NOTES_REF}"));
+    if include_notes_refspec {
+        // No leading `+`: the refspec must go through the
+        // `--force-with-lease` above rather than bypass it. A `+`
+        // here would make git ignore the lease and force-push
+        // unconditionally, which is exactly the bug this fixes.
+        args.push(format!("{STACK_NOTES_REF}:{STACK_NOTES_REF}"));
     }
 
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
@@ -268,9 +339,9 @@ mod tests {
     }
 
     #[test]
-    fn fetch_notes_ref_returns_false_on_first_push_when_neither_side_has_ref() {
+    fn fetch_notes_ref_returns_remote_absent_on_first_push_when_neither_side_has_ref() {
         // Bare remote with no notes ref + local repo with no
-        // notes ref → first-push path. Must return Ok(false)
+        // notes ref → first-push path. Must return `RemoteAbsent`
         // without erroring so the orchestrator drops the
         // `--force-with-lease` on the notes ref.
         let bare = init_bare_repo();
@@ -282,17 +353,17 @@ mod tests {
         );
 
         let got = fetch_notes_ref(Some(local.path()), "origin").unwrap();
-        assert!(!got, "first-push path must return Ok(false)");
+        assert_eq!(got, NotesLease::RemoteAbsent);
         // Local ref must still not exist (we didn't fabricate one).
         assert!(rev_parse(local.path(), STACK_NOTES_REF).is_none());
     }
 
     #[test]
-    fn fetch_notes_ref_returns_true_when_local_ref_already_exists() {
-        // Local `stack note` already created the ref — function
-        // returns Ok(true) without needing the remote to have
-        // anything. Best-effort remote-merge runs but its
-        // failure (no remote ref) is swallowed.
+    fn fetch_notes_ref_returns_remote_absent_when_local_ref_already_exists() {
+        // Local `stack note` already created the ref, but the
+        // remote has nothing — the fetch-and-merge path's fetch
+        // fails with "couldn't find remote ref", which maps to
+        // `RemoteAbsent` rather than erroring.
         let bare = init_bare_repo();
         let local = init_repo();
         let sha = seed_commit(local.path(), "x", "x\n", "x");
@@ -309,14 +380,14 @@ mod tests {
         assert!(rev_parse(local.path(), STACK_NOTES_REF).is_some());
 
         let got = fetch_notes_ref(Some(local.path()), "origin").unwrap();
-        assert!(got);
+        assert_eq!(got, NotesLease::RemoteAbsent);
     }
 
     #[test]
-    fn fetch_notes_ref_returns_true_when_only_remote_has_ref() {
+    fn fetch_notes_ref_returns_remote_at_when_only_remote_has_ref() {
         // Remote has notes (someone else pushed first); local
-        // is empty. The fetch lands the ref locally and we
-        // return Ok(true).
+        // is empty. The fetch lands the ref locally and the
+        // lease anchors on the remote's SHA.
         let bare = init_bare_repo();
 
         // Seed the bare with a commit + a note, then push them.
@@ -333,6 +404,7 @@ mod tests {
         );
         let notes_refspec = format!("+{STACK_NOTES_REF}:{STACK_NOTES_REF}");
         run(producer.path(), &["push", "origin", "main", &notes_refspec]);
+        let remote_sha = rev_parse(bare.path(), STACK_NOTES_REF).unwrap();
 
         // Fresh consumer with no notes ref locally.
         let local = init_repo();
@@ -344,9 +416,32 @@ mod tests {
         assert!(rev_parse(local.path(), STACK_NOTES_REF).is_none());
 
         let got = fetch_notes_ref(Some(local.path()), "origin").unwrap();
-        assert!(got);
+        assert_eq!(got, NotesLease::RemoteAt(remote_sha));
         // The fetch lands the notes ref locally.
         assert!(rev_parse(local.path(), STACK_NOTES_REF).is_some());
+    }
+
+    #[test]
+    fn fetch_notes_ref_returns_unknown_when_remote_unreachable() {
+        // Local ref exists (so the fetch-and-merge path runs), but
+        // the remote URL doesn't resolve to anything — the fetch
+        // fails for a reason other than "couldn't find remote
+        // ref", so no safe lease can be constructed.
+        let local = init_repo();
+        let sha = seed_commit(local.path(), "x", "x\n", "x");
+        let notes_ref_arg = format!("--ref={STACK_NOTES_REF}");
+        run(
+            local.path(),
+            &["notes", &notes_ref_arg, "add", "-m", "why", &sha],
+        );
+        let bogus_remote = local.path().join("no-such-remote");
+        run(
+            local.path(),
+            &["remote", "add", "origin", bogus_remote.to_str().unwrap()],
+        );
+
+        let got = fetch_notes_ref(Some(local.path()), "origin").unwrap();
+        assert_eq!(got, NotesLease::Unknown);
     }
 
     #[test]
@@ -356,7 +451,14 @@ mod tests {
         // since git push with no refspecs is a no-op).
         let local = init_repo();
         seed_commit(local.path(), "x", "x\n", "x");
-        push_branches(Some(local.path()), "origin", &[], false, false).unwrap();
+        push_branches(
+            Some(local.path()),
+            "origin",
+            &[],
+            false,
+            &NotesLease::RemoteAbsent,
+        )
+        .unwrap();
     }
 
     #[test]
@@ -378,7 +480,14 @@ mod tests {
             dest_branch: "stack/feat/x".into(),
             pull_head_sha: None,
         }];
-        push_branches(Some(local.path()), "origin", &entries, false, false).unwrap();
+        push_branches(
+            Some(local.path()),
+            "origin",
+            &entries,
+            false,
+            &NotesLease::RemoteAbsent,
+        )
+        .unwrap();
 
         // Remote now has the branch pointed at the same SHA.
         let remote_sha =
@@ -424,8 +533,14 @@ mod tests {
             // Stale: not equal to producer_sha on the remote.
             pull_head_sha: Some("0000000000000000000000000000000000000000".into()),
         }];
-        let err = push_branches(Some(local.path()), "origin", &entries, false, false)
-            .expect_err("stale lease must reject");
+        let err = push_branches(
+            Some(local.path()),
+            "origin",
+            &entries,
+            false,
+            &NotesLease::RemoteAbsent,
+        )
+        .expect_err("stale lease must reject");
         let CliError::Generic(msg) = err else {
             panic!("expected Generic CliError");
         };
@@ -438,5 +553,144 @@ mod tests {
         let remote_sha =
             run_git_capture(Some(bare.path()), &["rev-parse", "refs/heads/stack/feat/x"]).unwrap();
         assert_eq!(remote_sha, producer_sha);
+    }
+
+    #[test]
+    fn push_branches_notes_lease_rejects_when_remote_moved() {
+        // The core safety invariant this fix exists for: a lease
+        // captured at fetch time (`RemoteAt(v1)`) must reject the
+        // push once a concurrent `stack push` has moved the remote
+        // notes ref to `v2` — and the remote must be left exactly
+        // as producer B left it (no silent clobber, no partial
+        // atomic landing of the branch either).
+        let bare = init_bare_repo();
+        let notes_ref_arg = format!("--ref={STACK_NOTES_REF}");
+
+        // Producer A seeds the remote with a commit + a note.
+        let producer_a = init_repo();
+        let sha_a = seed_commit(producer_a.path(), "a", "a\n", "a");
+        run(
+            producer_a.path(),
+            &["remote", "add", "origin", bare.path().to_str().unwrap()],
+        );
+        run(
+            producer_a.path(),
+            &["notes", &notes_ref_arg, "add", "-m", "a", &sha_a],
+        );
+        run(producer_a.path(), &["push", "origin", "main"]);
+        let force_notes_refspec = format!("+{STACK_NOTES_REF}:{STACK_NOTES_REF}");
+        run(producer_a.path(), &["push", "origin", &force_notes_refspec]);
+
+        // Consumer fetches: local ref is missing, so `fetch_notes_ref`
+        // takes the fetch-and-capture path, lands the notes ref
+        // locally at v1, and returns `RemoteAt(v1)`.
+        let consumer = init_repo();
+        let consumer_sha = seed_commit(consumer.path(), "y", "y\n", "y");
+        run(
+            consumer.path(),
+            &["remote", "add", "origin", bare.path().to_str().unwrap()],
+        );
+        let lease = fetch_notes_ref(Some(consumer.path()), "origin").unwrap();
+        let NotesLease::RemoteAt(v1) = lease.clone() else {
+            panic!("expected RemoteAt, got {lease:?}");
+        };
+        assert_eq!(
+            rev_parse(consumer.path(), STACK_NOTES_REF),
+            Some(v1.clone())
+        );
+
+        // Producer B force-pushes a divergent notes state to the
+        // remote after the consumer's fetch — the remote moves to v2.
+        let producer_b = init_repo();
+        let sha_b = seed_commit(producer_b.path(), "b", "b\n", "b");
+        run(
+            producer_b.path(),
+            &["remote", "add", "origin", bare.path().to_str().unwrap()],
+        );
+        run(
+            producer_b.path(),
+            &["notes", &notes_ref_arg, "add", "-m", "b", &sha_b],
+        );
+        run(producer_b.path(), &["push", "origin", &force_notes_refspec]);
+        let v2 = rev_parse(bare.path(), STACK_NOTES_REF).unwrap();
+        assert_ne!(v1, v2, "producer B must have moved the remote notes ref");
+
+        // Consumer adds a local note (still built on the stale v1)
+        // and pushes with the now-stale `RemoteAt(v1)` lease.
+        run(
+            consumer.path(),
+            &["notes", &notes_ref_arg, "add", "-m", "y", &consumer_sha],
+        );
+        let entries = vec![PushEntry {
+            commit_sha: consumer_sha,
+            dest_branch: "stack/feat/y".into(),
+            pull_head_sha: None,
+        }];
+        push_branches(Some(consumer.path()), "origin", &entries, false, &lease)
+            .expect_err("stale notes lease must reject the whole atomic push");
+
+        // Remote notes ref unchanged → no silent clobber. The
+        // branch must not have landed either (atomic push).
+        assert_eq!(rev_parse(bare.path(), STACK_NOTES_REF).unwrap(), v2);
+        assert!(
+            rev_parse(bare.path(), "refs/heads/stack/feat/y").is_none(),
+            "atomic push must not land the branch when the notes lease fails"
+        );
+    }
+
+    #[test]
+    fn push_branches_notes_lease_succeeds_when_lease_current() {
+        // The positive case: when nothing raced, the lease is
+        // still current at push time and the push (branch + notes)
+        // lands normally, moving the remote notes ref to the
+        // consumer's local SHA.
+        let bare = init_bare_repo();
+        let notes_ref_arg = format!("--ref={STACK_NOTES_REF}");
+
+        // Producer seeds the remote with a commit + a note.
+        let producer = init_repo();
+        let sha_a = seed_commit(producer.path(), "a", "a\n", "a");
+        run(
+            producer.path(),
+            &["remote", "add", "origin", bare.path().to_str().unwrap()],
+        );
+        run(
+            producer.path(),
+            &["notes", &notes_ref_arg, "add", "-m", "a", &sha_a],
+        );
+        run(producer.path(), &["push", "origin", "main"]);
+        let force_notes_refspec = format!("+{STACK_NOTES_REF}:{STACK_NOTES_REF}");
+        run(producer.path(), &["push", "origin", &force_notes_refspec]);
+
+        // Consumer fetches, getting `RemoteAt(v1)` and landing the
+        // notes ref locally at v1.
+        let consumer = init_repo();
+        let consumer_sha = seed_commit(consumer.path(), "y", "y\n", "y");
+        run(
+            consumer.path(),
+            &["remote", "add", "origin", bare.path().to_str().unwrap()],
+        );
+        let lease = fetch_notes_ref(Some(consumer.path()), "origin").unwrap();
+        assert!(matches!(lease, NotesLease::RemoteAt(_)));
+
+        // Consumer adds a local note, extending the notes ref past
+        // v1, then pushes with the still-current lease.
+        run(
+            consumer.path(),
+            &["notes", &notes_ref_arg, "add", "-m", "y", &consumer_sha],
+        );
+        let local_notes_sha = rev_parse(consumer.path(), STACK_NOTES_REF).unwrap();
+        let entries = vec![PushEntry {
+            commit_sha: consumer_sha,
+            dest_branch: "stack/feat/y".into(),
+            pull_head_sha: None,
+        }];
+        push_branches(Some(consumer.path()), "origin", &entries, false, &lease).unwrap();
+
+        // Remote notes ref moved to the consumer's local SHA.
+        assert_eq!(
+            rev_parse(bare.path(), STACK_NOTES_REF).unwrap(),
+            local_notes_sha
+        );
     }
 }

--- a/crates/mergify-stack/src/revision_history.rs
+++ b/crates/mergify-stack/src/revision_history.rs
@@ -11,8 +11,14 @@
 //! 3. A single-line `<!-- mergify-revision-data: {…} -->`
 //!    marker that carries the *machine-readable* version of the
 //!    same data, including the SHAs the table-cell rendering
-//!    only shows in truncated form. `parse()` reads the marker
-//!    back so subsequent pushes can append instead of rewriting.
+//!    only shows in truncated form. This same marker line is
+//!    also written into the git note on the pushed head commit
+//!    (see [`crate::revision_note`]), which is now the machine
+//!    source subsequent pushes read to build the next revision.
+//!    `parse()` still reads the marker back off the comment
+//!    body — it remains the one-time migration seed for stacks
+//!    last pushed before notes carried history, and keeps
+//!    legacy comments round-tripping.
 //!
 //! Ported from `mergify_cli/stack/push.py::RevisionHistoryComment`.
 //! Wire shape — table format, marker JSON, ISO-8601 timestamps
@@ -52,7 +58,7 @@ const MARKER_SUFFIX: &str = " -->";
 /// keep the same number so re-renders of historic rows match.
 const MAX_REASON_LEN: usize = 200;
 
-const TIMESTAMP_HUMAN_FMT: &str = "%Y-%m-%d %H:%M UTC";
+pub(crate) const TIMESTAMP_HUMAN_FMT: &str = "%Y-%m-%d %H:%M UTC";
 const TIMESTAMP_ISO_FMT: &str = "%Y-%m-%dT%H:%M:%SZ";
 
 /// Escape `reason` for a single markdown table cell.
@@ -295,6 +301,34 @@ impl RevisionHistoryComment {
         format!("{MARKER_PREFIX}{json}{MARKER_SUFFIX}")
     }
 
+    /// The `<!-- mergify-revision-data: {…} -->` line alone — the
+    /// machine-readable history. Written both at the bottom of the
+    /// PR comment and into the git note on the pushed head commit
+    /// (see [`crate::revision_note`]), so there is exactly one
+    /// schema for revision data.
+    #[must_use]
+    pub fn marker_line(&self, pull_number: u64) -> String {
+        self.json_marker(pull_number)
+    }
+
+    /// Rebuild a history from bare entries (the note-based read
+    /// path). No `raw_rows`: rows render fresh from entry data.
+    #[must_use]
+    pub fn from_entries(
+        github_server: &str,
+        user: &str,
+        repo: &str,
+        entries: Vec<RevisionEntry>,
+    ) -> Self {
+        Self {
+            github_server: github_server.to_string(),
+            user: user.to_string(),
+            repo: repo.to_string(),
+            entries,
+            raw_rows: Vec::new(),
+        }
+    }
+
     /// Render the full comment body for `pull_number`.
     ///
     /// Rows preserved from [`Self::parse`] are emitted verbatim
@@ -494,9 +528,86 @@ fn parse_human_timestamp(s: &str) -> Option<DateTime<Utc>> {
     Some(Utc.from_utc_datetime(&naive))
 }
 
-fn parse_marker_line(line: &str) -> Option<serde_json::Value> {
+/// Parse one `<!-- mergify-revision-data: {…} -->` line into its
+/// JSON payload. Public because the git-notes history (see
+/// [`crate::revision_note`]) carries the exact same marker line.
+#[must_use]
+pub fn parse_marker_line(line: &str) -> Option<serde_json::Value> {
     let caps = MARKER_RE.captures(line)?;
     serde_json::from_str(caps.name("payload")?.as_str()).ok()
+}
+
+/// True when any line of `text` is a revision-data marker — used
+/// to tell a machine history note apart from a plain amend
+/// reason written by `mergify stack note`.
+#[must_use]
+pub fn contains_marker(text: &str) -> bool {
+    text.lines().any(|l| l.starts_with(MARKER_PREFIX))
+}
+
+/// Decode a marker payload into full [`RevisionEntry`] values.
+///
+/// Unlike [`RevisionHistoryComment::parse`] — which overlays the
+/// marker onto entries seeded from the rendered table rows — this
+/// builds entries from the marker alone (the note has no table).
+/// Returns `None` for a wrong `schema_version`, an empty entry
+/// list, or any entry missing its required fields: a truncated
+/// history must not silently pass for the real one.
+#[must_use]
+pub fn entries_from_marker(payload: &serde_json::Value) -> Option<Vec<RevisionEntry>> {
+    if payload
+        .get("schema_version")
+        .and_then(serde_json::Value::as_u64)
+        != Some(1)
+    {
+        return None;
+    }
+    let arr = payload.get("entries")?.as_array()?;
+    if arr.is_empty() {
+        return None;
+    }
+    let mut entries = Vec::with_capacity(arr.len());
+    for item in arr {
+        let obj = item.as_object()?;
+        let number = u32::try_from(obj.get("number").and_then(serde_json::Value::as_u64)?).ok()?;
+        let change_type =
+            ChangeType::from_str_lossy(obj.get("change_type").and_then(serde_json::Value::as_str)?);
+        let old_sha = match obj.get("old_sha") {
+            Some(serde_json::Value::String(s)) => Some(s.clone()),
+            _ => None,
+        };
+        // Present-but-empty is as invalid as absent: an entry
+        // with no head SHA can't anchor a revision.
+        let new_sha = obj
+            .get("new_sha")
+            .and_then(serde_json::Value::as_str)
+            .filter(|s| !s.is_empty())?
+            .to_string();
+        let timestamp = obj
+            .get("timestamp_iso")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|s| NaiveDateTime::parse_from_str(s, TIMESTAMP_ISO_FMT).ok())
+            .map(|naive| Utc.from_utc_datetime(&naive));
+        let reason = obj
+            .get("reason")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let replay_sha = match obj.get("replay_sha") {
+            Some(serde_json::Value::String(s)) => Some(s.clone()),
+            _ => None,
+        };
+        entries.push(RevisionEntry {
+            number,
+            change_type,
+            old_sha,
+            new_sha,
+            timestamp,
+            reason,
+            replay_sha,
+        });
+    }
+    Some(entries)
 }
 
 #[derive(Serialize, Deserialize)]
@@ -785,5 +896,88 @@ mod tests {
         // No marker so SHAs stay empty on the parsed entries —
         // the raw rows still render verbatim when re-emitted.
         assert!(parsed.entries[0].new_sha.is_empty());
+    }
+
+    #[test]
+    fn marker_line_round_trips_through_entries_from_marker() {
+        // The note and the comment share one marker schema. A comment's
+        // marker line must decode back into the same entries so the
+        // note-based read path reproduces history exactly.
+        let mut comment = RevisionHistoryComment::create_initial(
+            "https://api.github.com",
+            "o",
+            "r",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            ChangeType::Content,
+            t(),
+            "first reason",
+            None,
+        );
+        comment.append(
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "cccccccccccccccccccccccccccccccccccccccc",
+            ChangeType::Rebase,
+            t(),
+            "",
+            Some("dddddddddddddddddddddddddddddddddddddddd"),
+        );
+
+        let line = comment.marker_line(42);
+        let payload = parse_marker_line(&line).expect("marker line parses");
+        let entries = entries_from_marker(&payload).expect("entries decode");
+        assert_eq!(entries, comment.entries);
+    }
+
+    #[test]
+    fn entries_from_marker_rejects_bad_schema_and_empty() {
+        // Wrong schema_version → None.
+        let wrong = serde_json::json!({"schema_version": 2, "pull_number": 1, "entries": []});
+        assert!(entries_from_marker(&wrong).is_none());
+        // Valid version but empty entries → None (nothing to build on).
+        let empty = serde_json::json!({"schema_version": 1, "pull_number": 1, "entries": []});
+        assert!(entries_from_marker(&empty).is_none());
+        // Entry missing new_sha → None (bail, don't fabricate).
+        let broken = serde_json::json!({
+            "schema_version": 1, "pull_number": 1,
+            "entries": [{"number": 1, "change_type": "initial", "old_sha": null,
+                         "timestamp_iso": null, "reason": "", "replay_sha": null}],
+        });
+        assert!(entries_from_marker(&broken).is_none());
+        // Entry with an empty new_sha → None (present-but-empty is
+        // as invalid as absent).
+        let empty_sha = serde_json::json!({
+            "schema_version": 1, "pull_number": 1,
+            "entries": [{"number": 1, "change_type": "initial", "old_sha": null,
+                         "new_sha": "", "timestamp_iso": null, "reason": "",
+                         "replay_sha": null}],
+        });
+        assert!(entries_from_marker(&empty_sha).is_none());
+    }
+
+    #[test]
+    fn from_entries_builds_comment_that_renders() {
+        let entries = vec![RevisionEntry {
+            number: 1,
+            change_type: ChangeType::Initial,
+            old_sha: None,
+            new_sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+            timestamp: Some(t()),
+            reason: String::new(),
+            replay_sha: None,
+        }];
+        let comment =
+            RevisionHistoryComment::from_entries("https://api.github.com", "o", "r", entries);
+        let body = comment.body(7);
+        assert!(body.starts_with("### Revision history\n"));
+        assert!(body.contains("| 1 | initial |"));
+    }
+
+    #[test]
+    fn contains_marker_detects_marker_lines_only() {
+        assert!(contains_marker(
+            "digest text\n\n<!-- mergify-revision-data: {\"schema_version\":1} -->\n"
+        ));
+        assert!(!contains_marker("just a plain amend reason"));
     }
 }

--- a/crates/mergify-stack/src/revision_note.rs
+++ b/crates/mergify-stack/src/revision_note.rs
@@ -1,0 +1,416 @@
+//! The revision-history **git note** — the machine source of
+//! truth for a stacked change's revision history, stored on
+//! `refs/notes/mergify/stack` against the pushed head commit.
+//!
+//! Format: a human digest (newest revision first, no compare
+//! URLs — they reference SHAs that get GC'd), a blank line, then
+//! the same `<!-- mergify-revision-data: {…} -->` marker line the
+//! PR comment carries (one schema, owned by
+//! [`crate::revision_history`]). The PR comment is a rendering of
+//! this data; nothing machine-reads the comment anymore.
+//!
+//! The note replaces the plain amend-reason note `mergify stack
+//! note` wrote on the same commit — the reason is consumed into
+//! the new revision entry at push time. Disambiguation rule: a
+//! note containing a marker line is a history note; a note
+//! without one is a plain reason.
+//!
+//! `git notes merge --strategy=union` (run by
+//! [`crate::notes_push::fetch_notes_ref`]) can concatenate two
+//! divergent notes, so [`parse`] scans *all* lines for markers
+//! and keeps the payload with the most entries (tie → the later
+//! one). The next push rewrites a clean note — self-healing.
+//!
+//! At merge time the Mergify engine copies this note's blob
+//! verbatim onto the merge/squash commit, so the history stays
+//! reachable from the base branch forever. The engine never
+//! parses the content — the CLI owns the format outright.
+
+use std::fmt::Write as _;
+use std::path::Path;
+use std::process::Command;
+
+use mergify_core::{CliError, HttpClient};
+use serde::Deserialize;
+
+use crate::git::run_git_capture;
+use crate::local_commits::STACK_NOTES_REF;
+use crate::revision_history::{self, RevisionHistoryComment, TIMESTAMP_HUMAN_FMT};
+
+/// Render the full note text for `history`: digest + marker.
+#[must_use]
+pub fn render(history: &RevisionHistoryComment, pull_number: u64) -> String {
+    let mut out = format!("Revision history for #{pull_number}:\n\n");
+    for entry in history.entries.iter().rev() {
+        // Infallible: write! into a String cannot fail.
+        let _ = write!(out, "rev {} ({})", entry.number, entry.change_type.as_str());
+        if let Some(ts) = &entry.timestamp {
+            let _ = write!(out, " {}", ts.format(TIMESTAMP_HUMAN_FMT));
+        }
+        if !entry.reason.is_empty() {
+            let _ = write!(out, " \u{2014} {}", entry.reason.replace('\n', " "));
+        }
+        out.push('\n');
+    }
+    out.push('\n');
+    out.push_str(&history.marker_line(pull_number));
+    out.push('\n');
+    out
+}
+
+/// Parse a note back into a history. Returns `None` when no line
+/// carries a valid marker — i.e. the note is a plain amend
+/// reason (or absent history).
+#[must_use]
+pub fn parse(
+    note_text: &str,
+    github_server: &str,
+    user: &str,
+    repo: &str,
+) -> Option<RevisionHistoryComment> {
+    let mut best: Option<Vec<revision_history::RevisionEntry>> = None;
+    for line in note_text.lines() {
+        let Some(payload) = revision_history::parse_marker_line(line) else {
+            continue;
+        };
+        let Some(entries) = revision_history::entries_from_marker(&payload) else {
+            continue;
+        };
+        // `>=` so the later of two equally-long histories wins.
+        if best.as_ref().is_none_or(|b| entries.len() >= b.len()) {
+            best = Some(entries);
+        }
+    }
+    best.map(|entries| RevisionHistoryComment::from_entries(github_server, user, repo, entries))
+}
+
+/// Read the raw note text on `sha` from the stack notes ref.
+/// `None` covers both "no note" and "git failed" — the caller
+/// treats both as "no previous history here".
+#[must_use]
+pub fn read_note(repo_dir: Option<&Path>, sha: &str) -> Option<String> {
+    let notes_ref = format!("--ref={STACK_NOTES_REF}");
+    let mut cmd = Command::new("git");
+    if let Some(dir) = repo_dir {
+        cmd.arg("-C").arg(dir);
+    }
+    let output = cmd.args(["notes", &notes_ref, "show", sha]).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Overwrite the note on `sha` with `text` (`git notes add -f`).
+pub fn write_note(repo_dir: Option<&Path>, sha: &str, text: &str) -> Result<(), CliError> {
+    let notes_ref = format!("--ref={STACK_NOTES_REF}");
+    run_git_capture(
+        repo_dir,
+        &["notes", &notes_ref, "add", "-f", "-m", text, sha],
+    )
+    .map(|_| ())
+}
+
+#[derive(Deserialize)]
+struct Comment {
+    body: String,
+}
+
+/// Load the previous revision history for a change whose old
+/// remote head is `old_sha`.
+///
+/// Read order:
+/// 1. History note on `old_sha` (present locally after
+///    `fetch_notes_ref`) — the steady state.
+/// 2. The PR's revision-history comment — one-time migration
+///    seed for stacks last pushed by an older CLI. Converges on
+///    first push: the caller writes the note, and this GET never
+///    runs again for the change.
+/// 3. `None` — first revision of this PR; caller starts fresh
+///    with `create_initial`.
+pub async fn load_or_seed(
+    client: &HttpClient,
+    repo_dir: Option<&Path>,
+    github_server: &str,
+    user: &str,
+    repo: &str,
+    pull_number: u64,
+    old_sha: &str,
+) -> Result<Option<RevisionHistoryComment>, CliError> {
+    if let Some(text) = read_note(repo_dir, old_sha)
+        && let Some(history) = parse(&text, github_server, user, repo)
+    {
+        return Ok(Some(history));
+    }
+
+    let path = format!("/repos/{user}/{repo}/issues/{pull_number}/comments");
+    let comments: Vec<Comment> = client.get(&path).await?;
+    for comment in &comments {
+        if RevisionHistoryComment::is_revision_comment(&comment.body)
+            && let Some(parsed) =
+                RevisionHistoryComment::parse(&comment.body, github_server, user, repo)
+        {
+            return Ok(Some(parsed));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use mergify_core::ApiFlavor;
+    use serde_json::json;
+    use tempfile::TempDir;
+    use url::Url;
+    use wiremock::matchers::{method, path as wm_path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::change_type::ChangeType;
+
+    const GH: &str = "https://api.github.com";
+
+    fn t() -> chrono::DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 6, 4, 12, 30, 0).unwrap()
+    }
+
+    fn sample_history() -> RevisionHistoryComment {
+        let mut h = RevisionHistoryComment::create_initial(
+            GH,
+            "o",
+            "r",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            ChangeType::Content,
+            t(),
+            "first reason",
+            None,
+        );
+        h.append(
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "cccccccccccccccccccccccccccccccccccccccc",
+            ChangeType::Rebase,
+            t(),
+            "",
+            None,
+        );
+        h
+    }
+
+    #[test]
+    fn render_parse_round_trip() {
+        let history = sample_history();
+        let note = render(&history, 42);
+        // Digest is newest-first, human-readable, no URLs. The
+        // marker line that follows the digest *does* carry
+        // `compare_url` fields (it's the exact same JSON schema
+        // the PR comment marker uses), so scope the "no compare
+        // URLs" check to the digest portion only.
+        assert!(note.starts_with("Revision history for #42:\n\n"));
+        assert!(note.contains("rev 3 (rebase)"));
+        assert!(note.contains("rev 1 (initial)"));
+        assert!(note.contains("\u{2014} first reason"));
+        let digest = note.split("<!-- mergify-revision-data:").next().unwrap();
+        assert!(!digest.contains("compare"));
+
+        let parsed = parse(&note, GH, "o", "r").expect("round-trips");
+        assert_eq!(parsed.entries, history.entries);
+    }
+
+    #[test]
+    fn parse_plain_reason_returns_none() {
+        assert!(parse("fixed a typo in the docs", GH, "o", "r").is_none());
+    }
+
+    #[test]
+    fn parse_union_merged_note_keeps_longest_history() {
+        // Union merge concatenated a 2-entry history with a
+        // 3-entry one (order shouldn't matter): the 3-entry
+        // payload must win.
+        let long = sample_history(); // 3 entries
+        let short = RevisionHistoryComment::create_initial(
+            GH,
+            "o",
+            "r",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            ChangeType::Content,
+            t(),
+            "first reason",
+            None,
+        ); // 2 entries
+        let concatenated = format!("{}\n{}", render(&long, 42), render(&short, 42));
+        let parsed = parse(&concatenated, GH, "o", "r").expect("parses");
+        assert_eq!(parsed.entries.len(), 3);
+
+        let concatenated_rev = format!("{}\n{}", render(&short, 42), render(&long, 42));
+        let parsed = parse(&concatenated_rev, GH, "o", "r").expect("parses");
+        assert_eq!(parsed.entries.len(), 3);
+    }
+
+    #[test]
+    fn parse_tolerates_garbage_around_marker() {
+        let note = format!(
+            "user scribble\n<!-- mergify-revision-data: not json -->\n{}",
+            render(&sample_history(), 42),
+        );
+        let parsed = parse(&note, GH, "o", "r").expect("valid marker still found");
+        assert_eq!(parsed.entries.len(), 3);
+    }
+
+    // --- git IO ---
+
+    fn init_repo() -> TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        for args in [
+            &["init", "-q", "-b", "main"][..],
+            &["config", "user.email", "t@e.com"],
+            &["config", "user.name", "T"],
+            &["commit", "--allow-empty", "-m", "root"],
+        ] {
+            let ok = crate::test_env::isolated_git()
+                .arg("-C")
+                .arg(dir.path())
+                .args(args)
+                .status()
+                .unwrap()
+                .success();
+            assert!(ok, "git {args:?} failed");
+        }
+        dir
+    }
+
+    fn head_sha(dir: &std::path::Path) -> String {
+        run_git_capture(Some(dir), &["rev-parse", "HEAD"]).unwrap()
+    }
+
+    #[test]
+    fn write_then_read_note_round_trips() {
+        let dir = init_repo();
+        let sha = head_sha(dir.path());
+        let text = render(&sample_history(), 42);
+        write_note(Some(dir.path()), &sha, &text).unwrap();
+        let read = read_note(Some(dir.path()), &sha).expect("note exists");
+        // `git notes show` normalises the trailing newline; compare
+        // trimmed.
+        assert_eq!(read.trim_end(), text.trim_end());
+        // And the full note→history read path works.
+        assert!(parse(&read, GH, "o", "r").is_some());
+    }
+
+    #[test]
+    fn write_note_overwrites_existing_plain_reason() {
+        let dir = init_repo();
+        let sha = head_sha(dir.path());
+        write_note(Some(dir.path()), &sha, "plain reason").unwrap();
+        let text = render(&sample_history(), 42);
+        write_note(Some(dir.path()), &sha, &text).unwrap();
+        let read = read_note(Some(dir.path()), &sha).unwrap();
+        assert!(read.contains("mergify-revision-data"));
+        assert!(!read.contains("plain reason"));
+    }
+
+    #[test]
+    fn read_note_missing_returns_none() {
+        let dir = init_repo();
+        let sha = head_sha(dir.path());
+        assert!(read_note(Some(dir.path()), &sha).is_none());
+    }
+
+    // --- load_or_seed ---
+
+    fn client(server: &MockServer) -> HttpClient {
+        HttpClient::new(
+            Url::parse(&server.uri()).unwrap(),
+            "token",
+            ApiFlavor::GitHub,
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn load_prefers_note_over_comment() {
+        let dir = init_repo();
+        let sha = head_sha(dir.path());
+        write_note(Some(dir.path()), &sha, &render(&sample_history(), 42)).unwrap();
+
+        // No comment GET expected: mock with .expect(0).
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path("/repos/o/r/issues/42/comments"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let got = load_or_seed(&client(&server), Some(dir.path()), GH, "o", "r", 42, &sha)
+            .await
+            .unwrap()
+            .expect("note found");
+        assert_eq!(got.entries.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn load_seeds_from_comment_when_note_missing() {
+        let dir = init_repo();
+        let sha = head_sha(dir.path());
+        let comment_body = sample_history().body(42);
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path("/repos/o/r/issues/42/comments"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                {"url": format!("{}/repos/o/r/issues/comments/1", server.uri()), "body": comment_body},
+            ])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let got = load_or_seed(&client(&server), Some(dir.path()), GH, "o", "r", 42, &sha)
+            .await
+            .unwrap()
+            .expect("seeded from comment");
+        assert_eq!(got.entries.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn load_returns_none_when_neither_exists() {
+        let dir = init_repo();
+        let sha = head_sha(dir.path());
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path("/repos/o/r/issues/42/comments"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let got = load_or_seed(&client(&server), Some(dir.path()), GH, "o", "r", 42, &sha)
+            .await
+            .unwrap();
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn load_ignores_plain_reason_note_and_falls_through() {
+        // Old head carries a plain amend reason (older-CLI state):
+        // not a history note → fall through to the comment seed.
+        let dir = init_repo();
+        let sha = head_sha(dir.path());
+        write_note(Some(dir.path()), &sha, "an old plain reason").unwrap();
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path("/repos/o/r/issues/42/comments"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let got = load_or_seed(&client(&server), Some(dir.path()), GH, "o", "r", 42, &sha)
+            .await
+            .unwrap();
+        assert!(got.is_none());
+    }
+}

--- a/crates/mergify-stack/src/revision_note.rs
+++ b/crates/mergify-stack/src/revision_note.rs
@@ -84,6 +84,31 @@ pub fn parse(
     best.map(|entries| RevisionHistoryComment::from_entries(github_server, user, repo, entries))
 }
 
+/// Recover the history a previous (failed) push attempt already
+/// wrote on the local head commit. Returns it only when its last
+/// entry records exactly the `old_sha` → `new_sha` transition the
+/// current push is about to append — anything else (another
+/// machine pushed meanwhile, a different amend) means the note is
+/// stale and the caller must rebuild from the old head's note.
+/// Keeping the recovered entry (reason, timestamp, and all) makes
+/// retries idempotent instead of appending a blank-reason
+/// duplicate.
+#[must_use]
+pub fn recover_pending(
+    note_text: &str,
+    github_server: &str,
+    user: &str,
+    repo: &str,
+    old_sha: &str,
+    new_sha: &str,
+) -> Option<RevisionHistoryComment> {
+    parse(note_text, github_server, user, repo).filter(|h| {
+        h.entries
+            .last()
+            .is_some_and(|e| e.old_sha.as_deref() == Some(old_sha) && e.new_sha == new_sha)
+    })
+}
+
 /// Read the raw note text on `sha` from the stack notes ref.
 /// `None` covers both "no note" and "git failed" — the caller
 /// treats both as "no previous history here".
@@ -257,6 +282,59 @@ mod tests {
         );
         let parsed = parse(&note, GH, "o", "r").expect("valid marker still found");
         assert_eq!(parsed.entries.len(), 3);
+    }
+
+    #[test]
+    fn recover_pending_matches_last_entry_transition() {
+        let history = sample_history();
+        let note = render(&history, 42);
+        let last = history.entries.last().unwrap();
+        let recovered = recover_pending(
+            &note,
+            GH,
+            "o",
+            "r",
+            last.old_sha.as_deref().unwrap(),
+            &last.new_sha,
+        )
+        .expect("recovers matching pending history");
+        assert_eq!(recovered.entries, history.entries);
+    }
+
+    #[test]
+    fn recover_pending_rejects_mismatched_last_entry() {
+        let history = sample_history();
+        let note = render(&history, 42);
+        let last = history.entries.last().unwrap();
+        // A different new_sha than what's recorded means another
+        // push (or amend) happened since this note was written —
+        // the note is stale and must not be reused.
+        assert!(
+            recover_pending(
+                &note,
+                GH,
+                "o",
+                "r",
+                last.old_sha.as_deref().unwrap(),
+                "ffffffffffffffffffffffffffffffffffffffff",
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn recover_pending_rejects_plain_reason() {
+        assert!(
+            recover_pending(
+                "fixed a typo in the docs",
+                GH,
+                "o",
+                "r",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            )
+            .is_none()
+        );
     }
 
     // --- git IO ---

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,7 @@
+# Pinned so a new stable release can't break every open PR with new
+# clippy lints on untouched code. Renovate's rust-toolchain manager
+# proposes bumps (after the 7-day minimumReleaseAge); a bump PR that
+# trips new lints fails CI and must fix them in the same PR.
 [toolchain]
-channel = "stable"
+channel = "1.97"
 components = ["rustfmt", "clippy"]

--- a/skills/mergify-stack/SKILL.md
+++ b/skills/mergify-stack/SKILL.md
@@ -92,9 +92,9 @@ Use `mergify stack list` to see which commits have been pushed, which PRs they m
 
 `mergify stack note` records *why* a commit was amended. The note travels with the stack:
 
-- Stored locally under `refs/notes/mergify/stack` against the commit SHA.
-- Pushed automatically by `mergify stack push` (alongside the commit refspecs, with `--force-with-lease`).
-- Surfaced in the PR's **Revision history** comment as the `Reason` column of the markdown table, and embedded in the `<!-- mergify-revision-data: {...} -->` JSON marker (key `reason`) so it can be parsed programmatically.
+- The reason is stored locally under `refs/notes/mergify/stack` against the commit SHA.
+- On `mergify stack push`, the reason is consumed into the change's revision history; the note on the pushed head commit is replaced by the **full revision history** (human digest + the `<!-- mergify-revision-data: {...} -->` JSON marker). Git notes — not the PR comment — are the machine-readable source of truth; the PR's "Revision history" comment is rendered from them.
+- At merge time, Mergify copies the head commit's history note onto the merge/squash commit, so `git log --notes=mergify/stack` on the base branch shows why each change was revised.
 
 **When to attach a note** — any time you amend or rewrite a commit that already has a PR open (i.e. it has been pushed at least once). The note answers "why is this revision different?" so the reviewer doesn't have to diff old vs new SHAs to find out.
 


### PR DESCRIPTION
The notes refspec carried a leading `+`, which makes git ignore the
accompanying --force-with-lease entirely — and the lease's expect
value was the local SHA, which can never match the remote anyway. A
concurrent `stack push` could silently wipe remote notes; now that
the notes carry full revision history read at merge time, that's
permanent data loss.

Capture the remote SHA at fetch time and lease the un-forced push on
it (empty lease when the remote ref doesn't exist). When the remote
state can't be determined, skip the notes refspec for this push
rather than force-pushing blind; the notes catch up next push.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Depends-On: #1713