### PR TITLE
fix(stack): strip current-format Change-Id suffixes from branch refs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/crates/mergify-stack/src/change_id.rs
+++ b/crates/mergify-stack/src/change_id.rs
@@ -49,11 +49,30 @@ static SHORT_CHANGEID_RE: LazyLock<Regex> =
 static BRANCH_SUFFIX_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(&format!(r"/{CHANGEID_LOOSE_PATTERN}$")).unwrap());
 
-/// Strip a trailing `/Ixxxx…` Change-Id suffix from a branch
-/// name. Returns the input unchanged when there's no match.
+/// Strip a trailing Change-Id segment from a stack branch name,
+/// in either naming scheme: the legacy `/Ixxxx…` suffix or the
+/// current `/<slug>--xxxxxxxx` one. Returns the input unchanged
+/// when the last segment isn't a Change-Id segment — including
+/// when it's the *only* segment, since a branch name has to keep
+/// at least one.
+///
+/// This is what lets `stack checkout` accept a leaf branch ref
+/// (or a PR head ref) pasted verbatim and resolve it to the stack
+/// stem the rest of the stack hangs off.
 #[must_use]
 pub fn strip_branch_suffix(name: &str) -> String {
-    BRANCH_SUFFIX_RE.replace(name, "").into_owned()
+    // The legacy form goes through the loose pattern on purpose —
+    // a malformed `I<40 non-hex>` segment is still a suffix the
+    // user meant to paste, and dropping it beats searching for a
+    // stack branch that can't exist.
+    let stripped = BRANCH_SUFFIX_RE.replace(name, "");
+    if stripped != name {
+        return stripped.into_owned();
+    }
+    match name.rsplit_once('/') {
+        Some((stem, last)) if SHORT_CHANGEID_RE.is_match(last) => stem.to_string(),
+        _ => name.to_string(),
+    }
 }
 
 /// Return `true` if `value` is a strict, full-form Change-Id
@@ -210,5 +229,36 @@ mod tests {
         // Has the right shape but wrong length on the short tail.
         assert_eq!(extract_from_branch_segment("slug--abcd123"), None);
         assert_eq!(extract_from_branch_segment("slug--abcd12345"), None);
+    }
+
+    #[test]
+    fn strip_branch_suffix_removes_legacy_full_changeid_segment() {
+        assert_eq!(
+            strip_branch_suffix("stack/a/my-branch/I0123456789abcdef0123456789abcdef01234567"),
+            "stack/a/my-branch",
+        );
+    }
+
+    #[test]
+    fn strip_branch_suffix_removes_new_style_short_changeid_segment() {
+        // `stack push` names branches `<stack>/<slug>--<8 hex>`;
+        // pasting such a leaf ref into `stack checkout` must
+        // resolve to the stack stem, not to the leaf itself.
+        assert_eq!(
+            strip_branch_suffix("stack/a/my-branch/feat-a--abcd1234"),
+            "stack/a/my-branch",
+        );
+    }
+
+    #[test]
+    fn strip_branch_suffix_leaves_plain_branches_untouched() {
+        assert_eq!(
+            strip_branch_suffix("stack/a/my-branch"),
+            "stack/a/my-branch"
+        );
+        assert_eq!(strip_branch_suffix("my-feature"), "my-feature");
+        // A single segment that *is* a change-id segment is the
+        // whole branch name — nothing left to strip down to.
+        assert_eq!(strip_branch_suffix("feat-a--abcd1234"), "feat-a--abcd1234");
     }
 }


### PR DESCRIPTION
`strip_branch_suffix` only recognised the legacy `/I<40 hex>` suffix,
so a branch ref in the current `<slug>--<8 hex>` naming came back
unchanged. `stack checkout` is the only caller: pasting a leaf ref it
was given verbatim searched for `<leaf>/` — a stack branch that cannot
exist — and reported "no stacked pull requests" instead of the stack
the ref belongs to.

Strip the last segment whenever it parses as a Change-Id segment in
either scheme, and leave a single-segment name alone since a branch
has to keep at least one.

Depends-On: #1778