### PR TITLE
feat(queue): tell a dequeued PR apart from a never-queued one in `queue show`

### DIFF
--- a/crates/mergify-queue/src/last_leave.rs
+++ b/crates/mergify-queue/src/last_leave.rs
@@ -1,0 +1,744 @@
+//! Diagnosis fallback for a pull request that is **not** currently in
+//! the merge queue.
+//!
+//! `GET /v1/repos/<repo>/merge-queue/pull/<n>` answers only for a PR
+//! that is queued *right now*; it 404s for everything else. That 404
+//! is overloaded — it covers "dequeued ten minutes ago on failing
+//! CI", "nobody ever queued it", and "that PR number doesn't exist" —
+//! so `queue show` falls back to the activity log to tell them apart:
+//!
+//! ```text
+//! GET /v1/repos/<repo>/logs
+//!     ?pull_request=<n>
+//!     &event_type=action.queue.leave
+//!     &received_from=<now - 90d>
+//!     &per_page=1
+//! ```
+//!
+//! Four things about that request are load-bearing:
+//!
+//! - **The window.** `/logs` defaults `received_from` to
+//!   `received_to - 1 day`. Without an explicit range a PR dequeued
+//!   last week comes back as `size: 0`, which reads exactly like
+//!   never-queued — the failure mode this module exists to remove. The
+//!   API rejects a span over 93 days (422), and event retention is 90,
+//!   so [`LOOKBACK_DAYS`] asks for the whole retained history and no
+//!   more.
+//! - **The ordering.** Events come back newest-first, so `events[0]`
+//!   with `per_page=1` is the PR's *last* transition out of the queue.
+//!   A PR that conflicted, was requeued and then merged reports the
+//!   merge, not the conflict.
+//! - **The event type.** `action.queue.leave` is emitted only when the
+//!   PR actually leaves. The sibling `abort_code` values that ride on
+//!   `action.queue.checks_end` (`PR_AHEAD_DEQUEUED`,
+//!   `MERGE_QUEUE_RESET`, `CHECKS_RETRIED`, …) interrupt the *checks*
+//!   while the PR stays queued; filtering on the event type is what
+//!   keeps them out of this diagnosis. Reporting one as a dequeue
+//!   would tell an agent to requeue a PR that never left.
+//! - **`metadata.merged`.** A merge is also an `action.queue.leave`.
+//!   It is the boolean, not the `dequeue_code`, that separates "left
+//!   by merging" from "was dequeued".
+//!
+//! Everything user-facing (the sentence, its per-reason hint, the
+//! failing check names and URLs) is rendered from what the API
+//! returns. The CLI keeps no local copy of the ~32 `dequeue_code`
+//! strings: a stale copy would drift, and an unknown code must render
+//! rather than crash.
+
+use std::io::Write;
+
+use chrono::DateTime;
+use chrono::TimeDelta;
+use chrono::Utc;
+use mergify_core::CliError;
+use mergify_core::http::Client;
+use mergify_tui::Theme;
+use mergify_tui::relative_time;
+use serde::Deserialize;
+
+/// How far back to look for the pull request's last queue exit.
+/// Bounded by the API on both sides: `/logs` retains 90 days of
+/// events and rejects a `received_from`/`received_to` span over 93
+/// days with a 422.
+const LOOKBACK_DAYS: i64 = 90;
+
+const LEAVE_EVENT_TYPE: &str = "action.queue.leave";
+
+/// How many lines of the API's `reason` prose to print without
+/// `--verbose`. A `PR_DEQUEUED` reason embeds the full unmet
+/// condition tree and runs to 60+ lines on a real repository, which
+/// buries the headline and the failing checks under it. The first
+/// lines carry the sentence and its hint; the tree that follows is
+/// what `-v` is for — the same compact/verbose split the in-queue
+/// conditions section already uses.
+const REASON_COMPACT_LINES: usize = 12;
+
+/// The pull request's last `action.queue.leave`, both as the raw API
+/// event (what `--json` republishes, so unknown fields survive) and
+/// as the decoded view the human renderer reads.
+pub struct LastLeave {
+    pub raw: serde_json::Value,
+    pub event: LeaveEvent,
+}
+
+impl LastLeave {
+    /// Whether the PR *left the queue without merging* — the answer
+    /// `queued: false` alone could never give.
+    #[must_use]
+    pub const fn dequeued(&self) -> bool {
+        !self.event.metadata.merged
+    }
+
+    /// The PR head this diagnosis describes, for a caller that needs
+    /// to check it still is the PR's head — see
+    /// [`LeaveMetadata::pull_request_head_sha`].
+    #[must_use]
+    pub fn head_sha(&self) -> Option<&str> {
+        non_empty(self.event.metadata.pull_request_head_sha.as_deref())
+    }
+}
+
+/// Decoded `action.queue.leave` event. Every field is optional: a
+/// diagnosis rendered from a payload missing one field is worth more
+/// than a hard error, and new API fields must never break the
+/// fallback.
+#[derive(Deserialize, Default)]
+pub struct LeaveEvent {
+    #[serde(default)]
+    pub received_at: Option<String>,
+    #[serde(default)]
+    pub trigger: Option<String>,
+    #[serde(default)]
+    pub metadata: LeaveMetadata,
+}
+
+#[derive(Deserialize, Default)]
+pub struct LeaveMetadata {
+    #[serde(default)]
+    pub merged: bool,
+    #[serde(default)]
+    pub dequeue_code: Option<String>,
+    #[serde(default)]
+    pub reason: Option<String>,
+    #[serde(default)]
+    pub queue_name: Option<String>,
+    #[serde(default)]
+    pub queued_at: Option<String>,
+    /// The PR head the queue was testing when it left. Load-bearing
+    /// for anyone acting on this diagnosis: the `unsuccessful_checks`
+    /// below belong to *this* commit, and a push since then (the very
+    /// thing `PULL_REQUEST_UPDATED` and `DRAFT_PULL_REQUEST_CHANGED`
+    /// report) leaves them describing a commit the PR no longer has.
+    /// Comparing it against the current head is what tells a live
+    /// failure apart from one already superseded.
+    #[serde(default)]
+    pub pull_request_head_sha: Option<String>,
+    #[serde(default)]
+    pub unsuccessful_checks: Vec<LeaveCheck>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct LeaveCheck {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub state: Option<String>,
+    /// The check's own page (a workflow-job URL for GitHub Actions).
+    /// `queue show`'s in-queue checks section has never carried a URL,
+    /// which is why "where is the failure?" needed a second tool.
+    #[serde(default)]
+    pub details_url: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+}
+
+impl LeaveCheck {
+    /// The best link to the check. `details_url` is the check run's
+    /// own page; `url` is the fallback the API sends when the
+    /// integration provides no details link.
+    fn link(&self) -> Option<&str> {
+        self.details_url
+            .as_deref()
+            .or(self.url.as_deref())
+            .filter(|s| !s.is_empty())
+    }
+}
+
+#[derive(Deserialize)]
+struct EventsResponse {
+    #[serde(default)]
+    events: Vec<serde_json::Value>,
+}
+
+/// Fetch the pull request's last exit from the merge queue, or `None`
+/// when the activity log holds no `action.queue.leave` for it in the
+/// retained window (the genuine never-queued case, and the case of a
+/// PR number that never existed).
+///
+/// # Errors
+///
+/// Propagates the API failure. Callers treat that as "could not
+/// determine", not as a command failure: `queue show` must keep
+/// answering (and exiting 0) for a token that cannot read the
+/// repository's activity log.
+pub async fn fetch(
+    client: &Client,
+    repository: &str,
+    pr_number: u64,
+    now: DateTime<Utc>,
+) -> Result<Option<LastLeave>, CliError> {
+    let path = format!("/v1/repos/{repository}/logs");
+    let received_from = (now - TimeDelta::days(LOOKBACK_DAYS)).to_rfc3339();
+    let pr = pr_number.to_string();
+
+    let response: EventsResponse = client
+        .get_with_query(
+            &path,
+            &[
+                ("pull_request", pr.as_str()),
+                ("event_type", LEAVE_EVENT_TYPE),
+                ("received_from", received_from.as_str()),
+                // Newest-first ordering makes the single returned
+                // event the PR's latest exit.
+                ("per_page", "1"),
+            ],
+        )
+        .await?;
+
+    let Some(raw) = response.events.into_iter().next() else {
+        return Ok(None);
+    };
+    let event: LeaveEvent = serde_json::from_value(raw.clone())
+        .map_err(|e| CliError::wrap("decode queue leave event", e))?;
+    Ok(Some(LastLeave { raw, event }))
+}
+
+/// Render the diagnosis for a PR that left the merge queue: a
+/// headline naming *what* happened and when, an aligned facts block,
+/// the API's own reason prose, the failing checks with their URLs,
+/// and the next step.
+pub fn render(
+    w: &mut dyn Write,
+    theme: &Theme,
+    leave: &LastLeave,
+    pr_number: u64,
+    now: DateTime<Utc>,
+    verbose: bool,
+) -> std::io::Result<()> {
+    let meta = &leave.event.metadata;
+    let when = leave
+        .event
+        .received_at
+        .as_deref()
+        .map(|ts| relative_time(ts, now, false))
+        .filter(|rel| !rel.is_empty());
+
+    let headline = if meta.merged {
+        "was merged by the merge queue"
+    } else {
+        "was dequeued"
+    };
+    let style = if meta.merged { theme.green } else { theme.red };
+    write!(
+        w,
+        "{S}PR #{pr_number} {headline}{R}",
+        S = style,
+        R = theme.reset,
+    )?;
+    match &when {
+        Some(rel) => writeln!(w, " {D}{rel}{R}", D = theme.dim, R = theme.reset)?,
+        None => writeln!(w)?,
+    }
+    writeln!(w)?;
+
+    // Only a dequeue carries a meaningful code — a merge's code is
+    // always the tautological PR_MERGED.
+    if !meta.merged
+        && let Some(code) = non_empty(meta.dequeue_code.as_deref())
+    {
+        writeln!(
+            w,
+            "  Dequeue code:  {B}{code}{R}",
+            B = theme.bold,
+            R = theme.reset
+        )?;
+    }
+    if let Some(queue) = non_empty(meta.queue_name.as_deref()) {
+        writeln!(w, "  Queue:         {queue}")?;
+    }
+    if let Some(rel) = meta
+        .queued_at
+        .as_deref()
+        .map(|ts| relative_time(ts, now, false))
+        .filter(|rel| !rel.is_empty())
+    {
+        writeln!(w, "  Queued at:     {rel}")?;
+    }
+    if let Some(trigger) = non_empty(leave.event.trigger.as_deref()) {
+        writeln!(w, "  Trigger:       {trigger}")?;
+    }
+    // Printed for a merge too: it names the commit that landed. On a
+    // dequeue it is the caveat on everything below — the reason and
+    // the check URLs describe this commit, not necessarily the one the
+    // PR carries now.
+    if let Some(sha) = leave.head_sha() {
+        writeln!(w, "  Head SHA:      {sha}", sha = short_sha(sha))?;
+    }
+
+    if let Some(reason) = non_empty(meta.reason.as_deref()) {
+        writeln!(w)?;
+        print_reason(w, theme, reason, verbose)?;
+    }
+
+    if !meta.unsuccessful_checks.is_empty() {
+        writeln!(w)?;
+        print_failing_checks(w, theme, &meta.unsuccessful_checks)?;
+    }
+
+    if !meta.merged {
+        writeln!(w)?;
+        writeln!(
+            w,
+            "  {D}Fix the cause above, then comment `@mergifyio queue` on the pull request.{R}",
+            D = theme.dim,
+            R = theme.reset,
+        )?;
+    }
+    Ok(())
+}
+
+/// Print the API's own explanation. The engine owns this prose and
+/// the per-reason hint embedded in it; it arrives as multi-line
+/// markdown, so indent every line rather than squeezing it into the
+/// aligned facts block, and cap it at [`REASON_COMPACT_LINES`] unless
+/// `verbose`.
+fn print_reason(
+    w: &mut dyn Write,
+    theme: &Theme,
+    reason: &str,
+    verbose: bool,
+) -> std::io::Result<()> {
+    let lines: Vec<&str> = reason.lines().collect();
+    let shown = if verbose {
+        lines.len()
+    } else {
+        lines.len().min(REASON_COMPACT_LINES)
+    };
+    for line in &lines[..shown] {
+        if line.is_empty() {
+            writeln!(w)?;
+        } else {
+            writeln!(w, "  {line}")?;
+        }
+    }
+    let hidden = lines.len() - shown;
+    if hidden > 0 {
+        writeln!(
+            w,
+            "  {D}… {hidden} more lines (-v for the full reason){R}",
+            D = theme.dim,
+            R = theme.reset,
+        )?;
+    }
+    Ok(())
+}
+
+/// Print the checks that were not green when the PR left, each with
+/// its URL. `queue show`'s in-queue checks section renders names and
+/// states but no links, which is why "where is the failure?" used to
+/// need a second tool.
+fn print_failing_checks(
+    w: &mut dyn Write,
+    theme: &Theme,
+    checks: &[LeaveCheck],
+) -> std::io::Result<()> {
+    writeln!(w, "  Failing checks:")?;
+    for check in checks {
+        write!(
+            w,
+            "    {S}✗{R} {name}",
+            S = theme.red,
+            R = theme.reset,
+            name = check.name,
+        )?;
+        match non_empty(check.state.as_deref()) {
+            Some(state) => writeln!(w, "  {D}{state}{R}", D = theme.dim, R = theme.reset)?,
+            None => writeln!(w)?,
+        }
+        if let Some(link) = check.link() {
+            writeln!(w, "      {D}{link}{R}", D = theme.dim, R = theme.reset)?;
+        }
+    }
+    Ok(())
+}
+
+/// Render the "we looked and found nothing" case. Distinct from the
+/// bare notice line because "no queue activity in the retained
+/// window" is an answer, whereas silence is not.
+pub fn render_no_activity(w: &mut dyn Write, theme: &Theme) -> std::io::Result<()> {
+    writeln!(
+        w,
+        "  {D}No merge-queue activity in the last {LOOKBACK_DAYS} days.{R}",
+        D = theme.dim,
+        R = theme.reset,
+    )
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.filter(|s| !s.is_empty())
+}
+
+/// Abbreviate a commit SHA for display, the way git and GitHub do.
+/// `--json` keeps the full value — a caller comparing it against the
+/// PR head needs the whole thing.
+fn short_sha(sha: &str) -> &str {
+    sha.char_indices()
+        .nth(7)
+        .map_or(sha, |(byte_index, _)| &sha[..byte_index])
+}
+
+#[cfg(test)]
+mod tests {
+    use mergify_core::http::ApiFlavor;
+    use serde_json::json;
+    use url::Url;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    use super::*;
+
+    fn at(iso: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(iso)
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn client(server: &MockServer) -> Client {
+        Client::new(Url::parse(&server.uri()).unwrap(), "t", ApiFlavor::Mergify).unwrap()
+    }
+
+    /// Shape copied from a real `Mergifyio/mergify-cli` event.
+    fn checks_failed_event() -> serde_json::Value {
+        json!({
+            "id": 77_235_715,
+            "received_at": "2026-07-20T23:25:11.263987Z",
+            "trigger": "merge queue internal",
+            "repository": "owner/repo",
+            "pull_request": 1700,
+            "base_ref": "main",
+            "outcome": "failure",
+            "type": "action.queue.leave",
+            "metadata": {
+                "reason": "The merge conditions cannot be satisfied due to failing checks\n\n- `ci-gate`",
+                "merged": false,
+                "queue_name": "default",
+                "branch": "main",
+                "queued_at": "2026-07-20T23:11:42.944734Z",
+                "pull_request_head_sha": "31b4a485b8ce6f2c1d0e9a7b4c5d6e7f80910111",
+                "dequeue_code": "CHECKS_FAILED",
+                "checks": [],
+                "unsuccessful_checks": [{
+                    "name": "ci-gate",
+                    "description": "",
+                    "url": "https://github.com/owner/repo/actions/runs/1/job/2",
+                    "details_url": "https://github.com/owner/repo/actions/runs/1/job/2",
+                    "state": "failure",
+                    "avatar_url": null,
+                }],
+            },
+        })
+    }
+
+    async fn arrange(server: &MockServer, events: Vec<serde_json::Value>) {
+        let size = events.len();
+        Mock::given(method("GET"))
+            .and(path("/v1/repos/owner/repo/logs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "size": size,
+                "per_page": 1,
+                "events": events,
+            })))
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn fetch_sends_the_queue_leave_query_with_a_90_day_window() {
+        // Every one of these four parameters is a documented trap:
+        // the default 1-day window hides older dequeues, the event
+        // type keeps `checks_end` abort codes (which do NOT dequeue)
+        // out, newest-first + per_page=1 selects the latest exit.
+        let server = MockServer::start().await;
+        arrange(&server, vec![checks_failed_event()]).await;
+
+        let now = at("2026-07-30T00:00:00Z");
+        let got = fetch(&client(&server), "owner/repo", 1700, now)
+            .await
+            .unwrap();
+        assert!(got.is_some());
+
+        let received = server.received_requests().await.unwrap();
+        let query: Vec<(String, String)> = received[0]
+            .url
+            .query_pairs()
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+        assert!(
+            query.contains(&("pull_request".into(), "1700".into())),
+            "got: {query:?}",
+        );
+        assert!(
+            query.contains(&("event_type".into(), "action.queue.leave".into())),
+            "got: {query:?}",
+        );
+        assert!(
+            query.contains(&("per_page".into(), "1".into())),
+            "got: {query:?}",
+        );
+        let from = query
+            .iter()
+            .find(|(k, _)| k == "received_from")
+            .map(|(_, v)| v.clone())
+            .expect("received_from must be explicit, not left to the 1-day default");
+        assert_eq!(at(&from), at("2026-05-01T00:00:00Z"));
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_none_when_the_log_holds_no_leave_event() {
+        let server = MockServer::start().await;
+        arrange(&server, vec![]).await;
+
+        let got = fetch(
+            &client(&server),
+            "owner/repo",
+            999,
+            at("2026-07-30T00:00:00Z"),
+        )
+        .await
+        .unwrap();
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_tolerates_an_event_missing_every_optional_field() {
+        // A payload the CLI has never seen must still produce a
+        // diagnosis rather than a decode error.
+        let server = MockServer::start().await;
+        arrange(&server, vec![json!({"type": "action.queue.leave"})]).await;
+
+        let got = fetch(
+            &client(&server),
+            "owner/repo",
+            1,
+            at("2026-07-30T00:00:00Z"),
+        )
+        .await
+        .unwrap()
+        .expect("an event with only a type is still an event");
+        assert!(got.dequeued(), "merged defaults to false");
+        assert!(got.event.metadata.dequeue_code.is_none());
+    }
+
+    #[tokio::test]
+    async fn dequeued_is_false_for_a_merge() {
+        let server = MockServer::start().await;
+        let mut event = checks_failed_event();
+        event["metadata"]["merged"] = json!(true);
+        event["metadata"]["dequeue_code"] = json!("PR_MERGED");
+        arrange(&server, vec![event]).await;
+
+        let got = fetch(
+            &client(&server),
+            "owner/repo",
+            1700,
+            at("2026-07-30T00:00:00Z"),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(!got.dequeued(), "a merge is a leave, but not a dequeue");
+    }
+
+    fn render_with(leave: &LastLeave, pr_number: u64, verbose: bool) -> String {
+        let mut buf: Vec<u8> = Vec::new();
+        render(
+            &mut buf,
+            &Theme::new(false),
+            leave,
+            pr_number,
+            at("2026-07-30T00:00:00Z"),
+            verbose,
+        )
+        .unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    fn render_to_string(leave: &LastLeave, pr_number: u64) -> String {
+        render_with(leave, pr_number, false)
+    }
+
+    fn leave_from(raw: serde_json::Value) -> LastLeave {
+        let event = serde_json::from_value(raw.clone()).unwrap();
+        LastLeave { raw, event }
+    }
+
+    #[test]
+    fn render_dequeue_names_the_code_reason_checks_and_next_step() {
+        let rendered = render_to_string(&leave_from(checks_failed_event()), 1700);
+        assert!(
+            rendered.contains("PR #1700 was dequeued"),
+            "got: {rendered}"
+        );
+        assert!(rendered.contains("9d ago"), "got: {rendered}");
+        assert!(rendered.contains("CHECKS_FAILED"), "got: {rendered}");
+        assert!(rendered.contains("default"), "got: {rendered}");
+        assert!(
+            rendered.contains("The merge conditions cannot be satisfied"),
+            "got: {rendered}",
+        );
+        assert!(rendered.contains("ci-gate"), "got: {rendered}");
+        assert!(
+            rendered.contains("https://github.com/owner/repo/actions/runs/1/job/2"),
+            "the failing check's URL is the whole point: {rendered}",
+        );
+        assert!(rendered.contains("@mergifyio queue"), "got: {rendered}");
+    }
+
+    #[test]
+    fn render_merge_says_merged_and_offers_no_requeue() {
+        let mut raw = checks_failed_event();
+        raw["metadata"]["merged"] = json!(true);
+        raw["metadata"]["dequeue_code"] = json!("PR_MERGED");
+        raw["metadata"]["reason"] = json!("Pull request #1700 has been merged automatically");
+        raw["metadata"]["unsuccessful_checks"] = json!([]);
+
+        let rendered = render_to_string(&leave_from(raw), 1700);
+        assert!(
+            rendered.contains("PR #1700 was merged by the merge queue"),
+            "got: {rendered}",
+        );
+        assert!(
+            !rendered.contains("Dequeue code"),
+            "PR_MERGED is tautological, not a dequeue reason: {rendered}",
+        );
+        assert!(
+            !rendered.contains("requeue"),
+            "nothing to requeue after a merge: {rendered}",
+        );
+    }
+
+    #[test]
+    fn head_sha_is_the_commit_the_diagnosis_describes() {
+        // The checks in this event belong to that commit. A consumer
+        // comparing it against the PR's current head is what keeps a
+        // dequeue already superseded by a push from being reported as
+        // a live failure — so the full SHA must survive the decode.
+        let leave = leave_from(checks_failed_event());
+        assert_eq!(
+            leave.head_sha(),
+            Some("31b4a485b8ce6f2c1d0e9a7b4c5d6e7f80910111"),
+        );
+    }
+
+    #[test]
+    fn head_sha_is_absent_rather_than_empty_when_the_event_omits_it() {
+        let mut raw = checks_failed_event();
+        raw["metadata"]["pull_request_head_sha"] = json!("");
+        assert!(leave_from(raw).head_sha().is_none());
+
+        let mut raw = checks_failed_event();
+        raw["metadata"]
+            .as_object_mut()
+            .unwrap()
+            .remove("pull_request_head_sha");
+        assert!(leave_from(raw).head_sha().is_none());
+    }
+
+    #[test]
+    fn render_abbreviates_the_head_sha() {
+        let rendered = render_to_string(&leave_from(checks_failed_event()), 1700);
+        assert!(
+            rendered.contains("Head SHA:      31b4a48"),
+            "got: {rendered}",
+        );
+    }
+
+    #[test]
+    fn render_omits_the_head_sha_row_when_the_event_has_none() {
+        let mut raw = checks_failed_event();
+        raw["metadata"]["pull_request_head_sha"] = json!(null);
+        let rendered = render_to_string(&leave_from(raw), 1700);
+        assert!(!rendered.contains("Head SHA"), "got: {rendered}");
+    }
+
+    #[test]
+    fn render_survives_an_unknown_dequeue_code() {
+        // New engine codes must render verbatim, matching the
+        // survive-unknown-values stance `check_state_glyph` takes.
+        let mut raw = checks_failed_event();
+        raw["metadata"]["dequeue_code"] = json!("SOMETHING_NEW_IN_2027");
+        let rendered = render_to_string(&leave_from(raw), 1700);
+        assert!(
+            rendered.contains("SOMETHING_NEW_IN_2027"),
+            "got: {rendered}",
+        );
+    }
+
+    #[test]
+    fn render_falls_back_to_url_when_details_url_is_absent() {
+        let mut raw = checks_failed_event();
+        raw["metadata"]["unsuccessful_checks"][0]["details_url"] = json!(null);
+        let rendered = render_to_string(&leave_from(raw), 1700);
+        assert!(
+            rendered.contains("https://github.com/owner/repo/actions/runs/1/job/2"),
+            "got: {rendered}",
+        );
+    }
+
+    #[test]
+    fn render_truncates_a_long_reason_until_verbose() {
+        // A real `PR_DEQUEUED` reason embeds the whole unmet
+        // condition tree — 60+ lines on `Mergifyio/monorepo` — which
+        // would bury the headline and the failing checks.
+        let mut raw = checks_failed_event();
+        let long: Vec<String> = (0..40).map(|i| format!("line {i}")).collect();
+        raw["metadata"]["reason"] = json!(long.join("\n"));
+        let leave = leave_from(raw);
+
+        let compact = render_with(&leave, 1700, false);
+        assert!(compact.contains("line 0"), "got: {compact}");
+        assert!(compact.contains("line 11"), "got: {compact}");
+        assert!(!compact.contains("line 12"), "got: {compact}");
+        assert!(
+            compact.contains("… 28 more lines (-v for the full reason)"),
+            "truncation must announce itself: {compact}",
+        );
+        // The next step still lands after the truncated reason.
+        assert!(compact.contains("@mergifyio queue"), "got: {compact}");
+
+        let verbose = render_with(&leave, 1700, true);
+        assert!(verbose.contains("line 39"), "got: {verbose}");
+        assert!(!verbose.contains("more lines"), "got: {verbose}");
+    }
+
+    #[test]
+    fn render_does_not_announce_truncation_for_a_short_reason() {
+        let compact = render_to_string(&leave_from(checks_failed_event()), 1700);
+        assert!(!compact.contains("more lines"), "got: {compact}");
+    }
+
+    #[test]
+    fn render_omits_the_timestamp_when_it_is_unparseable() {
+        let mut raw = checks_failed_event();
+        raw["received_at"] = json!("not-a-date");
+        let rendered = render_to_string(&leave_from(raw), 1700);
+        assert!(
+            rendered.starts_with("PR #1700 was dequeued\n"),
+            "a bad timestamp must not leak into the headline: {rendered}",
+        );
+    }
+}

--- a/crates/mergify-queue/src/lib.rs
+++ b/crates/mergify-queue/src/lib.rs
@@ -2,8 +2,11 @@
 //!
 //! Hosts `pause` / `unpause` (idempotent API mutations), `status`
 //! (read-only batch tree + waiting list, with JSON passthrough),
-//! and `show` (per-PR detail with checks + conditions tree).
+//! and `show` (per-PR detail with checks + conditions tree, plus the
+//! [`last_leave`] activity-log fallback that tells a dequeued PR
+//! apart from a never-queued one).
 
+pub mod last_leave;
 pub mod pause;
 pub mod show;
 pub mod status;

--- a/crates/mergify-queue/src/show.rs
+++ b/crates/mergify-queue/src/show.rs
@@ -17,10 +17,23 @@
 //! not currently in the merge queue", which is a routine queryable
 //! state rather than a server failure. The command reports it on
 //! stdout and exits 0 — a not-queued PR is a normal answer, not an
-//! error a script should branch on as an API failure. Under `--json`
-//! the not-queued state is a `{"number": N, "queued": false}`
-//! document so pipeline consumers always get parseable output; in
-//! human mode it is the line `PR #N is not in the merge queue`. Live
+//! error a script should branch on as an API failure.
+//!
+//! That 404 is also *overloaded*: it is the same answer for a PR
+//! dequeued ten minutes ago on failing CI, a PR nobody ever queued,
+//! and a PR number that does not exist. So the 404 path asks the
+//! activity log for the pull request's last `action.queue.leave` (see
+//! [`crate::last_leave`]) and reports which of those three worlds it
+//! is in, with the dequeue reason and the failing checks' URLs.
+//!
+//! Contract, unchanged in both modes: **exit 0**, and under `--json` a
+//! `queued: false` document. The JSON gains `dequeued` (`true` /
+//! `false` / `null` when the log could not be read), `queue_leave`,
+//! the raw event verbatim so unknown fields survive, and
+//! `queue_leave_head_sha`, the head that diagnosis describes — without
+//! it a consumer cannot tell a live failure from one a later push has
+//! already superseded. In human mode a PR with no queue history still
+//! prints the exact line `PR #N is not in the merge queue` — live
 //! smoke tests assert against that substring, which is a stable
 //! contract.
 
@@ -32,11 +45,15 @@ use chrono::Utc;
 use mergify_core::CliError;
 use mergify_core::CommandContext;
 use mergify_core::Output;
+use mergify_core::http::Client;
 use mergify_tui::StyledGlyph;
 use mergify_tui::Theme;
 use mergify_tui::relative_time;
 use mergify_tui::tree;
 use serde::Deserialize;
+
+use crate::last_leave;
+use crate::last_leave::LastLeave;
 
 pub struct ShowOptions<'a> {
     pub repository: Option<&'a str>,
@@ -119,7 +136,7 @@ pub async fn run(opts: ShowOptions<'_>, output: &mut dyn Output) -> Result<(), C
 
     let raw: Option<serde_json::Value> = client.get_if_exists(&path).await?;
     let Some(raw) = raw else {
-        emit_not_queued(output, opts.pr_number, opts.output_json)?;
+        emit_not_queued(&client, &ctx.repository, output, &opts).await?;
         return Ok(());
     };
 
@@ -134,26 +151,103 @@ pub async fn run(opts: ShowOptions<'_>, output: &mut dyn Output) -> Result<(), C
     Ok(())
 }
 
-/// Emit the "PR is not in the merge queue" state. This is a normal
+/// Emit the "PR is not currently in the merge queue" state, with the
+/// diagnosis of *why* when the activity log has one. This is a normal
 /// answer, not a failure, so the command exits 0 — see the module
-/// docs. Under `--json` we emit a `{number, queued: false}` document
-/// (a machine consumer always gets parseable output); in human mode
-/// a single notice line. The wording is load-bearing: live smoke
-/// tests assert on the "is not in the merge queue" substring.
-fn emit_not_queued(
+/// docs.
+///
+/// Reading the activity log is best-effort. A token that can read the
+/// merge queue but not the repository's whole event log gets a 403
+/// here; turning that into a command failure would break a command
+/// that worked before. So a lookup failure degrades to the plain
+/// notice plus a stderr warning, and `--json` reports it as
+/// `dequeued: null` with a `queue_leave_error` — never as a silent
+/// "no dequeue found", which is the very ambiguity this path exists
+/// to remove.
+async fn emit_not_queued(
+    client: &Client,
+    repository: &str,
     output: &mut dyn Output,
-    pr_number: u64,
-    output_json: bool,
+    opts: &ShowOptions<'_>,
 ) -> Result<(), CliError> {
-    if output_json {
-        let payload = serde_json::json!({ "number": pr_number, "queued": false });
-        output.emit_json_value(&payload)?;
-    } else {
-        output.emit(&(), &mut |w: &mut dyn Write| {
-            writeln!(w, "PR #{pr_number} is not in the merge queue")
-        })?;
+    let pr_number = opts.pr_number;
+    let now = Utc::now();
+    let lookup = last_leave::fetch(client, repository, pr_number, now).await;
+    let (leave, error) = match lookup {
+        Ok(leave) => (leave, None),
+        Err(e) => {
+            let message = e.to_string();
+            output.status(&format!(
+                "could not read the activity log to check for a past dequeue: {message}",
+            ))?;
+            (None, Some(message))
+        }
+    };
+
+    if opts.output_json {
+        output.emit_json_value(&not_queued_json(
+            pr_number,
+            leave.as_ref(),
+            error.as_deref(),
+        ))?;
+        return Ok(());
     }
+
+    let theme = Theme::detect();
+    output.emit(&(), &mut |w: &mut dyn Write| {
+        if let Some(leave) = &leave {
+            return last_leave::render(w, &theme, leave, pr_number, now, opts.verbose);
+        }
+        // The exact wording live smoke tests assert on. It is also
+        // the truthful headline when the log lookup failed — the PR
+        // is not in the queue either way; the warning already went
+        // to stderr.
+        writeln!(w, "PR #{pr_number} is not in the merge queue")?;
+        if error.is_none() {
+            writeln!(w)?;
+            last_leave::render_no_activity(w, &theme)?;
+        }
+        Ok(())
+    })?;
     Ok(())
+}
+
+/// `--json` payload for the not-queued state. `queued: false` is kept
+/// verbatim for back-compat; `dequeued` is the tri-state answer
+/// (`true` left without merging, `false` never left / merged, `null`
+/// undetermined) and `queue_leave` republishes the raw API event so
+/// unknown fields survive, exactly as the queued path does.
+///
+/// `queue_leave_head_sha` is promoted out of that raw event because a
+/// consumer cannot act on the diagnosis without it: the failing checks
+/// it reports belong to the head the queue was testing, so a caller
+/// that does not compare it against the PR's current head will report
+/// a red that a later push has already superseded.
+fn not_queued_json(
+    pr_number: u64,
+    leave: Option<&LastLeave>,
+    error: Option<&str>,
+) -> serde_json::Value {
+    // `null` only when the lookup failed. "No leave event in the
+    // retained window" is a real answer — the PR was not dequeued —
+    // so it is `false`, not "undetermined".
+    let dequeued = match error {
+        Some(_) => None,
+        None => Some(leave.is_some_and(LastLeave::dequeued)),
+    };
+    let mut payload = serde_json::json!({
+        "number": pr_number,
+        "queued": false,
+        "dequeued": dequeued,
+        "queue_leave_head_sha": leave.and_then(LastLeave::head_sha),
+        "queue_leave": leave.map(|l| l.raw.clone()),
+    });
+    if let Some(error) = error
+        && let Some(map) = payload.as_object_mut()
+    {
+        map.insert("queue_leave_error".to_string(), error.into());
+    }
+    payload
 }
 
 fn emit_human(output: &mut dyn Output, view: &PullView, verbose: bool) -> std::io::Result<()> {
@@ -676,38 +770,101 @@ mod tests {
         assert_eq!(parsed["future_field"], json!("preserved"));
     }
 
-    #[tokio::test]
-    async fn run_404_human_is_not_in_queue_and_succeeds() {
-        // A not-queued PR is a normal queryable state, not an API
-        // failure: human mode prints the notice to stdout and the
-        // command returns Ok (exit 0).
-        let server = MockServer::start().await;
+    /// Mock the merge-queue 404 that sends `queue show` to the
+    /// activity-log fallback.
+    async fn arrange_not_queued(server: &MockServer, pr_number: u64) {
         Mock::given(method("GET"))
-            .and(path("/v1/repos/owner/repo/merge-queue/pull/999"))
+            .and(path(format!(
+                "/v1/repos/owner/repo/merge-queue/pull/{pr_number}"
+            )))
             .respond_with(ResponseTemplate::new(404))
             .expect(1)
-            .mount(&server)
+            .mount(server)
             .await;
+    }
 
-        let mut cap = Captured::human();
+    /// Mock the activity-log lookup with `events`.
+    async fn arrange_logs(server: &MockServer, events: Vec<serde_json::Value>) {
+        Mock::given(method("GET"))
+            .and(path("/v1/repos/owner/repo/logs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "size": events.len(),
+                "per_page": 1,
+                "events": events,
+            })))
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    fn dequeue_event() -> serde_json::Value {
+        json!({
+            "id": 1,
+            "received_at": "2026-07-20T23:25:11.263987Z",
+            "trigger": "merge queue internal",
+            "repository": "owner/repo",
+            "pull_request": 999,
+            "base_ref": "main",
+            "outcome": "failure",
+            "type": "action.queue.leave",
+            "metadata": {
+                "reason": "The merge conditions cannot be satisfied due to failing checks",
+                "merged": false,
+                "queue_name": "default",
+                "queued_at": "2026-07-20T23:11:42.944734Z",
+                "pull_request_head_sha": "31b4a485b8ce6f2c1d0e9a7b4c5d6e7f80910111",
+                "dequeue_code": "CHECKS_FAILED",
+                "unsuccessful_checks": [{
+                    "name": "ci-gate",
+                    "state": "failure",
+                    "details_url": "https://github.com/owner/repo/actions/runs/1/job/2",
+                }],
+            },
+        })
+    }
+
+    async fn run_not_queued(server: &MockServer, pr_number: u64, output_json: bool) -> Captured {
+        let mut cap = if output_json {
+            Captured::new(OutputMode::Json)
+        } else {
+            Captured::human()
+        };
         let api_url = server.uri();
         run(
             ShowOptions {
                 repository: Some("owner/repo"),
                 token: Some("t"),
                 api_url: Some(&api_url),
-                pr_number: 999,
+                pr_number,
                 verbose: false,
-                output_json: false,
+                output_json,
             },
             &mut cap.output,
         )
         .await
         .unwrap();
+        cap
+    }
 
+    #[tokio::test]
+    async fn run_404_human_is_not_in_queue_and_succeeds() {
+        // A PR with no queue history at all: a normal queryable
+        // state, not an API failure. Human mode prints the notice on
+        // stdout and the command returns Ok (exit 0). The wording is
+        // pinned by live smoke tests.
+        let server = MockServer::start().await;
+        arrange_not_queued(&server, 999).await;
+        arrange_logs(&server, vec![]).await;
+
+        let cap = run_not_queued(&server, 999, false).await;
         let stdout = cap.stdout();
         assert!(
             stdout.contains("PR #999 is not in the merge queue"),
+            "got: {stdout:?}",
+        );
+        // "we looked and found nothing" is an answer; silence is not.
+        assert!(
+            stdout.contains("No merge-queue activity"),
             "got: {stdout:?}",
         );
     }
@@ -717,35 +874,180 @@ mod tests {
         // Under `--json`, the not-queued state is a parseable
         // `{number, queued: false}` document on stdout (exit 0), so
         // pipeline consumers never get empty output for the common
-        // case.
+        // case. `queued: false` is back-compat and must not move.
         let server = MockServer::start().await;
+        arrange_not_queued(&server, 999).await;
+        arrange_logs(&server, vec![]).await;
+
+        let cap = run_not_queued(&server, 999, true).await;
+        let parsed: serde_json::Value = serde_json::from_str(&cap.stdout()).unwrap();
+        assert_eq!(parsed["number"], json!(999));
+        assert_eq!(parsed["queued"], json!(false));
+        assert_eq!(parsed["dequeued"], json!(false));
+        assert_eq!(parsed["queue_leave"], json!(null));
+    }
+
+    #[tokio::test]
+    async fn run_404_human_reports_the_dequeue_reason_and_check_urls() {
+        // The gap this fallback closes: one line used to cover
+        // "dequeued 10 minutes ago on failing CI" and "never queued"
+        // alike.
+        let server = MockServer::start().await;
+        arrange_not_queued(&server, 999).await;
+        arrange_logs(&server, vec![dequeue_event()]).await;
+
+        let cap = run_not_queued(&server, 999, false).await;
+        let stdout = cap.stdout();
+        assert!(stdout.contains("PR #999 was dequeued"), "got: {stdout:?}");
+        assert!(stdout.contains("CHECKS_FAILED"), "got: {stdout:?}");
+        assert!(
+            stdout.contains("The merge conditions cannot be satisfied"),
+            "got: {stdout:?}",
+        );
+        assert!(
+            stdout.contains("https://github.com/owner/repo/actions/runs/1/job/2"),
+            "got: {stdout:?}",
+        );
+        assert!(stdout.contains("@mergifyio queue"), "got: {stdout:?}");
+    }
+
+    #[tokio::test]
+    async fn run_404_json_reports_dequeued_with_the_raw_event() {
+        let server = MockServer::start().await;
+        arrange_not_queued(&server, 999).await;
+        arrange_logs(&server, vec![dequeue_event()]).await;
+
+        let cap = run_not_queued(&server, 999, true).await;
+        let parsed: serde_json::Value = serde_json::from_str(&cap.stdout()).unwrap();
+        assert_eq!(parsed["queued"], json!(false));
+        assert_eq!(parsed["dequeued"], json!(true));
+        // The event is republished verbatim — the schema is
+        // Mergify's contract, not this CLI's.
+        assert_eq!(parsed["queue_leave"], dequeue_event());
+    }
+
+    #[tokio::test]
+    async fn run_404_json_promotes_the_head_sha_the_diagnosis_describes() {
+        // Without this, a consumer reading `unsuccessful_checks` has
+        // no way to notice the checks belong to a commit a later push
+        // replaced, and reports a red the PR no longer has. Full SHA,
+        // not the abbreviation the human render uses — the caller
+        // compares it against the PR head.
+        let server = MockServer::start().await;
+        arrange_not_queued(&server, 999).await;
+        arrange_logs(&server, vec![dequeue_event()]).await;
+
+        let cap = run_not_queued(&server, 999, true).await;
+        let parsed: serde_json::Value = serde_json::from_str(&cap.stdout()).unwrap();
+        assert_eq!(
+            parsed["queue_leave_head_sha"],
+            json!("31b4a485b8ce6f2c1d0e9a7b4c5d6e7f80910111"),
+        );
+    }
+
+    #[tokio::test]
+    async fn run_404_json_head_sha_is_null_when_there_is_no_leave_event() {
+        // The key is always present, like `dequeued` and
+        // `queue_leave`, so a consumer can read it unconditionally.
+        let server = MockServer::start().await;
+        arrange_not_queued(&server, 999).await;
+        arrange_logs(&server, vec![]).await;
+
+        let cap = run_not_queued(&server, 999, true).await;
+        let parsed: serde_json::Value = serde_json::from_str(&cap.stdout()).unwrap();
+        assert_eq!(parsed["queue_leave_head_sha"], json!(null));
+    }
+
+    #[tokio::test]
+    async fn run_404_reports_a_merge_as_merged_not_dequeued() {
+        // A merge is also an `action.queue.leave`. Reporting it as a
+        // dequeue would tell an agent to requeue a merged PR.
+        let server = MockServer::start().await;
+        let mut event = dequeue_event();
+        event["metadata"]["merged"] = json!(true);
+        event["metadata"]["dequeue_code"] = json!("PR_MERGED");
+        event["metadata"]["unsuccessful_checks"] = json!([]);
+        arrange_not_queued(&server, 999).await;
+        arrange_logs(&server, vec![event]).await;
+
+        let cap = run_not_queued(&server, 999, false).await;
+        let stdout = cap.stdout();
+        assert!(
+            stdout.contains("PR #999 was merged by the merge queue"),
+            "got: {stdout:?}",
+        );
+        assert!(!stdout.contains("dequeued"), "got: {stdout:?}");
+    }
+
+    #[tokio::test]
+    async fn run_404_json_reports_a_merge_as_not_dequeued() {
+        let server = MockServer::start().await;
+        let mut event = dequeue_event();
+        event["metadata"]["merged"] = json!(true);
+        arrange_not_queued(&server, 999).await;
+        arrange_logs(&server, vec![event]).await;
+
+        let cap = run_not_queued(&server, 999, true).await;
+        let parsed: serde_json::Value = serde_json::from_str(&cap.stdout()).unwrap();
+        assert_eq!(parsed["dequeued"], json!(false));
+        assert_eq!(parsed["queue_leave"]["metadata"]["merged"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn run_404_degrades_when_the_activity_log_is_unreadable() {
+        // A queue-scoped token may be refused the repository's event
+        // log. `queue show` worked before this fallback existed and
+        // must keep working: exit 0, the notice on stdout, the reason
+        // on stderr — and never a silent "no dequeue found".
+        let server = MockServer::start().await;
+        arrange_not_queued(&server, 999).await;
         Mock::given(method("GET"))
-            .and(path("/v1/repos/owner/repo/merge-queue/pull/999"))
-            .respond_with(ResponseTemplate::new(404))
+            .and(path("/v1/repos/owner/repo/logs"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(json!({"detail": "nope"})))
             .expect(1)
             .mount(&server)
             .await;
 
-        let mut cap = Captured::new(OutputMode::Json);
-        let api_url = server.uri();
-        run(
-            ShowOptions {
-                repository: Some("owner/repo"),
-                token: Some("t"),
-                api_url: Some(&api_url),
-                pr_number: 999,
-                verbose: false,
-                output_json: true,
-            },
-            &mut cap.output,
-        )
-        .await
-        .unwrap();
-
+        let cap = run_not_queued(&server, 999, false).await;
         let stdout = cap.stdout();
-        let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-        assert_eq!(parsed["number"], json!(999));
+        assert!(
+            stdout.contains("PR #999 is not in the merge queue"),
+            "got: {stdout:?}",
+        );
+        assert!(
+            !stdout.contains("No merge-queue activity"),
+            "must not claim we looked when the lookup failed: {stdout:?}",
+        );
+        assert!(
+            cap.stderr().contains("could not read the activity log"),
+            "got: {:?}",
+            cap.stderr(),
+        );
+    }
+
+    #[tokio::test]
+    async fn run_404_json_reports_an_unreadable_log_as_undetermined() {
+        let server = MockServer::start().await;
+        arrange_not_queued(&server, 999).await;
+        Mock::given(method("GET"))
+            .and(path("/v1/repos/owner/repo/logs"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(json!({"detail": "nope"})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let cap = run_not_queued(&server, 999, true).await;
+        let parsed: serde_json::Value = serde_json::from_str(&cap.stdout()).unwrap();
         assert_eq!(parsed["queued"], json!(false));
+        // `null`, not `false`: "we could not tell" is not "it was
+        // never dequeued".
+        assert_eq!(parsed["dequeued"], json!(null));
+        assert!(
+            parsed["queue_leave_error"]
+                .as_str()
+                .is_some_and(|e| e.contains("403")),
+            "got: {parsed}",
+        );
     }
 
     #[tokio::test]

--- a/skills/mergify-merge-queue/SKILL.md
+++ b/skills/mergify-merge-queue/SKILL.md
@@ -9,7 +9,7 @@ description: Use Mergify merge queue to queue/dequeue PRs, to monitor and inspec
 
 The merge queue serializes PR merges, running CI on temporary merge commits to catch integration failures before they reach the target branch. Use comments on the PR to queue/dequeue it, and the CLI to monitor queue state, inspect individual PRs, and manage the queue.
 
-A PR that left the queue is diagnosed from **GitHub artifacts and the Mergify API**, not from the CLI — see [Diagnosing a dequeued PR](#diagnosing-a-dequeued-pr). Know that boundary before you start: `mergify queue show` only reports on PRs that are *currently* in the queue.
+`mergify queue show <PR>` reports on a PR that is **no longer** in the queue too — whether it was dequeued, merged by the queue, or never queued, and why — so start there for a PR that vanished from the queue. See [Diagnosing a dequeued PR](#diagnosing-a-dequeued-pr); the GitHub-side surfaces documented there are the fallback for when the CLI cannot read the activity log.
 
 ## Queuing and Dequeuing a PR
 
@@ -37,38 +37,81 @@ mergify queue pause --reason "..."   # Pause the queue (requires reason)
 mergify queue unpause                # Resume the queue
 ```
 
-That is the whole `queue` group: `status`, `show`, `pause`, `unpause`. There is no subcommand for dequeuing a PR, none for queue history, and no flag that reports a dequeue reason.
+That is the whole `queue` group: `status`, `show`, `pause`, `unpause`. There is no subcommand for dequeuing a PR and none for browsing queue history — the dequeue reason comes from `queue show` on a PR that has left the queue, not from a flag.
 
 ## Is the PR queued, dequeued, or never queued?
 
 Start here — the rest of the workflow branches on this answer.
 
-`mergify queue show <PR>` asks the API for the PR's *current* queue entry. A PR with no entry is a normal answer, not an error: the command prints a notice and **exits 0**.
+`mergify queue show <PR>` answers all four cases. A PR with no queue entry is a normal answer, not an error: the command prints a notice and **exits 0** in every case below.
 
 | `queue show` result | Meaning |
 |---|---|
 | `PR #N` block with position / CI state | The PR **is in the queue** |
-| `PR #N is not in the merge queue` | The PR is **not in the queue** — dequeued, never queued, or not a real PR number |
+| `PR #N was dequeued <when>` + a `Dequeue code` | It **left the queue without merging** — see the reason table |
+| `PR #N was merged by the merge queue <when>` | It left the queue **by merging**. Not a dequeue |
+| `PR #N is not in the merge queue` | **No queue activity in the retained window** — never queued, aged out, or not a real PR number |
 
-In `--json`, the not-queued case is the only payload carrying a `queued` key, so it is an unambiguous test:
+Under `--json`, a PR that is not currently queued carries `queued: false` plus a `dequeued` discriminator:
 
 ```bash
 mergify queue show 1234 --json | jq -e '.queued == false' >/dev/null && echo "not in queue"
 ```
 
-**`queue show` cannot tell "dequeued" from "never queued".** Both are the same 404 from the API and the same notice line. To separate them, look for a queue *history*. The discriminator is an `action.queue.leave` event: present means the PR was in the queue and left it, absent means it never got in. Get it from surface 1 below.
+- `dequeued: true` — left without merging; the raw leave event is under `queue_leave`
+- `dequeued: false` — merged by the queue, or never queued (`queue_leave` tells the two apart: `null` means never queued)
+- `dequeued: null` — the lookup itself failed, and `queue_leave_error` says why. **Not** the same as "never queued" — fall back to the GitHub-side surfaces rather than concluding anything
 
-The command does not check that the PR exists, so a typo'd number prints the same notice. If the leave-event lookup also comes back empty, confirm the PR is real (`gh pr view <PR>`) before concluding anything.
+`queue_leave_head_sha` carries the head the diagnosis describes. **Compare it against the PR's current head before reporting anything from it** — a dequeue is often *caused* by a push, so its failing checks routinely belong to a commit the PR no longer has:
+
+```bash
+mergify queue show 1234 --json | jq -r '.queue_leave_head_sha'   # 31b4a485b8ce…
+gh pr view 1234 --json headRefOid -q .headRefOid                 # 340361aae580…  → superseded, stay quiet
+```
+
+Two limits to keep in mind. History goes back **90 days** (the activity log's retention), so an older dequeue reads as "no activity". And the command does not check that the PR exists, so a typo'd number prints the same "not in the merge queue" notice — confirm the PR is real (`gh pr view <PR>`) before concluding it was never queued.
 
 Do not use the presence of a `Mergify Merge Queue` check run as the test — a PR that merely *matches* the queue conditions gets one titled `Waiting for queue conditions` without ever being queued. A `# Merge Queue Status` comment is a reliable positive signal (the pre-queue "Queue this pull request" offer comment deliberately carries no such heading), but its absence proves nothing, since the comment can be disabled per repository.
 
 ## Diagnosing a dequeued PR
 
-Three surfaces carry the reason. Prefer them in this order.
+Four surfaces carry the reason. Prefer them in this order.
 
-### 1. The Mergify activity log (machine-readable, authoritative)
+### 1. `mergify queue show <PR>` (start here)
 
-`GET /v1/repos/{owner}/{repo}/logs` returns the queue lifecycle events, newest first. **No CLI command exposes this** — call it directly:
+On a PR that is no longer queued, `queue show` reads the PR's last merge-queue exit and renders it:
+
+```
+PR #37823 was dequeued 24m ago
+
+  Dequeue code:  CHECKS_FAILED
+  Queue:         default
+  Queued at:     46m ago
+  Trigger:       merge queue internal
+  Head SHA:      31b4a48
+
+  The merge conditions cannot be satisfied due to failing checks
+
+  - `@github-actions/all-greens`
+
+  Failing checks:
+    ✗ all-greens  failure
+      https://github.com/Mergifyio/monorepo/actions/runs/…/job/…
+
+  Fix the cause above, then comment `@mergifyio queue` on the pull request.
+```
+
+That is the engine's own explanation plus the failing checks **with their job-log URLs** — go straight to the failing job rather than hunting for it. The explanation is capped at 12 lines in compact mode; add `-v` for the whole thing (a `PR_DEQUEUED` reason embeds the full unmet-condition tree, which runs to dozens of lines).
+
+`Head SHA` is the commit all of that describes. If it is not the PR's current head, the report is about a commit that has since been replaced — the checks above may already be green again. Check it before acting on the failure.
+
+`--json` gives the same thing machine-readably: `dequeued`, plus `queue_leave` carrying the raw event, so read `dequeue_code`, `reason`, and `unsuccessful_checks[].details_url` from `.queue_leave.metadata`. Use the promoted `queue_leave_head_sha` for the staleness check above.
+
+Reading the activity log is **best-effort**: a token scoped to the merge queue can be refused the repository's event log (403). The command then degrades to the plain "not in the merge queue" notice plus a warning on stderr, and reports `dequeued: null` — that is the signal to fall through to the surfaces below, not a statement that the PR was never queued.
+
+### 2. The Mergify activity log (what surface 1 reads underneath)
+
+`GET /v1/repos/{owner}/{repo}/logs` returns the queue lifecycle events, newest first. `queue show` calls this for you; go direct when it degrades (403 above), when you need the whole lifecycle rather than the last exit, or from somewhere the CLI is not installed:
 
 ```bash
 REPO=owner/repo
@@ -113,7 +156,7 @@ Two traps that make this silently return nothing:
 
 Same endpoint, other useful filters: `&outcome=failure` restricts leave events to dequeues (a merge is `success`); drop `event_type` to see the whole lifecycle (`action.queue.enter`, `checks_start`, `checks_end`, `leave`).
 
-### 2. The `Mergify Merge Queue` check run
+### 3. The `Mergify Merge Queue` check run
 
 The check-run **title** names the reason directly, and its summary is the full queue report:
 
@@ -132,9 +175,9 @@ Titles map to state without any parsing:
 | `Merged via merge queue` (conclusion `success`) | Merged by the queue |
 | `Waiting for queue conditions`, `Checks …`, `In merge queue` | Still in the lifecycle |
 
-Caveat: the check run lives on the **head SHA it was written against**. If the dequeue was caused by a push (`PULL_REQUEST_UPDATED`, `DRAFT_PULL_REQUEST_CHANGED`), the current head has a *fresh* check run and the dequeue report sits on the previous SHA. Use surface 1 or 3 in that case. Note also that `gh pr view --json statusCheckRollup` returns a null `title` — go through `gh api .../check-runs` as above.
+Caveat: the check run lives on the **head SHA it was written against**. If the dequeue was caused by a push (`PULL_REQUEST_UPDATED`, `DRAFT_PULL_REQUEST_CHANGED`), the current head has a *fresh* check run and the dequeue report sits on the previous SHA. Use surface 1 or 4 in that case — surface 1 names the SHA (`Head SHA` / `queue_leave_head_sha`), so it is the one that lets you *detect* the mismatch rather than fall into it. Note also that `gh pr view --json statusCheckRollup` returns a null `title` — go through `gh api .../check-runs` as above.
 
-### 3. The `# Merge Queue Status` comment
+### 4. The `# Merge Queue Status` comment
 
 `mergify[bot]` posts one comment per queue session, so **read the last one**. It survives pushes, which makes it the most robust GitHub-side surface.
 
@@ -206,7 +249,7 @@ Use `mergify queue show <PR_NUMBER>` to check why a PR is stuck or how it's prog
 - **Conditions**: which conditions are met and which are blocking
 - Use `-v` (verbose) for the full checks table and conditions tree
 
-`-v` lists check **names and states only — no links to the CI jobs**. For job-log URLs, use the dequeue-report surfaces above (they apply to a queued PR too, via the check-run summary). `--json` is a raw passthrough of the API payload, so it carries two fields the human render drops: `checks_timeout_at` (when this PR will hit `CHECKS_TIMEOUT` — worth reading *before* it does) and `queue_rule` (the resolved queue rule config, not just its name).
+`-v` lists check **names and states only — no links to the CI jobs**. For job-log URLs on a PR that is still queued, use the GitHub-side surfaces above (the check-run summary and the status comment); once the PR has left the queue, `queue show` itself prints them. `--json` is a raw passthrough of the API payload, so it carries two fields the human render drops: `checks_timeout_at` (when this PR will hit `CHECKS_TIMEOUT` — worth reading *before* it does) and `queue_rule` (the resolved queue rule config, not just its name).
 
 ## Queue States
 
@@ -243,7 +286,7 @@ mergify queue unpause
 - Make sure the PR was queued: post `@mergifyio queue` and confirm Mergify reacted with 👍 on the comment
 - Check that the PR's merge conditions are met: `mergify queue show <PR_NUMBER> -v`
 - Look at the conditions section for unmet requirements
-- If `queue show` says the PR is not in the queue, it may have been queued and dequeued already — check for a leave event before assuming the queue command never landed
+- Do not assume the queue command never landed: `queue show` tells a PR that was queued and dequeued apart from one that never entered
 
 **PR stuck in queue:**
 - Check CI state: `mergify queue show <PR_NUMBER>`
@@ -251,8 +294,9 @@ mergify queue unpause
 - If the queue is paused, check who paused it: `mergify queue status`
 
 **PR disappeared from the queue:**
-- Do not conclude it was never queued — `mergify queue show` reports the same "not in the merge queue" for both cases
-- Go to [Diagnosing a dequeued PR](#diagnosing-a-dequeued-pr): get `dequeue_code`, then act per the reason table
+- `mergify queue show <PR_NUMBER>` — it says whether the PR was dequeued, merged by the queue, or never queued, and prints the dequeue code, the reason, and the failing checks' URLs
+- Never assume "not in the merge queue" means "never queued": read the headline (or `dequeued` under `--json`) before telling anyone to requeue
+- Then act per the [reason table](#dequeue-reasons-and-what-to-do-next)
 
 **Queue moving slowly:**
 - Check for failing batches that trigger bisection: `mergify queue status`


### PR DESCRIPTION
`mergify queue show <PR>` could only report on a PR *currently* in the
queue. Outside that, one line covered three different worlds:

    $ mergify queue show 1740
    PR #1740 is not in the merge queue    # dequeued? never queued? or a
    $ mergify queue show 1740 --json      # PR number that doesn't exist?
    {"number": 1740, "queued": false}

The engine has ~32 `dequeue_code` values and records the failing checks
with their URLs, but none of it was reachable from any command or flag —
so the `mergify-merge-queue` skill routed agents out of the CLI to
`curl`/`gh api` to answer "why did my PR leave the queue?".

On a merge-queue 404, `queue show` now falls back to the activity log
for the PR's last `action.queue.leave` and reports which world it is in:

    PR #37823 was dequeued 24m ago

      Dequeue code:  CHECKS_FAILED
      Queue:         default
      Queued at:     46m ago
      Trigger:       merge queue internal
      Head SHA:      31b4a48

      The merge conditions cannot be satisfied due to failing checks

      - `@github-actions/all-greens`

      Failing checks:
        ✗ all-greens  failure
          https://github.com/Mergifyio/monorepo/actions/runs/…/job/…

      Fix the cause above, then comment `@mergifyio queue` on the pull request.

plus `PR #N was merged by the merge queue <when>` for a leave that
merged, and the unchanged `PR #N is not in the merge queue` — followed
by "No merge-queue activity in the last 90 days." — when the log holds
nothing. That exact wording is load-bearing (live smoke tests assert on
the substring) and stays put for the genuine never-queued case.

`--json` keeps `queued: false` for back-compat and adds:

  - `dequeued`: `true` (left without merging), `false` (merged, or never
    queued), `null` when the lookup failed — `queue_leave_error` then
    says why
  - `queue_leave_head_sha`: the PR head the diagnosis describes
  - `queue_leave`: the raw API event verbatim, so unknown fields survive
    exactly as they do on the queued path

`queue_leave_head_sha` is promoted out of the raw event rather than left
for the caller to dig out, because a consumer cannot safely act on the
diagnosis without it. The reported `unsuccessful_checks` belong to the
head the queue was testing, and a dequeue is frequently *caused* by a
push (`PULL_REQUEST_UPDATED`, `DRAFT_PULL_REQUEST_CHANGED`) — so the
checks routinely describe a commit the PR no longer carries. Live case
on Mergifyio/mergify-cli#1731: dequeued on `e330b5be`
(`CONFLICT_WITH_BASE_BRANCH`), merged 13 minutes later on `a1d41dd1`.
A caller that compares the field against the PR's current head can stay
quiet when they differ instead of reporting a red that no longer exists;
without it, a stale failure is indistinguishable from a live one — as
bad as the false green this change set out to remove. The human render
carries the same fact as an abbreviated `Head SHA` row; `--json` keeps
the full SHA, since that is the side doing the comparison.

Exit code stays 0 in every case: a not-queued PR is an answer, not a
failure.

Four things about the `/logs` request are load-bearing and each is
pinned by a test:

  - **The window.** `/logs` defaults `received_from` to `received_to -
    1 day`, so without an explicit range a PR dequeued last week comes
    back `size: 0` — reading exactly like never-queued, the failure this
    change exists to remove. The API rejects a span over 93 days (422)
    and retention is 90, so the fallback asks for the whole retained
    history and no more.
  - **The ordering.** Events are newest-first, so `events[0]` with
    `per_page=1` is the PR's *last* exit: a PR that conflicted, was
    requeued and then merged reports the merge.
  - **The event type.** The ~11 `AbortCodeT` values that are not
    dequeues (`PR_AHEAD_DEQUEUED`, `MERGE_QUEUE_RESET`,
    `CHECKS_RETRIED`, …) ride on `action.queue.checks_end` and interrupt
    the *checks* while the PR stays queued. Filtering on
    `action.queue.leave` is what keeps them out; reporting one as a
    dequeue would tell an agent to requeue a PR that never left.
  - **`metadata.merged`.** A merge is also an `action.queue.leave`; the
    boolean, not the `dequeue_code`, separates the two.

Reading the activity log is best-effort. A token scoped to the merge
queue can be refused the repository's event log (403); turning that into
a command failure would break a command that worked before, so it
degrades to the plain notice plus a stderr warning — and never to a
silent "no dequeue found", which would recreate the ambiguity.

A real `PR_DEQUEUED` reason embeds the whole unmet-condition tree (61
lines on Mergifyio/monorepo#37691) and buried both the headline and the
check URLs, so the reason is capped at 12 lines without `-v` — the same
compact/verbose split the in-queue conditions section already uses.

No local copy of the ~32 codes or their per-reason hints: those live in
the engine and a copy would drift. Unknown codes render verbatim,
matching the survive-unknown-values stance `check_state_glyph` takes.

Verified against the live API with the built binary, not only mocks:
dequeued (Mergifyio/monorepo#37823, #37691), merged
(Mergifyio/mergify-cli#1700, #1731), and never-queued (#999999). The
head SHA was re-checked the same way — `queue_leave_head_sha` on
Mergifyio/mergify-cli#1749 matches what `gh pr view --json headRefOid`
reports for the PR, which is what makes the comparison usable.

The `mergify-merge-queue` skill is rewritten around this rather than
merely extended. #1746 landed while this was in review and documented
the pre-change reality at length: "a PR that left the queue is diagnosed
from GitHub artifacts and the Mergify API, not from the CLI", "no CLI
command exposes this", "`queue show` cannot tell dequeued from never
queued", and a `curl` recipe for the activity log. Every one of those
sentences is false once this lands, so leaving them beside the new
section would ship a skill that contradicts itself — and an agent
reading top-down would follow the `curl`. The four diagnosis surfaces
are reordered with `queue show` first; the raw `/logs` call stays,
demoted to what the CLI reads underneath and the documented fallback for
the 403 degradation, the full lifecycle, and CLI-less environments. The
check-run and status-comment surfaces, the reason table and the
`abort_code` caveat are #1746's and are kept as they were.

The dequeue footer now says `@mergifyio queue`, not `@mergifyio
requeue`. Same #1746 verified in the engine's entry points that
`requeue` is a deprecated alias bound to the same command, and said so
in this very file — a CLI that prints the deprecated spelling while the
skill beside it says "post `@mergifyio queue`" teaches the wrong one.