### PR TITLE
fix(ci): bound scope glob `*` and `?` at `/` to match the engine

### DIFF
--- a/crates/mergify-ci/src/scopes_detect/matching.rs
+++ b/crates/mergify-ci/src/scopes_detect/matching.rs
@@ -1,12 +1,34 @@
 //! Glob-pattern matching: file path → matching scopes.
 //!
-//! Python uses `glob.translate` + `re.fullmatch`; we use `globset`.
-//! The `**` recursive wildcard and the `?` / `[…]` character class
-//! syntax match Python's `glob` semantics for the patterns Mergify
-//! configs actually use (file globs anchored to repo root). One
-//! intentional behavior: a pattern with an empty `include` list
-//! follows Python and matches every path (the scope's exclude list
-//! then decides) — the YAML deserializer fills the default
+//! The engine derives a pull request's scopes from the very same
+//! `scopes:` block, in `mergify_engine/rules/globs.py` (brace
+//! expansion, then `glob.translate`, matched with the third-party
+//! `regex` module's `.match()` — `glob.translate` end-anchors its
+//! output with `\z`, so that is a full match), and it — not this
+//! command — is what the merge queue acts on. So the
+//! semantics here have to track that module rather than globset's
+//! defaults, or one config means two things and `ci scopes` picks
+//! CI jobs for a scope set the engine never derives:
+//!
+//! - `*` and `?` stop at `/` (`literal_separator(true)`). `src/*.py`
+//!   is `src`'s own Python files, not the whole subtree; only `**`
+//!   crosses directories. This is also what
+//!   `/configuration/data-types` documents.
+//! - `{a,b}` alternation means the same on both sides — globset
+//!   compiles it inline, the engine expands it into one pattern per
+//!   branch (MRGFY-8359).
+//!
+//! Parity is exact for every path git can report as changed. The
+//! residual differences all need a path git never emits: a leading
+//! `/`, a trailing `/`, an empty segment (`a//b`), or the empty
+//! string. An unterminated `[` is the one place globset is stricter
+//! — it rejects the pattern where the engine degrades it to a
+//! literal — and erroring out on a malformed config is the side to
+//! be on.
+//!
+//! One intentional behavior: a pattern with an empty `include` list
+//! follows the engine and matches every path (the scope's exclude
+//! list then decides) — the YAML deserializer fills the default
 //! `["**/*"]` for us, so this fallthrough is mostly defensive.
 
 use std::collections::BTreeMap;
@@ -68,13 +90,16 @@ fn compile_list(scope: &str, patterns: &[String]) -> Result<Vec<GlobMatcher>, Cl
 }
 
 fn build_glob(scope: &str, pattern: &str) -> Result<GlobMatcher, CliError> {
-    // `literal_separator(false)` makes `*` and `**` cross `/`
-    // boundaries, which is how Python's `glob.translate(...,
-    // recursive=True)` behaves. `case_insensitive(false)` is the
-    // default but stated for the record — file paths are case-
-    // sensitive on the platforms Mergify cares about.
+    // `literal_separator(true)` is the whole parity story for
+    // everything but `**`: it compiles `*` to `[^/]*` and `?` to
+    // `[^/]`, which is what `glob.translate` emits and what the
+    // data-types page documents. globset defaults it off, and that
+    // default is what used to let `*.md` swallow every `.md` in the
+    // tree. `case_insensitive(false)` is the default but stated for
+    // the record — file paths are case-sensitive on the platforms
+    // Mergify cares about.
     GlobBuilder::new(pattern)
-        .literal_separator(false)
+        .literal_separator(true)
         .case_insensitive(false)
         .build()
         .map(|g| g.compile_matcher())
@@ -131,15 +156,98 @@ mod tests {
         compile(&m).expect("globs compile")
     }
 
+    /// Assert a single `include` pattern's verdict on one path.
+    fn assert_matches(cases: &[(&str, &str, bool)]) {
+        for &(pattern, path, expected) in cases {
+            let ms = compile_one(&[pattern], &[]);
+            let hit = route([path], &ms).hit.contains("s");
+            assert_eq!(
+                hit, expected,
+                "{pattern:?} vs {path:?}: expected match={expected}",
+            );
+        }
+    }
+
     #[test]
-    fn double_star_matches_across_path_separators() {
-        // `mergify_cli/**` must catch nested files like
-        // `mergify_cli/ci/scopes/cli.py`. This is the main
-        // expectation of `glob.translate(..., recursive=True)`:
-        // `**` traverses arbitrarily many directories.
-        let ms = compile_one(&["mergify_cli/**"], &[]);
-        let res = route(["mergify_cli/ci/scopes/cli.py"], &ms);
-        assert!(res.hit.contains("s"), "expected hit, got {:?}", res.hit);
+    fn single_star_and_question_mark_stop_at_a_separator() {
+        // MRGFY-8392. globset's default (`literal_separator(false)`)
+        // compiles `*` to `.*`, so `src/*.py` used to claim
+        // `src/deep/nested.py` — a file the engine, which compiles
+        // the same pattern to `src[/\\][^/\\]*\.py`, never puts in
+        // the scope. Each pattern below is paired with the path the
+        // two sides disagreed on and one they always agreed on, so
+        // the bound is pinned without pinning `*` shut entirely.
+        assert_matches(&[
+            ("src/*.py", "src/deep/nested.py", false),
+            ("src/*.py", "src/main.py", true),
+            ("*.md", "docs/readme.md", false),
+            ("*.md", "readme.md", true),
+            (
+                ".github/workflows/*",
+                ".github/workflows/nested/ci.yml",
+                false,
+            ),
+            (".github/workflows/*", ".github/workflows/ci.yml", true),
+            ("package*.json", "packages/ui/tsconfig.json", false),
+            ("package*.json", "package-lock.json", true),
+            ("a?c", "a/c", false),
+            ("a?c", "abc", true),
+        ]);
+    }
+
+    #[test]
+    fn separator_bounded_star_in_exclude_does_not_drop_a_scope() {
+        // The direction that actually skipped CI. With `*` crossing
+        // `/`, an `exclude: ['*.md']` swallowed every markdown file
+        // in the tree, so `ci scopes` reported *fewer* scopes than
+        // the engine and the matching CI job never ran for a pull
+        // request the engine did consider in scope. Bounded, the
+        // exclude only covers root-level markdown, as documented.
+        let ms = compile_one(&["**/*"], &["*.md"]);
+        let res = route(["docs/guide.md"], &ms);
+        assert!(
+            res.hit.contains("s"),
+            "nested markdown must stay in scope, got {:?}",
+            res.hit,
+        );
+        let res = route(["README.md"], &ms);
+        assert!(res.hit.is_empty(), "unexpected hit: {:?}", res.hit);
+    }
+
+    #[test]
+    fn double_star_is_the_only_wildcard_that_crosses_directories() {
+        // `**` keeps its recursive meaning, including the "zero
+        // segments" case (`**/x` matches a root-level `x`) that the
+        // engine's `(?:.+[/\\])?` prefix also allows. Without this,
+        // narrowing `*` could plausibly have been read as narrowing
+        // `**` too.
+        assert_matches(&[
+            ("**/*.py", "a/b/c.py", true),
+            ("**/*.py", "top.py", true),
+            ("**/x", "x", true),
+            ("**/x", "deep/nested/x", true),
+            ("src/**", "src/a/b/c.py", true),
+            ("src/**/*.py", "src/a/b.py", true),
+            ("**/tests/**", "a/b/tests/c/d.py", true),
+            // `**/*` is `FileFilters`' default `include`, so every
+            // scope that only declares an `exclude` list rides on it.
+            // Narrowing the trailing `*` must not stop it catching a
+            // nested file, or those scopes would quietly go empty.
+            ("**/*", "a/b/c/deep.py", true),
+            ("**/*", "top.py", true),
+        ]);
+    }
+
+    #[test]
+    fn brace_alternation_expands_within_the_separator_bound() {
+        // Braces are the other half of engine parity (MRGFY-8359),
+        // and they compose with the bound rather than escaping it:
+        // each branch is a separator-bounded `*` in its own right.
+        assert_matches(&[
+            ("*.{md,rst}", "readme.md", true),
+            ("*.{md,rst}", "readme.rst", true),
+            ("*.{md,rst}", "docs/readme.md", false),
+        ]);
     }
 
     #[test]


### PR DESCRIPTION
`mergify ci scopes` built every scope glob with globset's
`literal_separator(false)`, so a single `*` or `?` crossed `/`. The engine
derives the same scopes from the same `scopes:` block with `glob.translate`,
which keeps both separator-bounded, and that is also what
`/configuration/data-types` documents. One config, two meanings.

Both directions were wrong, not just the obvious one:

* on `include` the CLI over-reported. `src/*.py` claimed `src/deep/nested.py`,
  so CI ran jobs for a scope the engine never derives.
* on `exclude` the CLI under-reported, which is the direction that skips CI.
  `exclude: ['*.md']` swallowed every markdown file in the tree instead of the
  root ones only, dropping the scope entirely and skipping a job for a pull
  request the engine did consider in scope.

Measured before changing anything, against the 2026-07-14 production config
export (4709 repository configs, 46 with a `scopes:` block, 700 distinct
patterns):

* 666 patterns unaffected, 34 change match set.
* those 34 are exactly the patterns where today's CLI disagrees with the
  engine.
* after the flip, 0 of the 700 disagree.

Most of the 34 are `prefix*suffix` inside one segment (`package*.json`,
`docker-compose*.yml`) where the old behaviour let the `*` swallow a directory
boundary; the rest are `dir/*` read as recursive. The engine already behaved
the narrow way in every one of those repositories, so their CLI was disagreeing
with their own merge queue. This makes the CLI honest rather than newly wrong.

Verified by differential fuzz against `mergify_engine/rules/globs.py`: 428
generated patterns against 272 paths, plus all 700 production patterns run
through `build_glob` itself. `literal_separator(true)` diverges on none of
them; `literal_separator(false)` diverged on 37 of the 428. The residual gaps
all need a path git cannot report as changed: a leading `/`, a trailing `/`, an
empty segment (`a//b`), or the empty string.

This narrows matching, so a repository relying on the old wide behaviour will
see those scopes stop firing in CI. That is the intended correction: it aligns
CI with what the merge queue was already doing.

The module doc was wrong on two counts and is rewritten. It credited
`glob.translate(..., recursive=True)` for the separator crossing (`recursive`
affects `**` only), and it never mentioned brace alternation (MRGFY-8359).

Fixes MRGFY-8392