### PR TITLE
chore: clean gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
-__pycache__
-.mypy_cache
-dist
-build
-target
+target/


### PR DESCRIPTION
We moved away from Python to Rust, no need for this anymore.