### PR TITLE
feat(ci): read merge-queue metadata as a generic value, tolerating key renames

### DIFF
--- a/crates/mergify-ci/src/git.rs
+++ b/crates/mergify-ci/src/git.rs
@@ -28,13 +28,17 @@ use std::process::Stdio;
 #[must_use]
 pub(crate) fn read_note(notes_ref: &str, rev: &str) -> Option<serde_json::Value> {
     let content = capture(&["notes", &format!("--ref={notes_ref}"), "show", rev])?;
-    parse_note(&content)
+    parse_yaml_mapping(&content)
 }
 
-/// Parse a note body (YAML) into a JSON value, keeping every field.
-/// Restricted to mappings: a bare scalar or sequence isn't a
-/// merge-queue note and would make the JSON output meaningless.
-fn parse_note(content: &str) -> Option<serde_json::Value> {
+/// Parse an engine merge-queue YAML payload into a JSON value, keeping
+/// every field. Shared by the git-note reader ([`read_note`]) and the
+/// MQ PR-body reader (`queue_metadata::parse_yaml_block`): the engine
+/// writes the *same* payload to both, so both must accept exactly the
+/// same shapes. Restricted to mappings — a bare scalar or sequence
+/// isn't merge-queue metadata and would make the JSON output
+/// meaningless.
+pub(crate) fn parse_yaml_mapping(content: &str) -> Option<serde_json::Value> {
     let value: serde_json::Value = serde_yaml_ng::from_str(content).ok()?;
     value.is_object().then_some(value)
 }
@@ -72,7 +76,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_note_keeps_whole_payload() {
+    fn parse_yaml_mapping_keeps_whole_payload() {
         // The note body is the engine's full TrainInfo dump. Every
         // field must survive into the value — including top-level and
         // per-PR `scopes`, which a fixed struct would have dropped.
@@ -89,7 +93,7 @@ previous_failed_batches:
       - 7
 checking_base_sha: cafef00d
 ";
-        let note = parse_note(body).expect("engine payload should parse");
+        let note = parse_yaml_mapping(body).expect("engine payload should parse");
         assert_eq!(note["checking_base_sha"], "cafef00d");
         assert_eq!(note["scopes"][0], "backend");
         assert_eq!(note["pull_requests"][0]["number"], 7);
@@ -98,9 +102,9 @@ checking_base_sha: cafef00d
     }
 
     #[test]
-    fn parse_note_rejects_non_mapping() {
-        // A bare scalar or sequence isn't a merge-queue note.
-        assert!(parse_note("just a scalar\n").is_none());
-        assert!(parse_note("- a\n- b\n").is_none());
+    fn parse_yaml_mapping_rejects_non_mapping() {
+        // A bare scalar or sequence isn't a merge-queue payload.
+        assert!(parse_yaml_mapping("just a scalar\n").is_none());
+        assert!(parse_yaml_mapping("- a\n- b\n").is_none());
     }
 }

--- a/crates/mergify-ci/src/git_refs.rs
+++ b/crates/mergify-ci/src/git_refs.rs
@@ -239,11 +239,20 @@ fn detect_from_pull_request_event(
     }
 
     if let Some(meta) = extract_from_event(event, output)? {
-        return Ok(Some(References {
-            base: Some(meta.checking_base_sha),
-            head,
-            source: ReferencesSource::MergeQueue,
-        }));
+        if let Some(base) = checking_base_sha(&meta) {
+            return Ok(Some(References {
+                base: Some(base),
+                head,
+                source: ReferencesSource::MergeQueue,
+            }));
+        }
+        // MQ metadata is present but carries no `checking_base_sha`
+        // (e.g. a future engine renamed it). We fall through to the PR
+        // base below, but that would be the *wrong* base for a batch
+        // build — warn so it isn't diagnosed silently.
+        output.status(
+            "WARNING: MQ pull request metadata without checking_base_sha, skipping metadata extraction",
+        )?;
     }
 
     if let Some(pr) = &event.pull_request
@@ -321,10 +330,16 @@ pub fn real_notes_reader(branch: &str, head_sha: &str) -> Option<String> {
     checking_base_sha(&crate::git::read_note(&notes_ref_short, head_sha)?)
 }
 
-/// Pull `checking_base_sha` out of a note payload. Accepts the YAML
-/// scalar as either a string or (defensively) a number — a SHA is
-/// always a string in practice, but reading it tolerantly avoids
-/// silently dropping a note over a formatting quirk.
+/// Pull `checking_base_sha` out of an engine merge-queue payload —
+/// either the git note ([`real_notes_reader`]) or the YAML block in
+/// the MQ draft PR body (`queue_metadata`), which carry the same dump.
+/// Both read it through here so neither is coupled to the payload's
+/// other keys, which the engine renames independently.
+///
+/// Accepts the YAML scalar as either a string or (defensively) a
+/// number — a SHA is always a string in practice, but reading it
+/// tolerantly avoids silently dropping a payload over a formatting
+/// quirk.
 fn checking_base_sha(note: &serde_json::Value) -> Option<String> {
     match note.get("checking_base_sha")? {
         serde_json::Value::String(s) => Some(s.clone()),
@@ -544,6 +559,77 @@ mod tests {
         assert_eq!(refs.base.as_deref(), Some("mq-base"));
         assert_eq!(refs.head, "mq-head");
         assert_eq!(refs.source, ReferencesSource::MergeQueue);
+    }
+
+    #[test]
+    fn mq_body_with_post_contract_batch_still_yields_base() {
+        // The ticket's exact failure mode (MRGFY-8104): a batch body
+        // carries a non-empty `previous_failed_batches`, and a
+        // post-contract engine emits `batch_pr_number` with no
+        // `draft_pr_number`. The old rigid struct required
+        // `draft_pr_number`, so the whole document failed to parse and
+        // `checking_base_sha` was silently lost, dropping git-refs to
+        // the wrong-base `GithubEventPullRequest` fallthrough. The
+        // generic parse must keep the base and the MergeQueue source.
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_event(
+            &dir,
+            &serde_json::json!({
+                "pull_request": {
+                    "title": "merge queue: batch",
+                    "body": "```yaml\nchecking_base_sha: mq-base\nprevious_failed_batches:\n  - batch_pr_number: 42\n    checked_pull_requests:\n      - 7\n```",
+                    "head": {"sha": "mq-head", "ref": "mq/main/0"},
+                    "base": {"sha": "wrong-base"},
+                },
+            }),
+        );
+        let mut cap = Captured::human();
+        let refs = temp_env::with_vars(
+            [
+                ("GITHUB_EVENT_NAME", Some("pull_request")),
+                ("GITHUB_EVENT_PATH", Some(path.to_str().unwrap())),
+                ("BUILDKITE", None),
+            ],
+            || detect(&mut cap.output, &no_notes).unwrap(),
+        );
+        assert_eq!(refs.base.as_deref(), Some("mq-base"));
+        assert_eq!(refs.source, ReferencesSource::MergeQueue);
+    }
+
+    #[test]
+    fn mq_body_metadata_without_base_warns_and_falls_through() {
+        // A valid metadata block that carries no checking_base_sha
+        // (the shape a future engine key rename would produce) must not
+        // silently pick the wrong base: git-refs falls through to the
+        // PR base and warns so the operator sees why.
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_event(
+            &dir,
+            &serde_json::json!({
+                "pull_request": {
+                    "title": "merge queue: batch",
+                    "body": "```yaml\npull_requests:\n  - number: 7\n```",
+                    "head": {"sha": "mq-head", "ref": "mq/main/0"},
+                    "base": {"sha": "pr-base"},
+                },
+            }),
+        );
+        let mut cap = Captured::human();
+        let refs = temp_env::with_vars(
+            [
+                ("GITHUB_EVENT_NAME", Some("pull_request")),
+                ("GITHUB_EVENT_PATH", Some(path.to_str().unwrap())),
+                ("BUILDKITE", None),
+            ],
+            || detect(&mut cap.output, &no_notes).unwrap(),
+        );
+        assert_eq!(refs.base.as_deref(), Some("pr-base"));
+        assert_eq!(refs.source, ReferencesSource::GithubEventPullRequest);
+        assert!(
+            cap.stderr().contains("without checking_base_sha"),
+            "got: {:?}",
+            cap.stderr()
+        );
     }
 
     #[test]

--- a/crates/mergify-ci/src/queue_metadata.rs
+++ b/crates/mergify-ci/src/queue_metadata.rs
@@ -6,38 +6,28 @@
 //! draft or has no metadata; `git_refs` uses it as one of its base-SHA
 //! detection paths. (`queue-info` itself no longer reads the PR body —
 //! it reads the engine's git note; see `queue_info`.)
+//!
+//! The payload is parsed into a generic value rather than a fixed
+//! struct, matching how `git::read_note` reads the identical payload
+//! off the git note. This is load-bearing, not stylistic: the engine
+//! evolves these keys (`draft_pr_number` -> `batch_pr_number`, and it
+//! dual-emits both for a deprecation window). A struct with required
+//! fields would fail the *whole document* over one renamed key it
+//! never even reads, and the caller's `.ok()` would swallow that into
+//! `None` — silently costing `git_refs` the `checking_base_sha` it
+//! came for and sending CI diffs against the wrong base. Deserializing
+//! only what is read keeps the CLI working against any engine version.
 
 use mergify_core::Output;
-use serde::Deserialize;
-use serde::Serialize;
 
 use crate::github_event::GitHubEvent;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MergeQueuePullRequest {
-    pub number: u64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MergeQueueBatchFailed {
-    pub draft_pr_number: u64,
-    pub checked_pull_requests: Vec<u64>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MergeQueueMetadata {
-    pub checking_base_sha: String,
-    #[serde(default)]
-    pub pull_requests: Vec<MergeQueuePullRequest>,
-    #[serde(default)]
-    pub previous_failed_batches: Vec<MergeQueueBatchFailed>,
-}
-
-/// Parse the first ```yaml``` fenced block out of `body` and try to
-/// read a `MergeQueueMetadata` out of it. Returns `None` when the
-/// body has no fenced block or the YAML payload is the wrong shape.
+/// Parse the first ```yaml``` fenced block out of `body` into a
+/// generic value, keeping every field. Returns `None` when the body
+/// has no fenced block, or the block isn't a YAML mapping (a bare
+/// scalar or sequence isn't merge-queue metadata).
 #[must_use]
-pub fn parse_yaml_block(body: &str) -> Option<MergeQueueMetadata> {
+pub fn parse_yaml_block(body: &str) -> Option<serde_json::Value> {
     let mut inside = false;
     let mut lines: Vec<&str> = Vec::new();
     for line in body.lines() {
@@ -54,7 +44,9 @@ pub fn parse_yaml_block(body: &str) -> Option<MergeQueueMetadata> {
     if lines.is_empty() {
         return None;
     }
-    serde_yaml_ng::from_str(&lines.join("\n")).ok()
+    // Same parse as the git-note reader — the engine writes this
+    // identical payload to both the note and the PR body.
+    crate::git::parse_yaml_mapping(&lines.join("\n"))
 }
 
 /// Extract MQ metadata from an event payload's pull-request body.
@@ -65,7 +57,7 @@ pub fn parse_yaml_block(body: &str) -> Option<MergeQueueMetadata> {
 pub fn extract_from_event(
     ev: &GitHubEvent,
     output: &mut dyn Output,
-) -> std::io::Result<Option<MergeQueueMetadata>> {
+) -> std::io::Result<Option<serde_json::Value>> {
     let Some(pr) = &ev.pull_request else {
         return Ok(None);
     };
@@ -98,14 +90,53 @@ mod tests {
     fn parse_yaml_block_extracts_metadata() {
         let body = "prelude\n\n```yaml\nchecking_base_sha: abc\npull_requests:\n  - number: 1\n```\ntrailing";
         let meta = parse_yaml_block(body).unwrap();
-        assert_eq!(meta.checking_base_sha, "abc");
-        assert_eq!(meta.pull_requests.len(), 1);
-        assert_eq!(meta.pull_requests[0].number, 1);
+        assert_eq!(meta["checking_base_sha"], "abc");
+        assert_eq!(meta["pull_requests"][0]["number"], 1);
     }
 
     #[test]
     fn parse_yaml_block_returns_none_without_block() {
         assert!(parse_yaml_block("just text").is_none());
+    }
+
+    #[test]
+    fn parse_yaml_block_rejects_non_mapping() {
+        // A bare scalar or sequence isn't merge-queue metadata; the
+        // caller warns instead of treating it as an empty payload.
+        assert!(parse_yaml_block("```yaml\njust a scalar\n```").is_none());
+        assert!(parse_yaml_block("```yaml\n- a\n- b\n```").is_none());
+    }
+
+    #[test]
+    fn parse_yaml_block_survives_every_batch_pr_key_spelling() {
+        // The engine renamed `draft_pr_number` -> `batch_pr_number`
+        // and dual-emits both for a deprecation window. We never read
+        // the key, so all three spellings must yield the same
+        // `checking_base_sha` and none may fail the document. Modelling
+        // this block with a required field once made a *renamed* key
+        // silently cost us the base SHA entirely.
+        for batch_keys in [
+            "draft_pr_number: 42",
+            "batch_pr_number: 42",
+            "batch_pr_number: 42\n    draft_pr_number: 42",
+        ] {
+            let body = format!(
+                "prelude\n```yaml\nchecking_base_sha: cafef00d\nprevious_failed_batches:\n  - {batch_keys}\n    checked_pull_requests:\n      - 7\n```"
+            );
+            let meta = parse_yaml_block(&body)
+                .unwrap_or_else(|| panic!("should parse with {batch_keys:?}"));
+            assert_eq!(meta["checking_base_sha"], "cafef00d");
+        }
+    }
+
+    #[test]
+    fn parse_yaml_block_survives_unknown_and_missing_keys() {
+        // Same invariant, generalised: a key the engine adds later, and
+        // an entry missing keys we used to require, both leave
+        // `checking_base_sha` reachable.
+        let body = "```yaml\nchecking_base_sha: abc\nsomething_new: 1\nprevious_failed_batches:\n  - {}\n```";
+        let meta = parse_yaml_block(body).unwrap();
+        assert_eq!(meta["checking_base_sha"], "abc");
     }
 
     #[test]
@@ -153,6 +184,6 @@ mod tests {
         };
         let mut cap = Captured::human();
         let meta = extract_from_event(&ev, &mut cap.output).unwrap().unwrap();
-        assert_eq!(meta.checking_base_sha, "deadbeef");
+        assert_eq!(meta["checking_base_sha"], "deadbeef");
     }
 }


### PR DESCRIPTION
`queue_metadata::parse_yaml_block` modeled the MQ draft-PR-body payload
with a rigid serde struct whose `draft_pr_number` was required. The
engine (MRGFY-8075) renamed that key to `batch_pr_number` and dual-emits
both for one release window before dropping the old spelling. A missing
required field fails the *whole document*, and the caller's `.ok()`
swallows that into `None`, so once the alias is gone every batch body
with a non-empty `previous_failed_batches` would silently cost `git-refs`
its `checking_base_sha` and diff against the wrong base, with no error
surfaced anywhere.

That struct has been dead code since #1600: its only reader, `git_refs`,
uses just `checking_base_sha`; every other field is parsed and discarded.
So rather than a `#[serde(alias)]` band-aid on one key, parse the payload
into a generic `serde_json::Value` — exactly how the git-note twin
(`git::read_note`) already reads the identical payload — and pull
`checking_base_sha` out with the existing shared helper. The CLI is now
immune to any engine key rename in this block, with no schema left to
drift and no call-site churn.

While here: warn instead of silently falling through to the PR base when
MQ metadata is present but carries no `checking_base_sha`, so a future
rename of that key can't degrade the base silently either; and share the
YAML-mapping parse between the note and PR-body readers so they can't
diverge in what they accept.

Fixes MRGFY-8104

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>