### PR TITLE
docs(stack): record what a stack push rebases away in the skill

### DIFF
--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -1335,6 +1335,9 @@ fn run_stack_setup(force: bool) -> Result<(), mergify_core::CliError> {
     if outcome.notes_display_ref_added {
         println!("Added notes.displayRef = refs/notes/mergify/*");
     }
+    if outcome.notes_rewrite_ref_added {
+        println!("Added notes.rewriteRef = refs/notes/mergify/stack");
+    }
     if any_legacy_needs_force {
         println!("Some hooks are legacy. Run 'mergify stack hooks --setup --force' to migrate.");
     }

--- a/crates/mergify-stack/hooks/scripts/commit-msg.sh
+++ b/crates/mergify-stack/hooks/scripts/commit-msg.sh
@@ -32,6 +32,52 @@ if test ! -f "$1" ; then
   exit 1
 fi
 
+# Refuse `git commit --amend` while a rebase is stopped at a conflict.
+#
+# At a conflict the pick being replayed has not produced a commit yet,
+# so HEAD is the last commit the rebase already applied — the trunk tip
+# when the bottom commit conflicted, otherwise an earlier commit of the
+# stack. Amending rewrites that commit instead, stamping the work with
+# its message and Change-Id and mapping it to the wrong pull request.
+#
+# A `stack edit` pause is the opposite case: git records the commit it
+# expects you to amend in `rebase-merge/amend`, and amending there is
+# the documented way to continue.
+#
+# Amend detection: git exports the amended commit's author date, so
+# GIT_AUTHOR_DATE matches HEAD's and is in the past. The commit that
+# *resolves* a conflict is a new one, authored now — the same
+# distinction (and the same 2-second floor against a coincidental
+# same-second match) the prepare-commit-msg hook draws.
+git_dir=$(git rev-parse --git-dir 2>/dev/null)
+for state_dir in "$git_dir/rebase-merge" "$git_dir/rebase-apply" ; do
+    test -d "$state_dir" || continue
+    test -f "$state_dir/amend" && continue
+
+    env_epoch=$(echo "$GIT_AUTHOR_DATE" | cut -d' ' -f1 | tr -d '@')
+    test -n "$env_epoch" || continue
+    head_epoch=$(git log -1 --format=%ad --date=raw HEAD 2>/dev/null | cut -d' ' -f1)
+    test "$env_epoch" = "$head_epoch" || continue
+    test "$(($(date +%s) - env_epoch))" -ge 2 || continue
+
+    echo "Refusing to amend: this rebase is stopped at a conflict." >&2
+    echo "" >&2
+    echo "The commit being replayed does not exist yet, so HEAD is the last" >&2
+    echo "commit the rebase applied — not the one you are resolving. Amending" >&2
+    echo "it rewrites that commit and gives your work its message and" >&2
+    echo "Change-Id, which maps it to the wrong pull request." >&2
+    echo "" >&2
+    echo "Resolve the conflict instead:" >&2
+    echo "    git add <files>" >&2
+    echo "    git rebase --continue" >&2
+    echo "" >&2
+    echo "To amend a commit in the stack, let this rebase finish (or run" >&2
+    echo "git rebase --abort), then: mergify stack edit <Change-Id>" >&2
+    echo "" >&2
+    echo "Pass --no-verify to override this check." >&2
+    exit 1
+done
+
 # $RANDOM will be undefined if not using bash, so don't use set -u
 # $RANDOM is undefined in POSIX sh (dash), so include HEAD's SHA for entropy
 # to prevent collisions when two commits have the same message in the same second

--- a/crates/mergify-stack/src/commands/setup.rs
+++ b/crates/mergify-stack/src/commands/setup.rs
@@ -24,6 +24,7 @@ use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use crate::git::run_git_capture;
+use crate::local_commits::STACK_NOTES_REF;
 
 use mergify_core::CliError;
 
@@ -87,14 +88,15 @@ pub struct InstallLog {
     pub actions: Vec<HookAction>,
 }
 
-/// Outcome of an `install` run: the per-hook action log plus
-/// whether the local `notes.displayRef` config was added this run
-/// (so the caller can echo Python's `Added notes.displayRef = …`
-/// confirmation).
+/// Outcome of an `install` run: the per-hook action log plus, for
+/// each of the local `notes.displayRef` and `notes.rewriteRef`
+/// configs, whether it was added this run (so the caller can echo
+/// Python's `Added <key> = …` confirmation only for what changed).
 #[derive(Debug, Clone)]
 pub struct InstallOutcome {
     pub logs: Vec<InstallLog>,
     pub notes_display_ref_added: bool,
+    pub notes_rewrite_ref_added: bool,
 }
 
 pub struct Options<'a> {
@@ -153,9 +155,11 @@ pub fn install(opts: &Options<'_>) -> Result<InstallOutcome, CliError> {
     }
 
     let notes_display_ref_added = ensure_notes_display_ref(opts.repo_dir)?;
+    let notes_rewrite_ref_added = ensure_notes_rewrite_ref(opts.repo_dir)?;
     Ok(InstallOutcome {
         logs,
         notes_display_ref_added,
+        notes_rewrite_ref_added,
     })
 }
 
@@ -220,6 +224,40 @@ fn ensure_notes_display_ref(repo_dir: Option<&Path>) -> Result<bool, CliError> {
     run_git_capture(
         repo_dir,
         &["config", "--local", "--add", "notes.displayRef", desired],
+    )?;
+    Ok(true)
+}
+
+/// Ensure a rewritten commit keeps its stack note by adding the
+/// local `notes.rewriteRef = refs/notes/mergify/stack` config.
+/// Returns `true` when the config was added this run, `false` when
+/// it was already present.
+///
+/// A note is addressed by commit SHA, so an amend or a rebase would
+/// otherwise strand the reason on the pre-rewrite SHA and the push
+/// that follows would record a blank `Reason`. This is the setting
+/// that covers the rewrites git runs on its own — `git commit
+/// --amend`, and the `git rebase --continue` that finishes a
+/// conflicted rebase — which no flag on the CLI's own invocations
+/// can reach.
+fn ensure_notes_rewrite_ref(repo_dir: Option<&Path>) -> Result<bool, CliError> {
+    let current = run_git_capture(
+        repo_dir,
+        &["config", "--local", "--get-all", "notes.rewriteRef"],
+    )
+    .unwrap_or_default();
+    if current.lines().any(|l| l == STACK_NOTES_REF) {
+        return Ok(false);
+    }
+    run_git_capture(
+        repo_dir,
+        &[
+            "config",
+            "--local",
+            "--add",
+            "notes.rewriteRef",
+            STACK_NOTES_REF,
+        ],
     )?;
     Ok(true)
 }
@@ -474,5 +512,33 @@ mod tests {
             .unwrap();
         let content = String::from_utf8(out.stdout).unwrap();
         assert!(content.lines().any(|l| l == "refs/notes/mergify/*"));
+    }
+
+    #[test]
+    fn install_adds_notes_rewrite_ref_once() {
+        let dir = init_repo();
+        let opts = Options {
+            repo_dir: Some(dir.path()),
+            force: false,
+        };
+        assert!(install(&opts).unwrap().notes_rewrite_ref_added);
+        // Second run finds it already there: no duplicate value, and
+        // the outcome reports nothing added so the CLI stays quiet.
+        assert!(!install(&opts).unwrap().notes_rewrite_ref_added);
+
+        let out = StdCommand::new("git")
+            .arg("-C")
+            .arg(dir.path())
+            .args(["config", "--local", "--get-all", "notes.rewriteRef"])
+            .output()
+            .unwrap();
+        let content = String::from_utf8(out.stdout).unwrap();
+        assert_eq!(
+            content
+                .lines()
+                .filter(|l| *l == "refs/notes/mergify/stack")
+                .count(),
+            1
+        );
     }
 }

--- a/crates/mergify-stack/src/commands/setup.rs
+++ b/crates/mergify-stack/src/commands/setup.rs
@@ -514,6 +514,156 @@ mod tests {
         assert!(content.lines().any(|l| l == "refs/notes/mergify/*"));
     }
 
+    /// Run `git <args>` in `dir` through the installed hooks,
+    /// returning `(success, stderr)`.
+    fn try_git(dir: &Path, args: &[&str]) -> (bool, String) {
+        let out = crate::test_env::isolated_git()
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .output()
+            .unwrap();
+        (
+            out.status.success(),
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        )
+    }
+
+    fn git_stdout(dir: &Path, args: &[&str]) -> String {
+        let out = crate::test_env::isolated_git()
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .output()
+            .unwrap();
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    /// A repo stopped mid-rebase on a conflict, with the hooks
+    /// installed. The trunk commit is back-dated: the amend guard
+    /// reads a commit whose author date is at least two seconds old
+    /// as an amend target, which is what a real trunk tip is.
+    fn repo_stopped_at_conflict() -> TempDir {
+        let dir = init_repo();
+        let p = dir.path();
+        install(&Options {
+            repo_dir: Some(p),
+            force: false,
+        })
+        .unwrap();
+
+        std::fs::write(p.join("f"), "base\n").unwrap();
+        assert!(try_git(p, &["add", "f"]).0);
+        assert!(try_git(p, &["commit", "-q", "-m", "root"]).0);
+        let trunk = git_stdout(p, &["rev-parse", "--abbrev-ref", "HEAD"]);
+        assert!(try_git(p, &["checkout", "-q", "-b", "feature"]).0);
+        std::fs::write(p.join("f"), "feature\n").unwrap();
+        assert!(try_git(p, &["commit", "-q", "-a", "-m", "feat"]).0);
+        assert!(try_git(p, &["checkout", "-q", &trunk]).0);
+        std::fs::write(p.join("f"), "trunk\n").unwrap();
+        assert!(
+            try_git(
+                p,
+                &[
+                    "commit",
+                    "-q",
+                    "-a",
+                    "-m",
+                    "trunk moves",
+                    "--date=@1000000000 +0000",
+                ],
+            )
+            .0
+        );
+        assert!(try_git(p, &["checkout", "-q", "feature"]).0);
+
+        // Conflicts on `f`, leaving HEAD at the trunk tip.
+        assert!(!try_git(p, &["rebase", &trunk]).0, "rebase must conflict");
+        std::fs::write(p.join("f"), "resolved\n").unwrap();
+        assert!(try_git(p, &["add", "f"]).0);
+        dir
+    }
+
+    #[test]
+    fn amend_at_a_rebase_conflict_is_refused() {
+        // The trap the guard exists for: at a conflict HEAD is the
+        // last commit the rebase applied — here the trunk tip — so an
+        // amend rewrites *that* commit and re-maps the work to
+        // another pull request's Change-Id.
+        let dir = repo_stopped_at_conflict();
+        let p = dir.path();
+        let head_before = git_stdout(p, &["rev-parse", "HEAD"]);
+
+        let (ok, stderr) = try_git(p, &["commit", "--amend", "--no-edit"]);
+        assert!(!ok, "amend must be refused at a conflict pause");
+        assert!(stderr.contains("Refusing to amend"), "got: {stderr}");
+        assert_eq!(
+            git_stdout(p, &["rev-parse", "HEAD"]),
+            head_before,
+            "the already-applied commit must be left alone"
+        );
+
+        // The documented override still gets through.
+        assert!(
+            try_git(p, &["commit", "--amend", "--no-edit", "--no-verify"]).0,
+            "--no-verify overrides the guard"
+        );
+    }
+
+    #[test]
+    fn resolving_a_conflict_is_not_mistaken_for_an_amend() {
+        // `git commit` at the same pause creates the resolved commit
+        // rather than rewriting HEAD; the rebase then continues. The
+        // guard must stay out of the way of both.
+        let dir = repo_stopped_at_conflict();
+        let p = dir.path();
+
+        assert!(
+            try_git(p, &["commit", "-q", "-m", "resolved"]).0,
+            "resolving with a plain commit must be allowed"
+        );
+        assert!(try_git(p, &["rebase", "--continue"]).0);
+        assert!(!p.join(".git/rebase-merge").exists());
+    }
+
+    #[test]
+    fn amend_at_a_stack_edit_pause_is_allowed() {
+        // `stack edit` pauses *on* the target commit with a clean
+        // tree and records it in `rebase-merge/amend` — there the
+        // amend is the documented way to continue.
+        let dir = init_repo();
+        let p = dir.path();
+        install(&Options {
+            repo_dir: Some(p),
+            force: false,
+        })
+        .unwrap();
+        for name in ["one", "two", "three"] {
+            std::fs::write(p.join(name), format!("{name}\n")).unwrap();
+            assert!(try_git(p, &["add", name]).0);
+            assert!(try_git(p, &["commit", "-q", "-m", name, "--date=@1000000000 +0000"],).0);
+        }
+
+        let (ok, stderr) = try_git(
+            p,
+            &[
+                "-c",
+                "sequence.editor=sed -i.bak 1s/^pick/edit/",
+                "rebase",
+                "-i",
+                "HEAD~2",
+            ],
+        );
+        assert!(ok, "rebase must pause, not fail: {stderr}");
+        assert!(p.join(".git/rebase-merge/amend").exists());
+
+        std::fs::write(p.join("two"), "amended\n").unwrap();
+        assert!(try_git(p, &["add", "two"]).0);
+        let (ok, stderr) = try_git(p, &["commit", "--amend", "--no-edit"]);
+        assert!(ok, "amend at an edit pause must be allowed: {stderr}");
+        assert!(try_git(p, &["rebase", "--continue"]).0);
+    }
+
     #[test]
     fn install_adds_notes_rewrite_ref_once() {
         let dir = init_repo();

--- a/crates/mergify-stack/src/commands/sync.rs
+++ b/crates/mergify-stack/src/commands/sync.rs
@@ -25,8 +25,8 @@ use mergify_core::CliError;
 use mergify_core::HttpClient;
 
 use crate::git::{
-    compute_base_commit_sha, resolve_repo_toplevel, run_git_silent, shell_quote, spawn_rebase,
-    spawn_rebase_captured,
+    compute_base_commit_sha, notes_rewrite_config, resolve_repo_toplevel, run_git_silent,
+    shell_quote, spawn_rebase, spawn_rebase_captured,
 };
 use crate::local_commits;
 use crate::remote_changes;
@@ -130,7 +130,10 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
     if status.up_to_date() || status.all_merged() {
         // Either nothing to drop, or every commit got merged.
         // Both cases collapse to a plain pull --rebase.
-        run_git_silent(Some(&repo_dir), &["pull", "--rebase", remote, base_branch]).map_err(
+        let notes_config = notes_rewrite_config();
+        let mut args: Vec<&str> = notes_config.iter().map(String::as_str).collect();
+        args.extend(["pull", "--rebase", remote, base_branch]);
+        run_git_silent(Some(&repo_dir), &args).map_err(
             // A failed `pull --rebase` is almost always a conflict;
             // give the same recovery guidance and Conflict exit code as
             // `spawn_rebase` rather than a bare stderr. (`run_git_silent`

--- a/crates/mergify-stack/src/git.rs
+++ b/crates/mergify-stack/src/git.rs
@@ -14,6 +14,34 @@ use std::process::Command;
 
 use mergify_core::CliError;
 
+use crate::local_commits::STACK_NOTES_REF;
+
+/// `-c` overrides that make git carry the stack's notes from every
+/// rewritten commit onto its replacement.
+///
+/// A note is addressed by commit SHA, so without this a rebase
+/// strands the amend reason on the pre-rebase SHA and the push that
+/// follows records a blank `Reason` in the revision history.
+/// `mergify stack setup` persists only `notes.rewriteRef` into the
+/// repo config — the mode and the rebase toggle are git's defaults
+/// there. That config is what covers the rewrites git runs outside
+/// this process (`git commit --amend`, and the `git rebase
+/// --continue` that finishes a conflicted rebase); passing all three
+/// per-invocation keeps the CLI's own rebases correct in repos whose
+/// config predates that, and pins the defaults against a global
+/// `notes.rewriteMode=ignore` or `notes.rewrite.rebase=false`.
+#[must_use]
+pub(crate) fn notes_rewrite_config() -> Vec<String> {
+    vec![
+        "-c".to_string(),
+        format!("notes.rewriteRef={STACK_NOTES_REF}"),
+        "-c".to_string(),
+        "notes.rewriteMode=concatenate".to_string(),
+        "-c".to_string(),
+        "notes.rewrite.rebase=true".to_string(),
+    ]
+}
+
 /// Base `git` `Command` with `-C <repo_dir>` (when supplied) and a
 /// forced C locale. Use for any git invocation whose stderr or
 /// stdout the caller might parse — translated locales would
@@ -129,6 +157,7 @@ fn spawn_rebase_inner(
     capture: bool,
 ) -> Result<(), CliError> {
     let mut cmd = git_cmd(Some(repo_dir));
+    cmd.args(notes_rewrite_config());
     cmd.arg("rebase").arg("-i");
     if reapply_cherry_picks {
         // Keep commits whose patch-id already matches the base in
@@ -389,6 +418,47 @@ mod tests {
             !todo_text.contains("feat (reapplied)"),
             "without --reapply-cherry-picks the cherry-picked commit \
              must be absent from the todo:\n{todo_text}"
+        );
+    }
+
+    #[test]
+    fn rebase_carries_the_stack_note_onto_the_rewritten_commit() {
+        // The reason a user attaches with `mergify stack note` lives
+        // on the commit SHA, and `stack push` rebases before it reads
+        // it back. Without the notes-rewrite config the note stays on
+        // the pre-rebase SHA and the revision history records a blank
+        // `Reason` — this is that regression.
+        let dir = init_repo();
+        let p = dir.path();
+
+        run(p, &["checkout", "-q", "-b", "feature"]);
+        std::fs::write(p.join("feat.txt"), "feature\n").unwrap();
+        run(p, &["add", "feat.txt"]);
+        run(p, &["commit", "-q", "-m", "feat"]);
+        let notes_ref = format!("--ref={STACK_NOTES_REF}");
+        run(p, &["notes", &notes_ref, "add", "-m", "why: review fix"]);
+        let before = capture(p, &["rev-parse", "HEAD"]);
+
+        // Move the trunk so the rebase has to rewrite `feat`.
+        run(p, &["checkout", "-q", "main"]);
+        std::fs::write(p.join("trunk.txt"), "trunk\n").unwrap();
+        run(p, &["add", "trunk.txt"]);
+        run(p, &["commit", "-q", "-m", "trunk moves"]);
+        run(p, &["checkout", "-q", "feature"]);
+
+        spawn_rebase_captured(p, "main", Some("true"), false).unwrap();
+
+        let after = capture(p, &["rev-parse", "HEAD"]);
+        assert_ne!(after, before, "the rebase must have rewritten the commit");
+        assert_eq!(
+            capture(p, &["notes", &notes_ref, "show", &after]),
+            "why: review fix"
+        );
+        // Copied, not moved: the pre-rebase SHA keeps its note, which
+        // is what `load_or_seed` reads back off the old PR head.
+        assert_eq!(
+            capture(p, &["notes", &notes_ref, "show", &before]),
+            "why: review fix"
         );
     }
 

--- a/skills/mergify-stack/SKILL.md
+++ b/skills/mergify-stack/SKILL.md
@@ -20,18 +20,19 @@ A branch is a stack. Keep stacks short and focused:
 
 - **Push**: Use `mergify stack push` (never `git push`)
 - **Fixes**: Use `git commit --amend` (never create new commits to fix issues)
-- **Amend notes**: When amending a commit that already has a PR (i.e. has been pushed), attach a `mergify stack note` BEFORE `mergify stack push` to record *why* the commit was amended. The note appears in the PR's "Revision history" comment and JSON marker, so reviewers can see the reason without diffing.
-- **Mid-stack fixes**: Stash any local changes first (`git stash -u`), then use `mergify stack edit <SHA-or-Change-Id-prefix>` to pause the rebase at the target commit. Amend it with `git commit --amend`, then `git rebase --continue`, then `mergify stack push`, then `git stash pop`. Non-interactive — never use `git rebase -i` for this. (Calling `mergify stack edit` with no argument falls back to a fully interactive `git rebase -i` and will hang in agent contexts — always pass a commit prefix.)
+- **Amend notes**: When amending a commit that already has a PR (i.e. has been pushed), attach a `mergify stack note` BEFORE `mergify stack push` to record *why* the commit was amended. The note appears in the PR's "Revision history" comment and JSON marker, so reviewers can see the reason without diffing. It rides along with the commit through amends and rebases, so attaching it once is enough. See [Amend Notes](#amend-notes).
+- **Target by Change-Id, not SHA**: Address a commit by its `Change-Id` trailer — that is what maps a commit to its PR, and it survives every rebase, while SHAs change on every rebasing push. Both forms are accepted, and the difference when a SHA has gone stale matters: `stack edit` (like `drop`/`squash`/`fixup`/`move`/`reword`/`reorder`) matches the prefix against the commits *in the stack*, so a stale SHA fails loudly with `no commit found matching SHA prefix`; `mergify stack note` resolves any git revision without checking stack membership, so a stale SHA silently attaches the note to a commit no push will ever read.
+- **Mid-stack fixes**: Stash any local changes first (`git stash -u`), then use `mergify stack edit <Change-Id>` to pause the rebase at the target commit. `stack edit` pauses *on* the commit with a clean tree and git tells you to amend — that is correct: `git commit --amend --no-edit`, then `git rebase --continue`, then `mergify stack push`, then `git stash pop`. `--no-edit` keeps the message verbatim, so the existing `Change-Id` trailer (which maps the commit to its PR) is retained — the `commit-msg` hook only *inserts* a `Change-Id` when one is missing, so it won't rewrite yours. Amend ONLY at this edit pause — a rebase *conflict* pause is the opposite trap (see [Conflict Resolution](#conflict-resolution)). Non-interactive — never use `git rebase -i` for this. (Calling `mergify stack edit` with no argument falls back to a fully interactive `git rebase -i` and will hang in agent contexts — always pass a `Change-Id`.)
 - **Reordering**: Stash any local changes first (`git stash -u`), then use `mergify stack reorder` (list all commits in desired order) or `mergify stack move` (move a single commit) instead of manual `git rebase -i` — non-interactive and avoids `GIT_SEQUENCE_EDITOR` quoting issues
 - **Fixup**: Stash any local changes first (`git stash -u`), then use `mergify stack fixup <SHA>...` to fold a commit into its parent (drops the listed commit's message). Non-interactive — never use `git rebase -i` for this.
 - **Squash**: Stash any local changes first (`git stash -u`), then use `mergify stack squash SRC... into TARGET [-m "msg"]` to combine multiple commits into one, with an optional custom message. Non-interactive — never use `git rebase -i` for this.
 - **Reword**: Stash any local changes first (`git stash -u`), then use `mergify stack reword <SHA> -m "new message"` to change a commit's message in place. Non-interactive when `-m` is given — never use `git rebase -i` for this.
 - **Drop**: Stash any local changes first (`git stash -u`), then use `mergify stack drop <SHA>...` to remove commits from the stack. Non-interactive — never use `git rebase -i` for this.
 - **Commit titles**: Follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `docs:`)
-- **PR title & body**: `mergify stack` copies the commit message title to the PR title and the commit message body to the PR body — so write commit messages as if they were PR descriptions. **Everything that should appear in the PR (ticket references, context, test plans) MUST go in the commit message.**
+- **PR title & body**: `mergify stack` copies the commit message title to the PR title and the commit message body to the PR body — so write commit messages as if they were PR descriptions. **Everything that should appear in the PR (ticket references, context, test plans) MUST go in the commit message.** Unless `mergify-cli.stack-keep-pr-title-body` is set, every push re-syncs each PR's title and body from its commit message; and because a reword or amend at the *bottom* of a stack rebases everything above it, that push re-syncs *every* PR's body, not only the one you changed. This is why hand-edits via `gh pr edit --body` never stick (see the lifecycle rule below) — put the content in the commit message instead. If you truly must hand-edit a body, do it last, after the final push.
 - **Ticket references**: Include ticket/issue references (e.g., `MRGFY-1234`, `Fixes #123`) in the commit message body, not added separately to the PR.
 - **PR lifecycle is fully managed by `mergify stack`**: NEVER edit PR titles, bodies, or labels with `gh pr edit` or the GitHub MCP — they will be overwritten on the next push. NEVER close or merge PRs manually — `mergify stack` handles the entire PR lifecycle (creation, updates, and cleanup).
-- **Draft PRs**: NEVER mark a PR as ready-for-review — all PRs stay as drafts. The user will manually move them out of draft after reviewing.
+- **Draft PRs**: NEVER mark a PR as ready-for-review — all PRs stay as drafts; the user moves them out of draft after reviewing. Be aware this has a CI consequence: a stacked **draft** PR may get **no CI at all** (some CI setups gate their pipeline's entry job on the PR being non-draft), so the upper PRs can show a wall of `skipping` — that is "never ran", not "green". CI only starts once the PR is readied, which is the user's call — so don't read a skipped draft as passing. See [Reading CI status](#reading-ci-status).
 - **Each commit must pass CI independently**: Every commit in a stack becomes its own PR. Each PR runs CI separately, so every commit must be self-contained — it must compile, pass linters, and pass tests on its own without depending on later commits in the stack. When formatting or linting fixes are needed, they must be included in the commit that introduced the issue, not deferred to a later commit.
 
 ## Common Mistakes
@@ -46,18 +47,19 @@ A branch is a stack. Keep stacks short and focused:
 | `git rebase -i` to fixup a commit | `mergify stack fixup <SHA>` | Non-interactive — works inside LLM/agent sessions; no editor spawned |
 | `git rebase -i` to squash commits | `mergify stack squash A B into X [-m "..."]` | Non-interactive — works inside LLM/agent sessions; no editor spawned |
 | `git rebase -i` to change a commit message | `mergify stack reword <SHA> -m "..."` | Non-interactive — works inside LLM/agent sessions; no editor spawned |
-| `git rebase -i` to amend a mid-stack commit | `mergify stack edit <SHA-or-Change-Id-prefix>` then `git commit --amend` then `git rebase --continue` | Non-interactive — pauses the rebase at the target commit without spawning an editor |
+| `git rebase -i` to amend a mid-stack commit | `mergify stack edit <Change-Id>` then `git commit --amend --no-edit` then `git rebase --continue` | Non-interactive — pauses the rebase at the target commit; `--no-edit` keeps the message (and its `Change-Id`) verbatim without spawning an editor |
 | `git rebase -i` to drop a commit | `mergify stack drop <SHA>...` | Non-interactive — works inside LLM/agent sessions; no editor spawned |
 | `GIT_SEQUENCE_EDITOR='sed -i ...' git rebase -i` (any variant) | One of `mergify stack {edit,fixup,squash,reorder,move}` | Hand-rolled sequence-editor scripts are brittle; there is already a non-interactive command for every common rewrite |
 | Deferring lint fixes to a later commit | Include the fix in the commit that caused it | Each commit runs CI independently; later commits won't save earlier ones |
 | Rebase/reorder/checkout/sync with dirty worktree | `git stash -u` first, then `git stash pop` after | Uncommitted changes are lost or cause conflicts during these operations |
 | Amending a pushed commit with no explanation | `mergify stack note -m "why"` before `mergify stack push` | The reason is recorded in the PR's Revision history table and JSON marker, so reviewers don't need to diff to understand the change |
+| `git commit --amend` at a rebase *conflict* pause | `git add <files> && git rebase --continue` | The conflicting pick hasn't produced a commit yet; amending rewrites the last-applied commit and re-maps your work to the wrong PR's `Change-Id` |
 
 ## Commands
 
 ```bash
 mergify stack new NAME       # Create a new stack/branch for new work
-mergify stack push           # Push and create/update PRs
+mergify stack push           # Push and create/update PRs (rebases onto latest trunk first, unless PRs are approved)
 mergify stack checkout NAME  # Checkout an existing stack from GitHub (e.g. someone else's)
 mergify stack sync           # Fetch trunk, remove merged commits, rebase
 mergify stack list           # Show commit <-> PR mapping for current stack
@@ -107,11 +109,18 @@ mergify stack note -m "address review: rename foo() to bar()"
 mergify stack push
 
 # Or for a mid-stack commit (after the rebase that amended it):
-mergify stack note <SHA-or-Change-Id-prefix> -m "fix lint reported in CI"
+mergify stack note <Change-Id> -m "fix lint reported in CI"
 mergify stack push
 ```
 
-A note is per-commit, not per-revision. Each amend (or other history rewrite) creates a new commit SHA, so you must run `mergify stack note` again for the new SHA — the previous note stays attached to the old SHA and won't carry over. Use `--append` only when the current target commit already has a note and you want to add another reason; use `--remove` to clear it. Notes on commits that haven't changed since the last push are preserved but won't add a new revision row.
+A note is per-commit, not per-revision. It is stored against the commit SHA, but git carries it onto the rewritten commit through an amend or a rebase (`mergify stack setup` configures `notes.rewriteRef` for this), so the reason you attach survives the rebase `stack push` does and lands in the revision history. Use `--append` only when the current target commit already has a note and you want to add another reason; use `--remove` to clear it. Notes on commits that haven't changed since the last push are preserved but won't add a new revision row.
+
+## Reading CI status
+
+- Read a PR's status with **`gh pr checks <pr>`** and trust its exit code: `0` = all checks passed, `8` = a check is still pending. Any other non-zero code means "not green" but not necessarily a CI failure: `1` usually means a check failed, yet it is also `gh`'s generic error code (unknown PR, network error), and auth failures exit `4` — so read the output before calling any of them a failure. (`gh pr checks` considers *all* checks by default; add `--required` to consider only required ones.)
+- The `mergify stack list` CI column can go **stale** right after a rapid re-push — give CI a moment to register the new head, or confirm with `gh pr checks`.
+- `statusCheckRollup` (in `gh pr view --json` / the GitHub API) keeps `CANCELLED` entries from superseded runs: each re-push cancels the previous commit's in-flight CI, so those cancellations are **history, not failures**.
+- A stacked **draft** PR may show no checks at all — see the [Draft PRs](#core-conventions) convention for why a wall of `skipping` is "never ran", not "green".
 
 ## CRITICAL: Check Branch Before ANY Commit
 
@@ -184,3 +193,5 @@ When a rebase causes conflicts (during `git rebase -i` or `mergify stack push`):
 To abort instead: `git rebase --abort`
 
 After resolving, run `mergify stack push` to sync the updated stack.
+
+**NEVER `git commit --amend` at a conflict pause.** At a conflict the pick being replayed has **not** produced a commit yet, and HEAD still points at the last commit git already applied — the trunk tip if the *bottom* commit conflicted, otherwise a previously-replayed commit of your own stack. Either way it is **not** the commit you're resolving, so `git commit --amend` rewrites that already-applied commit — silently stamping your work with its title, author, and `Change-Id` and re-mapping it to the WRONG PR. Resolve a conflict with `git add <files> && git rebase --continue`, nothing more. Amend only ever belongs at a `mergify stack edit` pause (see **Mid-stack fixes**), where the tree is clean and git itself tells you to amend. If you already amended mid-conflict, compare HEAD's message against the commit you *meant* to resolve; if it doesn't match, the commit needs rebuilding from the correct tree. The `commit-msg` hook installed by `mergify stack setup` refuses this amend outright, so an up-to-date checkout stops you before the damage — but `--no-verify` walks straight past it.


### PR DESCRIPTION
Fold the rebase-hazard knowledge that was drafted into a consuming repo's
AGENTS.md into the mergify-stack skill, where it travels with the CLI and
surfaces at the point an agent runs the commands. Woven into the adjacent
conventions rather than bolted on, and generalized (config-dependent behavior
stated conditionally) since the skill is repo-agnostic.

- Amend notes: a note rides along with its commit through amends and rebases,
  so attaching it once is enough.
- Mid-stack fixes / Conflict Resolution: amend only at a `stack edit` pause
  (clean tree, git tells you to), with `git commit --amend --no-edit` so the
  message — and its Change-Id — stays verbatim; the commit-msg hook only inserts
  a Change-Id when one is missing, so it won't rewrite yours. At a rebase
  *conflict* pause the pick hasn't produced a commit yet and HEAD is the
  last-applied commit, so `git commit --amend` re-maps your work to the wrong
  PR's Change-Id — the commit-msg hook refuses it, and the resolve path is
  `git add` + `git rebase --continue`.
- Target notes and `stack edit` by Change-Id, not SHA — it maps a commit to its
  PR and survives every rebase. Both forms are accepted, and they diverge once a
  SHA is stale: `stack edit` matches against the commits in the stack and fails
  loudly, while `stack note` resolves any revision and silently attaches to a
  commit no push will read.
- PR title & body: unless `mergify-cli.stack-keep-pr-title-body` is set, every
  push re-syncs bodies from commit messages, and a reword at the bottom of a
  stack re-syncs every PR above it — so hand-edits don't stick.
- New "Reading CI status" section: `gh pr checks` exit codes (0 pass, 8 pending;
  non-zero is not always a CI failure — 1 is also gh's generic error, 4 is auth),
  the stale `stack list` CI column, and CANCELLED rollup entries being
  superseded-run history, not failures.
- Draft PRs: a stacked draft may get no CI at all, so a wall of `skipping` is
  "never ran", not "green".

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

Depends-On: #1730