### PR TITLE
feat(queue): show when a queued PR's checks will time out

### DIFF
--- a/crates/mergify-queue/src/show.rs
+++ b/crates/mergify-queue/src/show.rs
@@ -77,6 +77,12 @@ struct PullView {
     priority_rule_name: Option<String>,
     #[serde(default)]
     queue_rule_name: Option<String>,
+    /// When the queue will give up on this PR's checks. `--json`
+    /// passed it through from the start, but the human render dropped
+    /// it — so a `CHECKS_TIMEOUT` could only be diagnosed after the
+    /// fact, never seen coming.
+    #[serde(default)]
+    checks_timeout_at: Option<String>,
     #[serde(default)]
     mergeability_check: Option<MergeabilityCheck>,
 }
@@ -315,6 +321,11 @@ fn print_metadata(
         w,
         "  ETA:         {}",
         relative_or_raw_or_dash(view.estimated_time_of_merge.as_deref(), now, true),
+    )?;
+    writeln!(
+        w,
+        "  CI timeout:  {}",
+        relative_or_raw_or_dash(view.checks_timeout_at.as_deref(), now, true),
     )
 }
 
@@ -623,6 +634,7 @@ mod tests {
             "position": 3,
             "priority_rule_name": "default",
             "queue_rule_name": "default",
+            "checks_timeout_at": "2026-05-09T12:00:00Z",
             "queue_rule": {"name": "default", "config": {}},
             "mergeability_check": {
                 "check_type": "in_place",
@@ -689,6 +701,9 @@ mod tests {
         let stdout = cap.stdout();
         assert!(stdout.contains("PR #123"), "got: {stdout:?}");
         assert!(stdout.contains("Position:"), "got: {stdout:?}");
+        // A pending checks timeout is visible before it fires, not
+        // only diagnosable as CHECKS_TIMEOUT afterwards.
+        assert!(stdout.contains("CI timeout:"), "got: {stdout:?}");
         assert!(stdout.contains("CI State:"), "got: {stdout:?}");
         // Compact summary: 1 passed (tests), 1 pending (linters), 1
         // failed (security). The failing check name is listed below

--- a/skills/mergify-merge-queue/SKILL.md
+++ b/skills/mergify-merge-queue/SKILL.md
@@ -245,11 +245,12 @@ Use `mergify queue show <PR_NUMBER>` to check why a PR is stuck or how it's prog
 
 - **Position**: where the PR sits in the queue
 - **Priority**: which priority rule matched
+- **CI timeout**: when the queue will give up on the PR's checks (`-` when no timeout is configured) — watch this to catch a `CHECKS_TIMEOUT` before it fires
 - **CI state**: whether checks are passing, pending, or failing
 - **Conditions**: which conditions are met and which are blocking
 - Use `-v` (verbose) for the full checks table and conditions tree
 
-`-v` lists check **names and states only — no links to the CI jobs**. For job-log URLs on a PR that is still queued, use the GitHub-side surfaces above (the check-run summary and the status comment); once the PR has left the queue, `queue show` itself prints them. `--json` is a raw passthrough of the API payload, so it carries two fields the human render drops: `checks_timeout_at` (when this PR will hit `CHECKS_TIMEOUT` — worth reading *before* it does) and `queue_rule` (the resolved queue rule config, not just its name).
+`-v` lists check **names and states only — no links to the CI jobs**. For job-log URLs on a PR that is still queued, use the GitHub-side surfaces above (the check-run summary and the status comment); once the PR has left the queue, `queue show` itself prints them. `--json` is a raw passthrough of the API payload, so it carries one more field the human render drops: `queue_rule` (the resolved queue rule config, not just its name).
 
 ## Queue States
 


### PR DESCRIPTION
`checks_timeout_at` — "the timestamp when the checks will timeout for
this pull request" — has always been in the `merge-queue/pull/{n}`
response and has always reached `--json` consumers, because that path is
a raw passthrough. The human render dropped it: `PullView` never
deserialized the field, so it appeared nowhere in `queue show`.

The effect was that a `CHECKS_TIMEOUT` could only ever be diagnosed
after the fact. The one number that lets a user see it coming — and
decide whether to go chase a stuck job now — was the one number the
command didn't print.

Add it to the metadata block, rendered as a future relative time next to
the ETA it belongs beside:

      Position:    0
      Priority:    hotfix
      Queue rule:  default
      Queued at:   7m ago
      ETA:         ~6m
      CI timeout:  ~24m

`CI timeout` is spelled to fit the block's existing 15-column value
offset, so no other row moves. A queue with no checks timeout configured
sends `null` and gets the same `-` every other absent field already
gets.

Verified against a live queued PR (Mergifyio/monorepo#37886, whose
`checks_timeout_at` was 2026-07-30T15:08:17Z).

The `mergify-merge-queue` skill listed `checks_timeout_at` among the
fields "the human render drops" (#1746, merged since this stack was
first pushed). It no longer does, so that sentence now names only
`queue_rule`.

Depends-On: #1747