### PR TITLE
fix(stack): carry the revision note onto the rewritten commit

### DIFF
--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -1335,6 +1335,9 @@ fn run_stack_setup(force: bool) -> Result<(), mergify_core::CliError> {
     if outcome.notes_display_ref_added {
         println!("Added notes.displayRef = refs/notes/mergify/*");
     }
+    if outcome.notes_rewrite_ref_added {
+        println!("Added notes.rewriteRef = refs/notes/mergify/stack");
+    }
     if any_legacy_needs_force {
         println!("Some hooks are legacy. Run 'mergify stack hooks --setup --force' to migrate.");
     }

--- a/crates/mergify-stack/src/commands/setup.rs
+++ b/crates/mergify-stack/src/commands/setup.rs
@@ -24,6 +24,7 @@ use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use crate::git::run_git_capture;
+use crate::local_commits::STACK_NOTES_REF;
 
 use mergify_core::CliError;
 
@@ -87,14 +88,15 @@ pub struct InstallLog {
     pub actions: Vec<HookAction>,
 }
 
-/// Outcome of an `install` run: the per-hook action log plus
-/// whether the local `notes.displayRef` config was added this run
-/// (so the caller can echo Python's `Added notes.displayRef = …`
-/// confirmation).
+/// Outcome of an `install` run: the per-hook action log plus, for
+/// each of the local `notes.displayRef` and `notes.rewriteRef`
+/// configs, whether it was added this run (so the caller can echo
+/// Python's `Added <key> = …` confirmation only for what changed).
 #[derive(Debug, Clone)]
 pub struct InstallOutcome {
     pub logs: Vec<InstallLog>,
     pub notes_display_ref_added: bool,
+    pub notes_rewrite_ref_added: bool,
 }
 
 pub struct Options<'a> {
@@ -153,9 +155,11 @@ pub fn install(opts: &Options<'_>) -> Result<InstallOutcome, CliError> {
     }
 
     let notes_display_ref_added = ensure_notes_display_ref(opts.repo_dir)?;
+    let notes_rewrite_ref_added = ensure_notes_rewrite_ref(opts.repo_dir)?;
     Ok(InstallOutcome {
         logs,
         notes_display_ref_added,
+        notes_rewrite_ref_added,
     })
 }
 
@@ -220,6 +224,40 @@ fn ensure_notes_display_ref(repo_dir: Option<&Path>) -> Result<bool, CliError> {
     run_git_capture(
         repo_dir,
         &["config", "--local", "--add", "notes.displayRef", desired],
+    )?;
+    Ok(true)
+}
+
+/// Ensure a rewritten commit keeps its stack note by adding the
+/// local `notes.rewriteRef = refs/notes/mergify/stack` config.
+/// Returns `true` when the config was added this run, `false` when
+/// it was already present.
+///
+/// A note is addressed by commit SHA, so an amend or a rebase would
+/// otherwise strand the reason on the pre-rewrite SHA and the push
+/// that follows would record a blank `Reason`. This is the setting
+/// that covers the rewrites git runs on its own — `git commit
+/// --amend`, and the `git rebase --continue` that finishes a
+/// conflicted rebase — which no flag on the CLI's own invocations
+/// can reach.
+fn ensure_notes_rewrite_ref(repo_dir: Option<&Path>) -> Result<bool, CliError> {
+    let current = run_git_capture(
+        repo_dir,
+        &["config", "--local", "--get-all", "notes.rewriteRef"],
+    )
+    .unwrap_or_default();
+    if current.lines().any(|l| l == STACK_NOTES_REF) {
+        return Ok(false);
+    }
+    run_git_capture(
+        repo_dir,
+        &[
+            "config",
+            "--local",
+            "--add",
+            "notes.rewriteRef",
+            STACK_NOTES_REF,
+        ],
     )?;
     Ok(true)
 }
@@ -474,5 +512,33 @@ mod tests {
             .unwrap();
         let content = String::from_utf8(out.stdout).unwrap();
         assert!(content.lines().any(|l| l == "refs/notes/mergify/*"));
+    }
+
+    #[test]
+    fn install_adds_notes_rewrite_ref_once() {
+        let dir = init_repo();
+        let opts = Options {
+            repo_dir: Some(dir.path()),
+            force: false,
+        };
+        assert!(install(&opts).unwrap().notes_rewrite_ref_added);
+        // Second run finds it already there: no duplicate value, and
+        // the outcome reports nothing added so the CLI stays quiet.
+        assert!(!install(&opts).unwrap().notes_rewrite_ref_added);
+
+        let out = StdCommand::new("git")
+            .arg("-C")
+            .arg(dir.path())
+            .args(["config", "--local", "--get-all", "notes.rewriteRef"])
+            .output()
+            .unwrap();
+        let content = String::from_utf8(out.stdout).unwrap();
+        assert_eq!(
+            content
+                .lines()
+                .filter(|l| *l == "refs/notes/mergify/stack")
+                .count(),
+            1
+        );
     }
 }

--- a/crates/mergify-stack/src/commands/sync.rs
+++ b/crates/mergify-stack/src/commands/sync.rs
@@ -25,8 +25,8 @@ use mergify_core::CliError;
 use mergify_core::HttpClient;
 
 use crate::git::{
-    compute_base_commit_sha, resolve_repo_toplevel, run_git_silent, shell_quote, spawn_rebase,
-    spawn_rebase_captured,
+    compute_base_commit_sha, notes_rewrite_config, resolve_repo_toplevel, run_git_silent,
+    shell_quote, spawn_rebase, spawn_rebase_captured,
 };
 use crate::local_commits;
 use crate::remote_changes;
@@ -130,7 +130,10 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
     if status.up_to_date() || status.all_merged() {
         // Either nothing to drop, or every commit got merged.
         // Both cases collapse to a plain pull --rebase.
-        run_git_silent(Some(&repo_dir), &["pull", "--rebase", remote, base_branch]).map_err(
+        let notes_config = notes_rewrite_config();
+        let mut args: Vec<&str> = notes_config.iter().map(String::as_str).collect();
+        args.extend(["pull", "--rebase", remote, base_branch]);
+        run_git_silent(Some(&repo_dir), &args).map_err(
             // A failed `pull --rebase` is almost always a conflict;
             // give the same recovery guidance and Conflict exit code as
             // `spawn_rebase` rather than a bare stderr. (`run_git_silent`

--- a/crates/mergify-stack/src/git.rs
+++ b/crates/mergify-stack/src/git.rs
@@ -14,6 +14,34 @@ use std::process::Command;
 
 use mergify_core::CliError;
 
+use crate::local_commits::STACK_NOTES_REF;
+
+/// `-c` overrides that make git carry the stack's notes from every
+/// rewritten commit onto its replacement.
+///
+/// A note is addressed by commit SHA, so without this a rebase
+/// strands the amend reason on the pre-rebase SHA and the push that
+/// follows records a blank `Reason` in the revision history.
+/// `mergify stack setup` persists only `notes.rewriteRef` into the
+/// repo config — the mode and the rebase toggle are git's defaults
+/// there. That config is what covers the rewrites git runs outside
+/// this process (`git commit --amend`, and the `git rebase
+/// --continue` that finishes a conflicted rebase); passing all three
+/// per-invocation keeps the CLI's own rebases correct in repos whose
+/// config predates that, and pins the defaults against a global
+/// `notes.rewriteMode=ignore` or `notes.rewrite.rebase=false`.
+#[must_use]
+pub(crate) fn notes_rewrite_config() -> Vec<String> {
+    vec![
+        "-c".to_string(),
+        format!("notes.rewriteRef={STACK_NOTES_REF}"),
+        "-c".to_string(),
+        "notes.rewriteMode=concatenate".to_string(),
+        "-c".to_string(),
+        "notes.rewrite.rebase=true".to_string(),
+    ]
+}
+
 /// Base `git` `Command` with `-C <repo_dir>` (when supplied) and a
 /// forced C locale. Use for any git invocation whose stderr or
 /// stdout the caller might parse — translated locales would
@@ -129,6 +157,7 @@ fn spawn_rebase_inner(
     capture: bool,
 ) -> Result<(), CliError> {
     let mut cmd = git_cmd(Some(repo_dir));
+    cmd.args(notes_rewrite_config());
     cmd.arg("rebase").arg("-i");
     if reapply_cherry_picks {
         // Keep commits whose patch-id already matches the base in
@@ -389,6 +418,47 @@ mod tests {
             !todo_text.contains("feat (reapplied)"),
             "without --reapply-cherry-picks the cherry-picked commit \
              must be absent from the todo:\n{todo_text}"
+        );
+    }
+
+    #[test]
+    fn rebase_carries_the_stack_note_onto_the_rewritten_commit() {
+        // The reason a user attaches with `mergify stack note` lives
+        // on the commit SHA, and `stack push` rebases before it reads
+        // it back. Without the notes-rewrite config the note stays on
+        // the pre-rebase SHA and the revision history records a blank
+        // `Reason` — this is that regression.
+        let dir = init_repo();
+        let p = dir.path();
+
+        run(p, &["checkout", "-q", "-b", "feature"]);
+        std::fs::write(p.join("feat.txt"), "feature\n").unwrap();
+        run(p, &["add", "feat.txt"]);
+        run(p, &["commit", "-q", "-m", "feat"]);
+        let notes_ref = format!("--ref={STACK_NOTES_REF}");
+        run(p, &["notes", &notes_ref, "add", "-m", "why: review fix"]);
+        let before = capture(p, &["rev-parse", "HEAD"]);
+
+        // Move the trunk so the rebase has to rewrite `feat`.
+        run(p, &["checkout", "-q", "main"]);
+        std::fs::write(p.join("trunk.txt"), "trunk\n").unwrap();
+        run(p, &["add", "trunk.txt"]);
+        run(p, &["commit", "-q", "-m", "trunk moves"]);
+        run(p, &["checkout", "-q", "feature"]);
+
+        spawn_rebase_captured(p, "main", Some("true"), false).unwrap();
+
+        let after = capture(p, &["rev-parse", "HEAD"]);
+        assert_ne!(after, before, "the rebase must have rewritten the commit");
+        assert_eq!(
+            capture(p, &["notes", &notes_ref, "show", &after]),
+            "why: review fix"
+        );
+        // Copied, not moved: the pre-rebase SHA keeps its note, which
+        // is what `load_or_seed` reads back off the old PR head.
+        assert_eq!(
+            capture(p, &["notes", &notes_ref, "show", &before]),
+            "why: review fix"
         );
     }
 


### PR DESCRIPTION
A note is addressed by commit SHA, so every rewrite stranded it. The
rebase `stack push` runs before it reads notes back left the reason on
the pre-rebase SHA, and the revision history recorded a blank `Reason`;
a plain `git commit --amend` lost it the same way.

`stack setup` now adds a local `notes.rewriteRef`, which is what covers
the rewrites git runs on its own — `git commit --amend`, and the
`git rebase --continue` that finishes a conflicted rebase. The CLI's own
rebases pass the same settings with `-c` so they stay correct in
checkouts whose config predates this, and so a global
`notes.rewriteMode=ignore` cannot disable the copy. Existing checkouts
pick the config up on their next `mergify stack setup`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>