### PR TITLE
feat(ci): raise junit upload soft cap to 20 MiB

### DIFF
--- a/crates/mergify-ci/src/junit_process/upload.rs
+++ b/crates/mergify-ci/src/junit_process/upload.rs
@@ -61,13 +61,25 @@ impl std::error::Error for UploadError {}
 const ENDPOINT_PATH: &str = "/v1/repos/";
 const ENDPOINT_SUFFIX: &str = "/ci/traces";
 
-/// Hard cap on the size of a single gzipped OTLP upload, in bytes
-/// (10 MiB). The ingest endpoint refuses payloads larger than this,
-/// so [`crate::junit_process::split`] partitions an oversized trace
-/// into several uploads that each gzip under the cap. The cap is on
-/// the *compressed* body — the exact bytes we put on the wire — not
-/// the raw XML or the uncompressed protobuf.
-pub const MAX_GZIPPED_UPLOAD_BYTES: usize = 10 * 1024 * 1024;
+/// Soft cap on the size of a single gzipped OTLP upload, in bytes
+/// (20 MiB). This is the client-side split *target*, not the server's
+/// limit: the ingest endpoint hard-caps payloads at 25 MiB
+/// (MRGFY-8124), so sizing each chunk under 20 MiB leaves 5 MiB of
+/// headroom below the rejection threshold. [`crate::junit_process::split`]
+/// partitions an oversized trace into several uploads that each gzip
+/// under this cap. The cap is on the *compressed* body — the exact
+/// bytes we put on the wire — not the raw XML or the uncompressed
+/// protobuf.
+pub const MAX_GZIPPED_UPLOAD_BYTES: usize = 20 * 1024 * 1024;
+
+// The soft cap is only safe if it stays under the ingest server's hard
+// cap on the *gzipped* body (MRGFY-8124: 25 MiB, enforced by the
+// content-length middleware — the same compressed bytes `split_request`
+// sizes chunks against). That limit lives in another service, so mirror
+// it here and enforce the documented 5 MiB headroom at compile time: a
+// future bump that crossed the hard cap breaks the build instead of
+// silently 413-dropping every over-cap chunk in production.
+const _: () = assert!(MAX_GZIPPED_UPLOAD_BYTES + 5 * 1024 * 1024 <= 25 * 1024 * 1024);
 
 fn endpoint_url(api_url: &str, repository: &str) -> String {
     // The shape `<api_url>/v1/repos/<owner>/<repo>/ci/traces`


### PR DESCRIPTION
Raise the client-side gzipped upload soft cap (the per-chunk split
target in junit_process::split) from 10 MiB to 20 MiB.

This cap is a client-side split target, not the server's limit: the
ingest endpoint hard-caps gzipped payloads at 25 MiB (MRGFY-8124), so
sizing each chunk under 20 MiB leaves 5 MiB of headroom below the 413
rejection threshold. Larger chunks mean fewer, larger uploads for big
reports (WiseTech Global case): a 20 MiB gzipped chunk holds roughly
120 MiB of raw JUnit XML worst-case (stacktrace-heavy), up to ~190 MiB
for passing-heavy reports.

The doc comment is rewritten to describe the soft/hard split, dropping
the old wording that implied the CLI cap was itself the endpoint's
refusal threshold.

A compile-time assertion mirrors the backend's 25 MiB hard cap and
enforces the 5 MiB headroom: since the two limits live in separate
services linked only by prose, a future bump that crossed the hard cap
would otherwise ship silently and 413-drop every over-cap chunk. Now
it breaks the build instead. Existing split tests inject their own
small cap, so they are unaffected by the constant's value.

Blocked by MRGFY-8124: must not deploy before the backend 25 MiB hard
cap is live. With the server still at 10 MiB, chunks in the 10-20 MiB
range would 413 and their data would be dropped. Ships as a draft
until the backend is deployed.

Fixes MRGFY-8125