### PR TITLE
feat(ci): cap gzipped junit upload at 10 MiB and split oversized reports

### DIFF
--- a/crates/mergify-ci/src/junit_process/command.rs
+++ b/crates/mergify-ci/src/junit_process/command.rs
@@ -32,6 +32,7 @@ use crate::detector;
 use crate::junit_process::junit::{self, ParseResult, TestCase};
 use crate::junit_process::quarantine::{self, QuarantineFailed, QuarantineResult};
 use crate::junit_process::spans::{self, UploadMetadata};
+use crate::junit_process::split;
 use crate::junit_process::upload;
 
 const SEPARATOR: &str = "══════════════════════════════════════════";
@@ -59,13 +60,25 @@ pub struct JunitProcessOptions<'a> {
 /// argument resolution failures (e.g. missing token) and
 /// unrecoverable input errors (no XML, parse failure on every
 /// file).
+pub async fn run(
+    opts: JunitProcessOptions<'_>,
+    output: &mut dyn Output,
+) -> Result<ExitCode, CliError> {
+    run_with_cap(opts, output, upload::MAX_GZIPPED_UPLOAD_BYTES).await
+}
+
+/// Body of [`run`], parameterized on the per-upload gzip cap so tests
+/// can force the split path with a small cap instead of a
+/// multi-megabyte fixture. Production always passes
+/// [`upload::MAX_GZIPPED_UPLOAD_BYTES`].
 #[allow(clippy::too_many_lines)] // Straight-line orchestration: parse →
 // quarantine → build spans → upload → render. Splitting this into
 // helpers spreads the report builder's ordering across the file
 // without buying anything you can't already see by scrolling.
-pub async fn run(
+async fn run_with_cap(
     opts: JunitProcessOptions<'_>,
     output: &mut dyn Output,
+    upload_cap: usize,
 ) -> Result<ExitCode, CliError> {
     // ── Resolve required inputs up front so we fail before
     // printing any of the banner — matches Python's click defaults
@@ -160,17 +173,60 @@ pub async fn run(
     };
     let built = spans::build_traces(&parsed, &metadata);
 
+    // Cap each gzipped upload at MAX_GZIPPED_UPLOAD_BYTES. A normal
+    // report is one chunk (byte-identical to before); only an
+    // oversized payload fans out into several uploads.
+    let (chunks, oversized_cases, mut upload_error) =
+        match split::split_request(&built.request, upload_cap) {
+            Ok(outcome) => (outcome.chunks, outcome.oversized_cases, None),
+            // gzip is an in-memory write and effectively never fails,
+            // but if it does we surface it as an upload error rather
+            // than dropping the run silently.
+            Err(e) => (
+                Vec::new(),
+                Vec::new(),
+                Some(upload::UploadError {
+                    status: None,
+                    message: format!("failed to gzip OTLP payload: {e}"),
+                }),
+            ),
+        };
+
     let client = upload::default_client();
-    let upload_error = upload::upload(
-        &client,
-        api_url.as_str(),
-        &token,
-        &repository,
-        &built.request,
-    )
-    .await
-    .err();
-    maybe_write_github_output(upload_status_label(upload_error.as_ref()));
+    // Nothing reached the backend when the split produced no chunks
+    // (every case individually oversized) or gzip failed. Captured
+    // before the loop consumes `chunks`. That must not be reported as
+    // a successful upload.
+    let nothing_uploaded = chunks.is_empty();
+
+    // Post each chunk. Stop early only on a permanent rejection (bad
+    // token / no ingest access) — it would fail every remaining chunk
+    // identically. A transient failure on one chunk doesn't abandon
+    // the rest: each chunk is an idempotent self-contained trace, so
+    // delivering as many as possible is strictly better than dropping
+    // the tail. The chunk is consumed so its (multi-MiB) gzipped body
+    // moves into the request instead of being cloned per attempt.
+    for chunk in chunks {
+        if let Some(err) = upload::upload_compressed(
+            &client,
+            api_url.as_str(),
+            &token,
+            &repository,
+            chunk.compressed,
+        )
+        .await
+        .err()
+        {
+            let permanent = err.is_rejection();
+            upload_error = Some(err);
+            if permanent {
+                break;
+            }
+        }
+    }
+
+    let upload_failed = upload_error.is_some() || nothing_uploaded;
+    maybe_write_github_output(upload_status_label(upload_error.as_ref(), nothing_uploaded));
 
     // ── Report sections — order matches Python verbatim.
     write_run_id(&mut report, &built.run_id);
@@ -182,12 +238,20 @@ pub async fn run(
         files.len(),
         total_cases,
         nb_failures,
-        upload_error.is_some(),
+        upload_failed,
     );
 
     if let Some(err) = &upload_error {
         write_upload_error_block(&mut report, &err.to_string(), err.is_rejection());
         if let Some(annotation) = gha_upload_annotation(err) {
+            report.push_str(&annotation);
+            report.push('\n');
+        }
+    }
+
+    if !oversized_cases.is_empty() {
+        write_oversized_cases(&mut report, &oversized_cases);
+        if let Some(annotation) = gha_oversized_annotation(&oversized_cases) {
             report.push_str(&annotation);
             report.push('\n');
         }
@@ -455,16 +519,24 @@ fn write_upload_summary(
 
 /// `$GITHUB_OUTPUT` key reporting the upload outcome:
 /// `success`, `rejected` (4xx except 408/429 — permanent, e.g.
-/// bad token), or `failed` (transient: 5xx, 408, 429, network).
-/// Lets workflows detect dead ingest programmatically without
-/// parsing the human report (issue #1571).
+/// bad token), or `failed` (transient: 5xx, 408, 429, network, or
+/// nothing reached ingest because every case was individually
+/// oversized). Lets workflows detect dead ingest programmatically
+/// without parsing the human report (issue #1571).
 const UPLOAD_STATUS_OUTPUT_NAME: &str = "test_results_upload";
 
-fn upload_status_label(error: Option<&upload::UploadError>) -> &'static str {
+fn upload_status_label(
+    error: Option<&upload::UploadError>,
+    nothing_uploaded: bool,
+) -> &'static str {
     match error {
-        None => "success",
         Some(e) if e.is_rejection() => "rejected",
         Some(_) => "failed",
+        // No HTTP error, but the split produced no chunks (every case
+        // individually oversized) or gzip failed: nothing reached the
+        // backend, so it is not a success.
+        None if nothing_uploaded => "failed",
+        None => "success",
     }
 }
 
@@ -521,6 +593,23 @@ fn gha_upload_annotation(error: &upload::UploadError) -> Option<String> {
     })
 }
 
+/// GitHub Actions `::warning::` annotation for test cases dropped
+/// because they were individually too large to upload, or `None`
+/// outside GitHub Actions. Makes the data loss visible in the run
+/// summary / checks UI — otherwise it only appears in the human
+/// report prose. Never an error: the CI outcome is unaffected.
+fn gha_oversized_annotation(names: &[String]) -> Option<String> {
+    if std::env::var("GITHUB_ACTIONS").as_deref() != Ok("true") {
+        return None;
+    }
+    Some(format!(
+        "::warning title=Mergify Test Insights::{n} test result(s) exceeded the upload size \
+         limit and were skipped: {names}. The rest of the run was uploaded.",
+        n = names.len(),
+        names = gha_escape_data(&names.join(", ")),
+    ))
+}
+
 /// Escape the data section of a GHA workflow command. A multi-line
 /// value (e.g. an HTTP response body inside the error message)
 /// would otherwise terminate the command at the first newline.
@@ -542,6 +631,23 @@ fn write_upload_error_block(out: &mut String, error: &str, rejected: bool) {
     out.push_str("      ┌ Details\n");
     for line in error.lines() {
         out.push_str(&format!("      │  {line}\n"));
+    }
+    out.push_str("      └─\n");
+}
+
+/// Report test cases dropped from the upload because a single case
+/// gzips past [`upload::MAX_GZIPPED_UPLOAD_BYTES`] on its own — there
+/// is no upload it can fit into. The CI verdict is unaffected (it's
+/// computed from the parsed cases, not the upload), so this is a
+/// best-effort data-loss notice, not a failure.
+fn write_oversized_cases(out: &mut String, names: &[String]) {
+    out.push_str("\n  ⚠️ Some test results were too large to upload\n");
+    out.push_str("    A single test's output exceeded the upload size limit and was skipped.\n");
+    out.push_str("    Quarantine status and CI outcome are unaffected.\n");
+    out.push('\n');
+    out.push_str("      ┌ Skipped\n");
+    for name in names {
+        out.push_str(&format!("      │  {name}\n"));
     }
     out.push_str("      └─\n");
 }
@@ -871,6 +977,57 @@ mod tests {
         assert!(s.contains("│  line2"), "{s}");
     }
 
+    #[test]
+    fn write_oversized_cases_lists_skipped_tests() {
+        let mut s = String::new();
+        write_oversized_cases(&mut s, &["a.big".to_string(), "b.huge".to_string()]);
+        assert!(s.contains("too large to upload"), "{s}");
+        assert!(s.contains("a.big"), "{s}");
+        assert!(s.contains("b.huge"), "{s}");
+        // The verdict must stay unaffected — this is a data-loss
+        // notice, not a failure.
+        assert!(s.contains("CI outcome are unaffected"), "{s}");
+    }
+
+    #[test]
+    fn upload_status_label_maps_every_outcome() {
+        let err = |status: Option<u16>| upload::UploadError {
+            status,
+            message: String::new(),
+        };
+        // Clean success only when something uploaded and no error.
+        assert_eq!(upload_status_label(None, false), "success");
+        // Nothing reached ingest (every case oversized / gzip failed)
+        // must not read as success — issue #1571 keys on this.
+        assert_eq!(upload_status_label(None, true), "failed");
+        // A permanent rejection stays "rejected"; anything else that
+        // errored is "failed", regardless of the nothing_uploaded flag.
+        assert_eq!(
+            upload_status_label(Some(&err(Some(403))), false),
+            "rejected"
+        );
+        assert_eq!(upload_status_label(Some(&err(Some(503))), false), "failed");
+        assert_eq!(upload_status_label(Some(&err(None)), false), "failed");
+    }
+
+    #[test]
+    fn gha_oversized_annotation_lists_names_only_on_gha() {
+        // Outside GitHub Actions: no annotation.
+        let none = temp_env::with_var("GITHUB_ACTIONS", None::<&str>, || {
+            gha_oversized_annotation(&["a.big".to_string()])
+        });
+        assert!(none.is_none());
+        // On GitHub Actions: a warning naming the dropped tests, never
+        // an error (CI outcome is unaffected).
+        let ann = temp_env::with_var("GITHUB_ACTIONS", Some("true"), || {
+            gha_oversized_annotation(&["a.big".to_string(), "b.huge".to_string()])
+        })
+        .unwrap();
+        assert!(ann.starts_with("::warning"), "{ann}");
+        assert!(ann.contains("a.big, b.huge"), "{ann}");
+        assert!(ann.contains("exceeded the upload size limit"), "{ann}");
+    }
+
     // ── End-to-end orchestrator tests. Drive the full `run()`
     // entry point with on-disk fixtures and a wiremock-backed API
     // so the stdout banner + exit code are pinned for each verdict
@@ -980,6 +1137,219 @@ mod tests {
             let stdout = String::from_utf8(cap.stdout.lock().unwrap().clone()).unwrap();
             assert!(stdout.contains("✅ OK — all tests passed"), "{stdout}");
             assert!(stdout.contains("Exit code: 0"), "{stdout}");
+        }
+
+        // A large report must fan out into several gzipped uploads,
+        // each under the cap, without changing the verdict. Driven
+        // through `run_with_cap` with a tiny cap and asserted at the
+        // wire with a per-request count.
+        #[tokio::test]
+        async fn large_report_fans_out_into_several_uploads() {
+            let server = MockServer::start().await;
+            mount_mocks(&server).await;
+            let tmp = tempfile::tempdir().unwrap();
+
+            // 30 failing cases, each carrying ~2 KiB of incompressible
+            // text in its <failure> body — high-entropy so gzip can't
+            // collapse it, which is what forces the split on the small
+            // cap. Failures (not passing cases) so the verdict is a
+            // deterministic GenericError we can assert on.
+            let file = write_xml(&tmp, "report.xml", &incompressible_failures_xml(30, 2048));
+
+            let api_url = server.uri();
+            let mut cap = captured();
+            let cap_bytes = 4 * 1024;
+            let code = with_ci_env_async(&[], async {
+                let opts = JunitProcessOptions {
+                    api_url: Some(&api_url),
+                    token: Some("secret"),
+                    repository: Some("owner/repo"),
+                    test_framework: None,
+                    test_language: None,
+                    tests_target_branch: Some("main"),
+                    test_exit_code: None,
+                    files: &[file],
+                };
+                run_with_cap(opts, &mut cap.output, cap_bytes)
+                    .await
+                    .unwrap()
+            })
+            .await;
+
+            // Verdict is unchanged by splitting: 30 unquarantined
+            // failures still fail the run.
+            assert_eq!(code, ExitCode::GenericError);
+
+            // More than one POST reached the traces endpoint, and each
+            // body is a gzipped payload under the cap.
+            let uploads: Vec<_> = server
+                .received_requests()
+                .await
+                .unwrap()
+                .into_iter()
+                .filter(|r| r.url.path() == "/v1/repos/owner/repo/ci/traces")
+                .collect();
+            assert!(
+                uploads.len() > 1,
+                "expected a fan-out, got {} upload(s)",
+                uploads.len()
+            );
+            for req in &uploads {
+                assert!(
+                    req.body.len() <= cap_bytes,
+                    "an upload body ({} bytes) exceeded the cap",
+                    req.body.len()
+                );
+            }
+        }
+
+        // A JUnit report of `n` failing cases, each with a
+        // `body_len`-byte incompressible <failure> body — the shape
+        // that forces the split path under a small cap.
+        fn incompressible_failures_xml(n: usize, body_len: usize) -> String {
+            use crate::testing::incompressible;
+            let mut xml = String::from("<?xml version=\"1.0\"?>\n<testsuites>\n");
+            xml.push_str(&format!(
+                "  <testsuite name=\"pytest\" tests=\"{n}\" failures=\"{n}\">\n"
+            ));
+            for i in 0..n {
+                xml.push_str(&format!(
+                    "    <testcase classname=\"tests\" name=\"test_{i}\">\n\
+                     <failure message=\"boom\">{body}</failure>\n\
+                     </testcase>\n",
+                    body = incompressible(i as u64, body_len),
+                ));
+            }
+            xml.push_str("  </testsuite>\n</testsuites>");
+            xml
+        }
+
+        async fn traces_requests(server: &MockServer) -> usize {
+            server
+                .received_requests()
+                .await
+                .unwrap()
+                .into_iter()
+                .filter(|r| r.url.path() == "/v1/repos/owner/repo/ci/traces")
+                .count()
+        }
+
+        // Every case individually gzips past the (absurdly small) cap:
+        // the split drops them all, nothing reaches the backend, and
+        // that must be reported as NOT uploaded / status=failed — never
+        // as a success. The CI verdict is still driven by the failures.
+        #[tokio::test]
+        async fn all_cases_oversized_reports_nothing_uploaded() {
+            let server = MockServer::start().await;
+            mount_mocks(&server).await;
+            let tmp = tempfile::tempdir().unwrap();
+            let file = write_xml(&tmp, "report.xml", &incompressible_failures_xml(3, 512));
+            let github_output = tmp.path().join("github_output");
+
+            let api_url = server.uri();
+            let output_path = github_output.to_string_lossy().into_owned();
+            let mut cap = captured();
+            // 64-byte cap: smaller than any single case's gzipped span.
+            let code = with_ci_env_async(
+                &[
+                    ("GITHUB_ACTIONS", Some("true")),
+                    ("GITHUB_OUTPUT", Some(&output_path)),
+                ],
+                async {
+                    let opts = JunitProcessOptions {
+                        api_url: Some(&api_url),
+                        token: Some("secret"),
+                        repository: Some("owner/repo"),
+                        test_framework: None,
+                        test_language: None,
+                        tests_target_branch: Some("main"),
+                        test_exit_code: None,
+                        files: &[file],
+                    };
+                    run_with_cap(opts, &mut cap.output, 64).await.unwrap()
+                },
+            )
+            .await;
+
+            assert_eq!(code, ExitCode::GenericError);
+            // Nothing was POSTed to the traces endpoint.
+            assert_eq!(traces_requests(&server).await, 0);
+            let stdout = String::from_utf8(cap.stdout.lock().unwrap().clone()).unwrap();
+            assert!(stdout.contains("not uploaded"), "{stdout}");
+            assert!(stdout.contains("too large to upload"), "{stdout}");
+            let outputs = std::fs::read_to_string(&github_output).unwrap();
+            assert!(outputs.contains("test_results_upload=failed"), "{outputs}");
+        }
+
+        // A transient failure on one chunk must not abandon the rest:
+        // with the traces endpoint always 503, every chunk is still
+        // attempted (continue-on-transient), not just the first.
+        #[tokio::test]
+        async fn transient_error_still_attempts_all_chunks() {
+            let server = MockServer::start().await;
+            mount_mocks_with_upload_status(&server, 503).await;
+            let tmp = tempfile::tempdir().unwrap();
+            let file = write_xml(&tmp, "report.xml", &incompressible_failures_xml(20, 2048));
+
+            let api_url = server.uri();
+            let mut cap = captured();
+            let code = with_ci_env_async(&[], async {
+                let opts = JunitProcessOptions {
+                    api_url: Some(&api_url),
+                    token: Some("secret"),
+                    repository: Some("owner/repo"),
+                    test_framework: None,
+                    test_language: None,
+                    tests_target_branch: Some("main"),
+                    test_exit_code: None,
+                    files: &[file],
+                };
+                run_with_cap(opts, &mut cap.output, 4 * 1024).await.unwrap()
+            })
+            .await;
+
+            // Verdict unaffected by the upload trouble.
+            assert_eq!(code, ExitCode::GenericError);
+            // All chunks attempted despite the first 503, not just one.
+            assert!(
+                traces_requests(&server).await > 1,
+                "a transient error must not abandon the remaining chunks"
+            );
+        }
+
+        // A permanent rejection (bad token) fails every chunk
+        // identically, so the loop must stop after the first rather
+        // than re-POST the whole fan-out.
+        #[tokio::test]
+        async fn rejection_stops_after_first_chunk() {
+            let server = MockServer::start().await;
+            mount_mocks_with_upload_status(&server, 403).await;
+            let tmp = tempfile::tempdir().unwrap();
+            let file = write_xml(&tmp, "report.xml", &incompressible_failures_xml(20, 2048));
+
+            let api_url = server.uri();
+            let mut cap = captured();
+            let code = with_ci_env_async(&[], async {
+                let opts = JunitProcessOptions {
+                    api_url: Some(&api_url),
+                    token: Some("secret"),
+                    repository: Some("owner/repo"),
+                    test_framework: None,
+                    test_language: None,
+                    tests_target_branch: Some("main"),
+                    test_exit_code: None,
+                    files: &[file],
+                };
+                run_with_cap(opts, &mut cap.output, 4 * 1024).await.unwrap()
+            })
+            .await;
+
+            assert_eq!(code, ExitCode::GenericError);
+            assert_eq!(
+                traces_requests(&server).await,
+                1,
+                "a permanent rejection must stop after the first chunk"
+            );
         }
 
         #[tokio::test]

--- a/crates/mergify-ci/src/junit_process/mod.rs
+++ b/crates/mergify-ci/src/junit_process/mod.rs
@@ -7,6 +7,8 @@
 //!   [`TestCase`] values. Hermetic, no network.
 //! - [`spans`]: turns parser output into an OTLP
 //!   `ExportTraceServiceRequest`.
+//! - [`split`]: partitions an oversized request into several uploads
+//!   that each gzip under [`upload::MAX_GZIPPED_UPLOAD_BYTES`].
 //! - [`upload`]: gzips that protobuf payload and POSTs it to
 //!   `/v1/repos/<owner>/<repo>/ci/traces`.
 //! - [`quarantine`]: queries the quarantine API to learn which
@@ -18,10 +20,14 @@ pub mod command;
 pub mod junit;
 pub mod quarantine;
 pub mod spans;
+pub mod split;
 pub mod upload;
 
 pub use command::{JunitProcessOptions, run};
 pub use junit::{Failure, InvalidJunitXml, ParseResult, TestCase, TestStatus};
 pub use quarantine::{QuarantineFailed, QuarantineResult, QuarantinedTests};
 pub use spans::{BuiltTraces, UploadMetadata, build_traces};
-pub use upload::{UploadError, default_client, upload};
+pub use split::{Chunk, SplitOutcome, split_request};
+pub use upload::{
+    MAX_GZIPPED_UPLOAD_BYTES, UploadError, default_client, upload, upload_compressed,
+};

--- a/crates/mergify-ci/src/junit_process/split.rs
+++ b/crates/mergify-ci/src/junit_process/split.rs
@@ -1,0 +1,472 @@
+//! Split an oversized OTLP trace request into several uploads that
+//! each gzip under [`upload::MAX_GZIPPED_UPLOAD_BYTES`].
+//!
+//! [`spans::build_traces`] produces one `ExportTraceServiceRequest`
+//! for a whole run: a session root span, one suite span per
+//! `<testsuite>`, and one case span per `<testcase>`, all sharing a
+//! single trace id. A very large `JUnit` report (tens of thousands of
+//! cases, or a handful with enormous stack traces) can gzip past the
+//! ingest cap. Rather than drop the entire upload, we partition the
+//! case spans into several requests.
+//!
+//! Each chunk is a **self-contained trace**: it carries the session
+//! span, the suite spans for the cases it holds, and those cases.
+//! Every chunk keeps the original trace id and the original span ids,
+//! so the backend reassembles them into one trace exactly as if a
+//! single upload had carried them all — repeating the session/suite
+//! spans across chunks is an idempotent upsert keyed by
+//! `(trace_id, span_id)`. Splitting on the *gzipped* size (the bytes
+//! actually sent) is the point of the exercise: gzip ratios vary
+//! wildly between a run dominated by short case names and one
+//! dominated by megabyte stack traces, so a raw-size heuristic can't
+//! predict the compressed body.
+//!
+//! Each returned [`Chunk`] carries the gzipped bytes it was sized
+//! against, so the upload step posts them directly instead of
+//! re-compressing.
+//!
+//! [`spans::build_traces`]: crate::junit_process::spans::build_traces
+
+use std::collections::HashMap;
+
+use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span};
+use prost::Message as _;
+
+use crate::junit_process::upload;
+
+/// One upload: the request plus the gzipped bytes to POST. The bytes
+/// are the exact payload the chunk was measured against, so the
+/// caller never gzips twice.
+#[derive(Debug)]
+pub struct Chunk {
+    pub request: ExportTraceServiceRequest,
+    pub compressed: Vec<u8>,
+}
+
+/// Outcome of [`split_request`].
+#[derive(Debug)]
+pub struct SplitOutcome {
+    /// One gzip-under-cap upload per entry, in order. Empty only in
+    /// the pathological case where every case is individually
+    /// oversized (see `oversized_cases`).
+    pub chunks: Vec<Chunk>,
+    /// Names of case spans that gzip past the cap on their own — a
+    /// single test whose captured output/stack trace is so large it
+    /// can't fit in any upload. These are dropped from the upload
+    /// (there is nowhere to put them) and reported to the user; the
+    /// CI verdict is unaffected because it's computed from the parsed
+    /// cases, not the upload.
+    pub oversized_cases: Vec<String>,
+}
+
+/// Partition `request` into uploads that each gzip to at most `cap`
+/// bytes.
+///
+/// The common case is a small report: the whole request already fits,
+/// so a single-element `chunks` is returned after one gzip and the
+/// upload path posts that exact payload. Only when the full payload
+/// exceeds `cap` do we decompose it and pack the case spans into
+/// several requests.
+///
+/// Returns `Err` only if gzip itself fails (an in-memory
+/// `flate2` write, so effectively never) — surfaced rather than
+/// swallowed so a compression failure reads as a diagnosable upload
+/// error instead of silently dropping every case as "too large".
+pub fn split_request(
+    request: &ExportTraceServiceRequest,
+    cap: usize,
+) -> Result<SplitOutcome, std::io::Error> {
+    let compressed = gzip_request(request)?;
+    if compressed.len() <= cap {
+        return Ok(SplitOutcome {
+            chunks: vec![Chunk {
+                request: request.clone(),
+                compressed,
+            }],
+            oversized_cases: Vec::new(),
+        });
+    }
+
+    // Decompose the single-resource / single-scope layout that
+    // `build_traces` emits. Anything else is unexpected and not
+    // structurally splittable here, so fall back to a lone chunk —
+    // the upload may be refused, but that's strictly better than
+    // panicking, and this branch is unreachable for our own builder.
+    let Some(decomposed) = Decomposed::from_request(request) else {
+        return Ok(SplitOutcome {
+            chunks: vec![Chunk {
+                request: request.clone(),
+                compressed,
+            }],
+            oversized_cases: Vec::new(),
+        });
+    };
+
+    let mut chunks = Vec::new();
+    let mut oversized_cases = Vec::new();
+    decomposed.pack(&decomposed.cases, cap, &mut chunks, &mut oversized_cases)?;
+    Ok(SplitOutcome {
+        chunks,
+        oversized_cases,
+    })
+}
+
+/// A case span together with the suite span it hangs off (if any) and
+/// its protobuf-encoded size (computed once, reused by
+/// [`split_index`]).
+struct CaseEntry<'a> {
+    case: &'a Span,
+    suite: Option<&'a Span>,
+    encoded_len: usize,
+}
+
+/// The pieces of a built trace we need to reassemble arbitrary
+/// subsets of its cases into standalone requests.
+struct Decomposed<'a> {
+    template: &'a ExportTraceServiceRequest,
+    session: &'a Span,
+    cases: Vec<CaseEntry<'a>>,
+}
+
+impl<'a> Decomposed<'a> {
+    fn from_request(request: &'a ExportTraceServiceRequest) -> Option<Self> {
+        let [resource_spans] = request.resource_spans.as_slice() else {
+            return None;
+        };
+        let [scope_spans] = resource_spans.scope_spans.as_slice() else {
+            return None;
+        };
+        let spans = &scope_spans.spans;
+
+        // Session is the sole root (empty parent). Suites are its
+        // direct children; everything else is a case hanging off a
+        // suite. Build a span-id → suite lookup so each case resolves
+        // its suite in one pass.
+        let session = spans.iter().find(|s| s.parent_span_id.is_empty())?;
+        let mut suites: HashMap<&[u8], &Span> = HashMap::new();
+        for span in spans {
+            if span.parent_span_id == session.span_id && span.span_id != session.span_id {
+                suites.insert(span.span_id.as_slice(), span);
+            }
+        }
+
+        let cases = spans
+            .iter()
+            .filter(|s| s.span_id != session.span_id && !suites.contains_key(s.span_id.as_slice()))
+            .map(|case| CaseEntry {
+                case,
+                suite: suites.get(case.parent_span_id.as_slice()).copied(),
+                encoded_len: case.encoded_len(),
+            })
+            .collect();
+
+        Some(Self {
+            template: request,
+            session,
+            cases,
+        })
+    }
+
+    /// Recursively split `cases` until every produced request gzips
+    /// under `cap`, appending the uploads to `chunks`. A single case
+    /// that can't fit even on its own is recorded in `oversized` and
+    /// dropped.
+    ///
+    /// Each node re-gzips its own slice rather than estimating from a
+    /// ratio: gzip is the only exact measure of the wire size, and
+    /// this path only runs for the rare report that already exceeds
+    /// the cap, where the multi-MiB upload I/O dwarfs the extra
+    /// compression. Correctness (never ship an over-cap chunk) is
+    /// worth the ~log(chunk-count) re-compressions.
+    fn pack(
+        &self,
+        cases: &[CaseEntry<'a>],
+        cap: usize,
+        chunks: &mut Vec<Chunk>,
+        oversized: &mut Vec<String>,
+    ) -> Result<(), std::io::Error> {
+        let request = self.assemble(cases);
+        let compressed = gzip_request(&request)?;
+        if compressed.len() <= cap {
+            chunks.push(Chunk {
+                request,
+                compressed,
+            });
+            return Ok(());
+        }
+        if cases.len() <= 1 {
+            // The lone case (plus the unavoidable session/suite
+            // framing) still overflows — nowhere left to split.
+            if let Some(entry) = cases.first() {
+                oversized.push(entry.case.name.clone());
+            }
+            return Ok(());
+        }
+        let mid = split_index(cases);
+        self.pack(&cases[..mid], cap, chunks, oversized)?;
+        self.pack(&cases[mid..], cap, chunks, oversized)
+    }
+
+    /// Build a standalone request carrying `cases`: the session span,
+    /// the distinct suite spans those cases belong to (first-seen
+    /// order), then the case spans. Resource and scope metadata are
+    /// cloned from the original so the chunk routes identically.
+    fn assemble(&self, cases: &[CaseEntry<'a>]) -> ExportTraceServiceRequest {
+        let resource_spans = &self.template.resource_spans[0];
+        let scope_spans = &resource_spans.scope_spans[0];
+
+        let mut spans = Vec::with_capacity(1 + cases.len());
+        spans.push(self.session.clone());
+
+        let mut seen_suites: Vec<&[u8]> = Vec::new();
+        for entry in cases {
+            if let Some(suite) = entry.suite
+                && !seen_suites.contains(&suite.span_id.as_slice())
+            {
+                seen_suites.push(suite.span_id.as_slice());
+                spans.push(suite.clone());
+            }
+        }
+        for entry in cases {
+            spans.push(entry.case.clone());
+        }
+
+        ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: resource_spans.resource.clone(),
+                scope_spans: vec![ScopeSpans {
+                    scope: scope_spans.scope.clone(),
+                    spans,
+                    schema_url: scope_spans.schema_url.clone(),
+                }],
+                schema_url: resource_spans.schema_url.clone(),
+            }],
+        }
+    }
+}
+
+/// Pick the index that splits `cases` into two halves of roughly
+/// equal *encoded* size, so one giant case is isolated fast instead
+/// of dragged through many count-based halvings. The result is always
+/// in `1..cases.len()` so both halves are non-empty (caller
+/// guarantees `cases.len() >= 2`).
+fn split_index(cases: &[CaseEntry]) -> usize {
+    let total: usize = cases.iter().map(|e| e.encoded_len).sum();
+    let mut acc = 0;
+    for (i, entry) in cases.iter().enumerate() {
+        acc += entry.encoded_len;
+        if acc * 2 >= total {
+            return (i + 1).clamp(1, cases.len() - 1);
+        }
+    }
+    // Unreachable for non-empty encoded sizes; keep a sane fallback.
+    cases.len() / 2
+}
+
+/// gzip a request the same way [`upload::upload`] does. The error is
+/// propagated so a compression failure surfaces as a real upload
+/// error rather than being mistaken for an oversized payload.
+fn gzip_request(request: &ExportTraceServiceRequest) -> Result<Vec<u8>, std::io::Error> {
+    upload::gzip(&request.encode_to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::junit_process::junit::{Failure, ParseResult, TestCase, TestStatus};
+    use crate::junit_process::spans::{UploadMetadata, build_traces};
+    use crate::testing::{incompressible, with_ci_env};
+    use std::collections::BTreeSet;
+    use std::time::Duration;
+
+    fn case(name: &str, suite: &str, stacktrace_len: usize) -> TestCase {
+        // Derive a stable per-case seed from the name so repeated
+        // builds are deterministic.
+        let seed = name.bytes().fold(1u64, |acc, b| {
+            acc.wrapping_mul(31).wrapping_add(u64::from(b))
+        });
+        TestCase {
+            name: name.to_string(),
+            suite_name: suite.to_string(),
+            duration: Some(Duration::from_secs(0)),
+            file: None,
+            line: None,
+            status: if stacktrace_len > 0 {
+                TestStatus::Failed
+            } else {
+                TestStatus::Passed
+            },
+            failure: Failure {
+                kind: None,
+                message: None,
+                stacktrace: (stacktrace_len > 0).then(|| incompressible(seed, stacktrace_len)),
+            },
+        }
+    }
+
+    fn build(cases: Vec<TestCase>) -> ExportTraceServiceRequest {
+        let parsed = ParseResult {
+            suite_names: cases.iter().map(|c| c.suite_name.clone()).collect(),
+            cases,
+        };
+        let metadata = UploadMetadata {
+            test_framework: Some("pytest".to_string()),
+            test_language: Some("python".to_string()),
+            mergify_test_job_name: None,
+            quarantined: BTreeSet::new(),
+        };
+        with_ci_env(&[], || build_traces(&parsed, &metadata)).request
+    }
+
+    /// Collect the `test.case.name` of every case span in a chunk.
+    fn case_names(chunk: &Chunk) -> Vec<String> {
+        spans_with_scope(chunk, "case")
+            .map(|s| s.name.clone())
+            .collect()
+    }
+
+    /// Iterate the spans of a chunk whose `test.scope` attribute
+    /// equals `scope` (`session` / `suite` / `case`).
+    fn spans_with_scope<'a>(chunk: &'a Chunk, scope: &'a str) -> impl Iterator<Item = &'a Span> {
+        use opentelemetry_proto::tonic::common::v1::any_value::Value;
+        chunk.request.resource_spans[0].scope_spans[0]
+            .spans
+            .iter()
+            .filter(move |s| {
+                s.attributes.iter().any(|kv| {
+                    kv.key == "test.scope"
+                        && matches!(
+                            kv.value.as_ref().and_then(|v| v.value.as_ref()),
+                            Some(Value::StringValue(v)) if v == scope
+                        )
+                })
+            })
+    }
+
+    #[test]
+    fn small_report_stays_a_single_chunk() {
+        let request = build(vec![case("t.a", "suite", 0), case("t.b", "suite", 0)]);
+        let outcome = split_request(&request, upload::MAX_GZIPPED_UPLOAD_BYTES).unwrap();
+        assert_eq!(outcome.chunks.len(), 1);
+        assert!(outcome.oversized_cases.is_empty());
+        // Byte-identical to the un-split request: the common path must
+        // not perturb the payload, and the compressed bytes are the
+        // gzip of exactly that request (posted as-is, no re-gzip).
+        assert_eq!(
+            outcome.chunks[0].request.encode_to_vec(),
+            request.encode_to_vec()
+        );
+        assert_eq!(
+            outcome.chunks[0].compressed,
+            gzip_request(&request).unwrap()
+        );
+    }
+
+    #[test]
+    fn large_report_splits_into_under_cap_chunks_covering_every_case() {
+        // 40 cases × ~2 KiB of stacktrace each. With a 4 KiB cap the
+        // whole thing must fan out into several uploads.
+        let cases: Vec<TestCase> = (0..40)
+            .map(|i| case(&format!("t.case_{i}"), "suite", 2048))
+            .collect();
+        let request = build(cases);
+        let cap = 4 * 1024;
+
+        let outcome = split_request(&request, cap).unwrap();
+
+        assert!(
+            outcome.chunks.len() > 1,
+            "expected a fan-out, got {} chunk(s)",
+            outcome.chunks.len()
+        );
+        assert!(outcome.oversized_cases.is_empty());
+
+        // Every chunk's stored bytes are under the cap and are the
+        // gzip of its own request; each chunk is self-contained (has
+        // the session span).
+        for chunk in &outcome.chunks {
+            assert!(chunk.compressed.len() <= cap, "chunk exceeds cap");
+            assert_eq!(chunk.compressed, gzip_request(&chunk.request).unwrap());
+            let spans = &chunk.request.resource_spans[0].scope_spans[0].spans;
+            assert!(
+                spans.iter().any(|s| s.parent_span_id.is_empty()),
+                "chunk missing session span"
+            );
+        }
+
+        // Union of case names across chunks == the original set, no
+        // loss and no duplication.
+        let mut got: Vec<String> = outcome.chunks.iter().flat_map(case_names).collect();
+        got.sort();
+        let mut want: Vec<String> = (0..40).map(|i| format!("t.case_{i}")).collect();
+        want.sort();
+        assert_eq!(got, want);
+
+        // Every chunk carries the same trace id — one trace, many
+        // uploads.
+        let trace_id = &request.resource_spans[0].scope_spans[0].spans[0].trace_id;
+        for chunk in &outcome.chunks {
+            for span in &chunk.request.resource_spans[0].scope_spans[0].spans {
+                assert_eq!(&span.trace_id, trace_id, "trace id drifted across chunks");
+            }
+        }
+    }
+
+    #[test]
+    fn oversized_single_case_is_reported_and_dropped_but_others_upload() {
+        // One monster case that can't fit under the cap on its own,
+        // alongside two normal ones that must still upload.
+        let cap = 4 * 1024;
+        let request = build(vec![
+            case("t.normal_a", "suite", 256),
+            case("t.monster", "suite", 64 * 1024),
+            case("t.normal_b", "suite", 256),
+        ]);
+
+        let outcome = split_request(&request, cap).unwrap();
+
+        assert_eq!(outcome.oversized_cases, vec!["t.monster".to_string()]);
+        for chunk in &outcome.chunks {
+            assert!(chunk.compressed.len() <= cap);
+        }
+        let uploaded: Vec<String> = outcome.chunks.iter().flat_map(case_names).collect();
+        assert!(uploaded.contains(&"t.normal_a".to_string()));
+        assert!(uploaded.contains(&"t.normal_b".to_string()));
+        assert!(
+            !uploaded.contains(&"t.monster".to_string()),
+            "oversized case must not be uploaded"
+        );
+    }
+
+    #[test]
+    fn cases_from_distinct_suites_keep_their_suite_span_in_each_chunk() {
+        // Two suites, enough stacktrace to force a split; whichever
+        // suite a case lands in, its suite span must ride along.
+        let cases: Vec<TestCase> = (0..20)
+            .map(|i| {
+                let suite = if i % 2 == 0 { "alpha" } else { "beta" };
+                case(&format!("t.case_{i}"), suite, 2048)
+            })
+            .collect();
+        let request = build(cases);
+        let cap = 4 * 1024;
+
+        let outcome = split_request(&request, cap).unwrap();
+        assert!(outcome.chunks.len() > 1);
+
+        for chunk in &outcome.chunks {
+            // Every case's parent suite span is present in the chunk.
+            let suite_ids: BTreeSet<&[u8]> = spans_with_scope(chunk, "suite")
+                .map(|s| s.span_id.as_slice())
+                .collect();
+            for case_span in spans_with_scope(chunk, "case") {
+                assert!(
+                    suite_ids.contains(case_span.parent_span_id.as_slice()),
+                    "case {} has no suite span in its chunk",
+                    case_span.name
+                );
+            }
+        }
+    }
+}

--- a/crates/mergify-ci/src/junit_process/upload.rs
+++ b/crates/mergify-ci/src/junit_process/upload.rs
@@ -61,6 +61,14 @@ impl std::error::Error for UploadError {}
 const ENDPOINT_PATH: &str = "/v1/repos/";
 const ENDPOINT_SUFFIX: &str = "/ci/traces";
 
+/// Hard cap on the size of a single gzipped OTLP upload, in bytes
+/// (10 MiB). The ingest endpoint refuses payloads larger than this,
+/// so [`crate::junit_process::split`] partitions an oversized trace
+/// into several uploads that each gzip under the cap. The cap is on
+/// the *compressed* body — the exact bytes we put on the wire — not
+/// the raw XML or the uncompressed protobuf.
+pub const MAX_GZIPPED_UPLOAD_BYTES: usize = 10 * 1024 * 1024;
+
 fn endpoint_url(api_url: &str, repository: &str) -> String {
     // The shape `<api_url>/v1/repos/<owner>/<repo>/ci/traces`
     // matches the Python implementation. The repository segment is
@@ -70,7 +78,7 @@ fn endpoint_url(api_url: &str, repository: &str) -> String {
     format!("{trimmed}{ENDPOINT_PATH}{repository}{ENDPOINT_SUFFIX}")
 }
 
-fn gzip(bytes: &[u8]) -> Result<Vec<u8>, std::io::Error> {
+pub(crate) fn gzip(bytes: &[u8]) -> Result<Vec<u8>, std::io::Error> {
     let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
     encoder.write_all(bytes)?;
     encoder.finish()
@@ -96,13 +104,28 @@ pub async fn upload(
         return Ok(());
     }
 
-    let url = endpoint_url(api_url, repository);
-
     let encoded = request.encode_to_vec();
     let compressed = gzip(&encoded).map_err(|e| UploadError {
         status: None,
         message: format!("failed to gzip OTLP payload: {e}"),
     })?;
+
+    upload_compressed(client, api_url, token, repository, compressed).await
+}
+
+/// POST an already-gzipped OTLP payload. The splitting path
+/// ([`crate::junit_process::split`]) gzips each chunk once to size it
+/// against the cap and hands the compressed bytes straight here, so
+/// the payload is never gzipped twice. Callers guarantee `compressed`
+/// is a non-empty gzipped `ExportTraceServiceRequest`.
+pub async fn upload_compressed(
+    client: &reqwest::Client,
+    api_url: &str,
+    token: &str,
+    repository: &str,
+    compressed: Vec<u8>,
+) -> Result<(), UploadError> {
+    let url = endpoint_url(api_url, repository);
 
     let resp = client
         .post(&url)

--- a/crates/mergify-ci/src/testing.rs
+++ b/crates/mergify-ci/src/testing.rs
@@ -122,3 +122,30 @@ where
 {
     temp_env::async_with_vars(merged_overrides(extra), f).await
 }
+
+/// A high-entropy alphanumeric string of `len` chars, seeded so
+/// different callers produce different content. Used by the
+/// `junit_process::split` tests to fill stack traces with data gzip
+/// can't collapse — a repeating or low-entropy filler would compress
+/// to almost nothing and never force a split, so the compressed-size
+/// path would go untested. Alphanumeric output is XML-safe, so the
+/// same helper works both for building `TestCase` values directly and
+/// for embedding inside a `<failure>` body in an XML fixture.
+pub(crate) fn incompressible(seed: u64, len: usize) -> String {
+    // xorshift64 → one alphanumeric char per step.
+    const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+    (0..len)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            // `state % ALPHABET.len()` is always < 62, so it fits
+            // usize on every target and the conversion can't fail;
+            // `unwrap_or(0)` keeps it panic-free and ties the range to
+            // the alphabet (no magic number).
+            let idx = usize::try_from(state % ALPHABET.len() as u64).unwrap_or(0);
+            char::from(ALPHABET[idx])
+        })
+        .collect()
+}


### PR DESCRIPTION
`mergify ci junit-process` builds every parsed JUnit report into one OTLP
`ExportTraceServiceRequest`, gzips it, and POSTs it in a single request. A
large report (tens of thousands of cases, or a few with huge stack traces)
can gzip past what the ingest endpoint accepts, and the whole upload is lost.

Cap the compressed body at a named constant `MAX_GZIPPED_UPLOAD_BYTES`
(10 MiB) and split an oversized payload into several uploads that each gzip
under the cap. The cap is on the *gzipped* bytes actually sent, not the raw
XML or the uncompressed protobuf: gzip ratios swing wildly between a run of
short case names and one of megabyte stack traces, so only the compressed
size is meaningful. A normal report stays a single upload, byte-identical to
before.

How the split works (new `junit_process::split`):

- Decompose the built request into its session / suite / case spans, then
  recursively halve the case list — by encoded size, so one giant case is
  isolated fast — verifying each candidate chunk with an actual gzip.
- Each chunk is a self-contained trace: the session span, the suite spans for
  the cases it carries, and those cases. Every chunk keeps the original
  trace_id and span_ids, so the backend reassembles one trace from N uploads.
- Each chunk carries the gzipped bytes it was sized against, so the upload
  step posts them directly instead of compressing a second time.

Oversize single case (one test whose trace alone exceeds the cap gzipped):
skip-and-warn. There is no upload it can fit into, so it is dropped and
listed in the report under "Some test results were too large to upload". The
CI verdict is unaffected — it is computed from the parsed cases, not the
upload — so no test's blocking status is lost, only its telemetry.

Upload semantics: a transient failure on one chunk does not abandon the
rest (each chunk is a self-contained, idempotent trace, so delivering as
many as possible is best), but a permanent rejection stops the loop. When
nothing reaches ingest (every case oversized, or gzip fails) the run reports
test_results_upload=failed rather than a false success, and dropped oversize
cases emit a GitHub Actions warning naming them.

Backend support: the split relies on the ingest endpoint accepting several
same-test_run_id uploads and merging them additively/idempotently by
(trace_id, span_id). That landed in monorepo #36926 (MRGFY-8051); without it
the backend would drop every chunk after the first. This CLI change is inert
until that backend is deployed.

Fixes MRGFY-8050

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>