### PR TITLE
chore(release): exclude renovate[bot] from generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,3 +3,4 @@ changelog:
     authors:
       - dependabot[bot]
       - mergify[bot]
+      - renovate[bot]


### PR DESCRIPTION
The "Generate release notes" button was listing every dependency bump,
because `.github/release.yml` only excluded dependabot[bot] and
mergify[bot] — while Renovate is the bot that actually opens most dep
PRs here (185 of the last 1000 PRs, 17 of the last 100 merged, vs 47
lifetime for dependabot).

`renovate[bot]` is the exact author login the GitHub API reports for the
Renovate App (`gh` renders it as `app/renovate`, but `release.yml`
matches on the API login). It is the only Renovate-flavoured account in
this repo history, and no human login can collide with it since `[` is
not a legal GitHub username character — so no human-authored PR is swept
up by this.