### PR TITLE
feat(stack): check out a stack by branch or pull request URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -232,9 +232,9 @@ enum NativeCommand {
     /// [--dry-run]` — fold several commits into a target,
     /// reordering them adjacent first.
     StackSquash(StackSquashOpts),
-    /// `mergify stack checkout <NAME>` — fetch a stack of pull
-    /// requests from GitHub and create a local branch tracking
-    /// the leaf head.
+    /// `mergify stack checkout <BRANCH|PR_URL>` — fetch a stack of
+    /// pull requests from GitHub and create a local branch
+    /// tracking the leaf head.
     StackCheckout(StackCheckoutOpts),
     /// `mergify stack sync [--dry-run]` — rebase the stack onto
     /// trunk, dropping commits whose PR has merged.
@@ -330,11 +330,10 @@ struct StackSquashOpts {
 }
 
 struct StackCheckoutOpts {
-    name: String,
-    author: Option<String>,
+    /// Stack branch name or pull request URL.
+    target: String,
     repository: Option<String>,
     branch: Option<String>,
-    branch_prefix: Option<String>,
     dry_run: bool,
     /// `Some((remote, branch))` from `--trunk REMOTE/BRANCH`;
     /// `None` falls back to `trunk::get_trunk` at runtime.
@@ -1213,6 +1212,32 @@ async fn resolve_stack_context(
     })
 }
 
+/// Resolve the stack branch prefix this machine pushes under, the
+/// way every other stack command computes it.
+///
+/// `stack checkout` needs it for naming only — never for finding
+/// the stack — so it takes the configured value when there is one
+/// and only falls back to `stack/<login>` (one `GET /user`) when
+/// there isn't. Getting it right is what keeps a multi-segment
+/// branch name intact across a push/checkout/push round-trip.
+async fn resolve_local_stack_prefix(
+    client: &mergify_core::HttpClient,
+) -> Result<String, mergify_core::CliError> {
+    if let Some(configured) = mergify_stack::stack_context::configured_branch_prefix(None) {
+        return Ok(configured);
+    }
+    let user_payload: serde_json::Value = client.get("/user").await?;
+    let login = user_payload
+        .get("login")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            mergify_core::CliError::GitHubApi("/user response missing `login`".to_string())
+        })?;
+    // Not `resolve_default_branch_prefix` — the config lookup it
+    // starts with was just done above and came back empty.
+    Ok(mergify_stack::stack_context::default_branch_prefix(login))
+}
+
 /// Render `stack list` output to stdout in human-readable form.
 /// Port of Python's `display_stack_list`. No colour codes — we
 /// keep it plain so log scrapers don't have to strip ANSI; users
@@ -2080,42 +2105,25 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 };
                 let remote = &trunk.0;
 
-                let slug = mergify_stack::stack_context::resolve_repo(
-                    None,
-                    opts.repository.as_deref(),
-                    remote,
-                )?;
-
-                // Author: explicit wins; else GET /user.
-                let author = if let Some(a) = opts.author.as_deref() {
-                    a.to_string()
+                // This machine's stack prefix, needed only to name
+                // the local branch and to spot a stack that isn't
+                // ours. Skipped entirely when `--branch` already
+                // names the branch, so the `/user` call it may
+                // need doesn't happen for nothing.
+                let local_stack_prefix = if opts.branch.is_some() {
+                    None
                 } else {
-                    let user_payload: serde_json::Value = client.get("/user").await?;
-                    user_payload
-                        .get("login")
-                        .and_then(serde_json::Value::as_str)
-                        .map(str::to_owned)
-                        .ok_or_else(|| {
-                            mergify_core::CliError::GitHubApi(
-                                "/user response missing `login`".to_string(),
-                            )
-                        })?
+                    Some(resolve_local_stack_prefix(&client).await?)
                 };
-
-                let branch_prefix = opts.branch_prefix.unwrap_or_else(|| {
-                    mergify_stack::stack_context::resolve_default_branch_prefix(None, &author)
-                });
 
                 let outcome = mergify_stack::commands::checkout::run(
                     &mergify_stack::commands::checkout::Options {
                         repo_dir: None,
                         client: &client,
-                        user: &slug.owner,
-                        repo: &slug.repo,
-                        author: &author,
-                        branch_prefix: &branch_prefix,
-                        name: &opts.name,
+                        repository: opts.repository.as_deref(),
+                        target: &opts.target,
                         local_branch: opts.branch.as_deref(),
+                        local_stack_prefix: local_stack_prefix.as_deref(),
                         remote,
                         dry_run: opts.dry_run,
                     },
@@ -2136,8 +2144,10 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                         created,
                         local_branch,
                         upstream,
+                        stack_branch,
+                        under_local_prefix,
                     } => {
-                        println!("Stacked pull requests:");
+                        println!("Stacked pull requests on '{stack_branch}':");
                         for pr in &chain {
                             println!(
                                 "* #{n} {title}  {url}",
@@ -2150,6 +2160,26 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                         if created {
                             println!(
                                 "Checked out '{local_branch}' tracking {upstream}",
+                            );
+                        } else {
+                            // Dry-run: name the branch it would
+                            // create, since that's half of what
+                            // there is to preview.
+                            println!(
+                                "Would check out '{local_branch}' tracking {upstream}",
+                            );
+                        }
+                        if !under_local_prefix {
+                            // Every other stack command scopes
+                            // itself to your own prefix and login,
+                            // so pushing from here would open a
+                            // second, parallel set of PRs rather
+                            // than update these ones.
+                            println!(
+                                "Note: '{stack_branch}' is not under your stack branch prefix. \
+                                 You can work on these commits, but 'mergify stack push' from \
+                                 '{local_branch}' would create a separate stack rather than \
+                                 update these pull requests.",
                             );
                         }
                         Ok(mergify_core::ExitCode::Success)
@@ -2617,7 +2647,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                     &opts.user,
                     &opts.repo,
                     &opts.stack_prefix,
-                    &opts.author,
+                    Some(opts.author.as_str()),
                 )
                 .await?;
                 let json = serde_json::to_string(&changes).map_err(|e| {
@@ -2842,10 +2872,11 @@ enum StackSubcommand {
     Squash(StackSquashCli),
     /// Check out a pull request stack from GitHub.
     ///
-    /// Fetch a stack of pull requests by name and create a local branch
-    /// that tracks its leaf, so you can continue working on a stack
-    /// created elsewhere (a teammate's, or your own from another
-    /// machine).
+    /// Identify the stack by its remote branch name, or by the URL of any
+    /// pull request in it — the middle of the stack works as well as the
+    /// tip. Creates a local branch tracking the stack's leaf, so you can
+    /// continue working on a stack created elsewhere (a teammate's, or
+    /// your own from another machine).
     Checkout(StackCheckoutCli),
     /// Sync the stack with its trunk.
     ///
@@ -3150,24 +3181,21 @@ struct StackSquashCli {
 
 #[derive(clap::Args)]
 struct StackCheckoutCli {
-    /// Name of the stack to check out.
-    name: String,
-
-    /// Author of the stack. Defaults to the token's user.
-    #[arg(long)]
-    author: Option<String>,
+    /// Stack to check out: its remote branch name, or the URL of
+    /// any pull request in it.
+    target: String,
 
     /// `owner/repo`. Falls back to the URL of `--trunk`'s remote.
+    /// Ignored when the target is a pull request URL, which
+    /// carries its own.
     #[arg(long = "repository", alias = "repo")]
     repository: Option<String>,
 
-    /// Local branch name. Defaults to the normalised NAME.
+    /// Local branch name. Defaults to the stack branch minus your
+    /// own stack branch prefix, or to its last segment when the
+    /// stack isn't under that prefix.
     #[arg(long)]
     branch: Option<String>,
-
-    /// Override the stack branch prefix.
-    #[arg(long = "branch-prefix")]
-    branch_prefix: Option<String>,
 
     /// Show the plan without checking out.
     #[arg(short = 'n', long = "dry-run", action = clap::ArgAction::SetTrue)]
@@ -3187,11 +3215,9 @@ struct StackCheckoutCli {
 impl From<StackCheckoutCli> for StackCheckoutOpts {
     fn from(cli: StackCheckoutCli) -> Self {
         Self {
-            name: cli.name,
-            author: cli.author,
+            target: cli.target,
             repository: cli.repository,
             branch: cli.branch,
-            branch_prefix: cli.branch_prefix,
             dry_run: cli.dry_run,
             trunk: cli.trunk,
             token: cli.token,

--- a/crates/mergify-cli/src/snapshots/mergify__tests__cli_schema_golden.snap
+++ b/crates/mergify-cli/src/snapshots/mergify__tests__cli_schema_golden.snap
@@ -2942,47 +2942,29 @@ expression: schema
                 "default": null,
                 "env": null,
                 "global": false,
-                "help": "Name of the stack to check out",
-                "id": "name",
+                "help": "Stack to check out: its remote branch name, or the URL of any pull request in it",
+                "id": "target",
                 "kind": "positional",
                 "long": null,
-                "longHelp": "Name of the stack to check out",
+                "longHelp": "Stack to check out: its remote branch name, or the URL of any pull request in it",
                 "numArgs": "1",
                 "possibleValues": [],
                 "required": true,
                 "short": null,
                 "valueHint": null,
                 "valueNames": [
-                  "NAME"
+                  "TARGET"
                 ]
               },
               {
                 "default": null,
                 "env": null,
                 "global": false,
-                "help": "Author of the stack. Defaults to the token's user",
-                "id": "author",
-                "kind": "option",
-                "long": "author",
-                "longHelp": "Author of the stack. Defaults to the token's user",
-                "numArgs": "1",
-                "possibleValues": [],
-                "required": false,
-                "short": null,
-                "valueHint": null,
-                "valueNames": [
-                  "AUTHOR"
-                ]
-              },
-              {
-                "default": null,
-                "env": null,
-                "global": false,
-                "help": "`owner/repo`. Falls back to the URL of `--trunk`'s remote",
+                "help": "`owner/repo`. Falls back to the URL of `--trunk`'s remote. Ignored when the target is a pull request URL, which carries its own",
                 "id": "repository",
                 "kind": "option",
                 "long": "repository",
-                "longHelp": "`owner/repo`. Falls back to the URL of `--trunk`'s remote",
+                "longHelp": "`owner/repo`. Falls back to the URL of `--trunk`'s remote. Ignored when the target is a pull request URL, which carries its own",
                 "numArgs": "1",
                 "possibleValues": [],
                 "required": false,
@@ -2996,11 +2978,11 @@ expression: schema
                 "default": null,
                 "env": null,
                 "global": false,
-                "help": "Local branch name. Defaults to the normalised NAME",
+                "help": "Local branch name. Defaults to the stack branch minus your own stack branch prefix, or to its last segment when the stack isn't under that prefix",
                 "id": "branch",
                 "kind": "option",
                 "long": "branch",
-                "longHelp": "Local branch name. Defaults to the normalised NAME",
+                "longHelp": "Local branch name. Defaults to the stack branch minus your own stack branch prefix, or to its last segment when the stack isn't under that prefix",
                 "numArgs": "1",
                 "possibleValues": [],
                 "required": false,
@@ -3008,24 +2990,6 @@ expression: schema
                 "valueHint": null,
                 "valueNames": [
                   "BRANCH"
-                ]
-              },
-              {
-                "default": null,
-                "env": null,
-                "global": false,
-                "help": "Override the stack branch prefix",
-                "id": "branch_prefix",
-                "kind": "option",
-                "long": "branch-prefix",
-                "longHelp": "Override the stack branch prefix",
-                "numArgs": "1",
-                "possibleValues": [],
-                "required": false,
-                "short": null,
-                "valueHint": null,
-                "valueNames": [
-                  "BRANCH_PREFIX"
                 ]
               },
               {
@@ -3082,7 +3046,7 @@ expression: schema
               }
             ],
             "commands": [],
-            "longAbout": "Check out a pull request stack from GitHub.\n\nFetch a stack of pull requests by name and create a local branch that tracks its leaf, so you can continue working on a stack created elsewhere (a teammate's, or your own from another machine).",
+            "longAbout": "Check out a pull request stack from GitHub.\n\nIdentify the stack by its remote branch name, or by the URL of any pull request in it — the middle of the stack works as well as the tip. Creates a local branch tracking the stack's leaf, so you can continue working on a stack created elsewhere (a teammate's, or your own from another machine).",
             "name": "checkout",
             "path": [
               "mergify",
@@ -3091,7 +3055,7 @@ expression: schema
             ],
             "source": "native",
             "subcommandRequired": false,
-            "usage": "mergify stack checkout [OPTIONS] <NAME>"
+            "usage": "mergify stack checkout [OPTIONS] <TARGET>"
           },
           {
             "about": "Sync the stack with its trunk",

--- a/crates/mergify-stack/src/change_id.rs
+++ b/crates/mergify-stack/src/change_id.rs
@@ -49,11 +49,30 @@ static SHORT_CHANGEID_RE: LazyLock<Regex> =
 static BRANCH_SUFFIX_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(&format!(r"/{CHANGEID_LOOSE_PATTERN}$")).unwrap());
 
-/// Strip a trailing `/Ixxxx…` Change-Id suffix from a branch
-/// name. Returns the input unchanged when there's no match.
+/// Strip a trailing Change-Id segment from a stack branch name,
+/// in either naming scheme: the legacy `/Ixxxx…` suffix or the
+/// current `/<slug>--xxxxxxxx` one. Returns the input unchanged
+/// when the last segment isn't a Change-Id segment — including
+/// when it's the *only* segment, since a branch name has to keep
+/// at least one.
+///
+/// This is what lets `stack checkout` accept a leaf branch ref
+/// (or a PR head ref) pasted verbatim and resolve it to the stack
+/// stem the rest of the stack hangs off.
 #[must_use]
 pub fn strip_branch_suffix(name: &str) -> String {
-    BRANCH_SUFFIX_RE.replace(name, "").into_owned()
+    // The legacy form goes through the loose pattern on purpose —
+    // a malformed `I<40 non-hex>` segment is still a suffix the
+    // user meant to paste, and dropping it beats searching for a
+    // stack branch that can't exist.
+    let stripped = BRANCH_SUFFIX_RE.replace(name, "");
+    if stripped != name {
+        return stripped.into_owned();
+    }
+    match name.rsplit_once('/') {
+        Some((stem, last)) if SHORT_CHANGEID_RE.is_match(last) => stem.to_string(),
+        _ => name.to_string(),
+    }
 }
 
 /// Return `true` if `value` is a strict, full-form Change-Id
@@ -210,5 +229,36 @@ mod tests {
         // Has the right shape but wrong length on the short tail.
         assert_eq!(extract_from_branch_segment("slug--abcd123"), None);
         assert_eq!(extract_from_branch_segment("slug--abcd12345"), None);
+    }
+
+    #[test]
+    fn strip_branch_suffix_removes_legacy_full_changeid_segment() {
+        assert_eq!(
+            strip_branch_suffix("stack/a/my-branch/I0123456789abcdef0123456789abcdef01234567"),
+            "stack/a/my-branch",
+        );
+    }
+
+    #[test]
+    fn strip_branch_suffix_removes_new_style_short_changeid_segment() {
+        // `stack push` names branches `<stack>/<slug>--<8 hex>`;
+        // pasting such a leaf ref into `stack checkout` must
+        // resolve to the stack stem, not to the leaf itself.
+        assert_eq!(
+            strip_branch_suffix("stack/a/my-branch/feat-a--abcd1234"),
+            "stack/a/my-branch",
+        );
+    }
+
+    #[test]
+    fn strip_branch_suffix_leaves_plain_branches_untouched() {
+        assert_eq!(
+            strip_branch_suffix("stack/a/my-branch"),
+            "stack/a/my-branch"
+        );
+        assert_eq!(strip_branch_suffix("my-feature"), "my-feature");
+        // A single segment that *is* a change-id segment is the
+        // whole branch name — nothing left to strip down to.
+        assert_eq!(strip_branch_suffix("feat-a--abcd1234"), "feat-a--abcd1234");
     }
 }

--- a/crates/mergify-stack/src/commands/checkout.rs
+++ b/crates/mergify-stack/src/commands/checkout.rs
@@ -1,21 +1,33 @@
-//! `mergify stack checkout <NAME>` — fetch a stack of pull
-//! requests from GitHub and create a local branch tracking the
-//! leaf head.
+//! `mergify stack checkout <BRANCH|PR_URL>` — fetch a stack of
+//! pull requests from GitHub and create a local branch tracking
+//! the leaf head.
 //!
-//! Port of `mergify_cli/stack/checkout.py::stack_checkout`. The
-//! flow:
+//! The target is whatever identifies the stack on GitHub:
 //!
-//! 1. Resolve author (falls back to `GET /user`).
-//! 2. Normalise the user-supplied `NAME` — strip any trailing
-//!    `/Ixxxx…` Change-Id suffix and any leading
-//!    `<branch_prefix>/` so users can paste a branch ref verbatim.
-//! 3. Search GitHub for the stack's PRs (via
-//!    [`crate::remote_changes::get_remote_changes`]).
-//! 4. Link open PRs into a single chain via their `head.ref` →
+//! - a **stack branch**, exactly as it exists on the remote
+//!   (`stack/jd/my-feature`, `mystacks/foo`, `feature-x`, …). A
+//!   leaf ref pasted verbatim works too — the trailing Change-Id
+//!   segment gets stripped back to the stack stem.
+//! - a **pull-request URL**, from any position in the stack. The
+//!   PR's `head.ref` yields the stack branch, so a URL grabbed
+//!   from the middle of a stack still checks out the whole thing.
+//!
+//! Nothing is derived from a user login. Other people's stacks,
+//! and stacks under a branch prefix with no author in it, are as
+//! reachable as your own.
+//!
+//! The flow:
+//!
+//! 1. Resolve the target into a stack branch (+ `owner/repo`,
+//!    which a PR URL carries).
+//! 2. Search GitHub for the stack's PRs (via
+//!    [`crate::remote_changes::get_remote_changes`], with no
+//!    `author:` filter — a branch name is unique within a repo).
+//! 3. Link open PRs into a single chain via their `head.ref` →
 //!    `base.ref` pointers, find the root (the PR whose `base.ref`
 //!    is *outside* the stack — i.e. doesn't start with the stack
 //!    branch prefix), walk up to the leaf.
-//! 5. Print the chain. When not `--dry-run`, `git fetch` the leaf
+//! 4. Print the chain. When not `--dry-run`, `git fetch` the leaf
 //!    head, `git checkout -b <local>` on it, set upstream
 //!    tracking to the root's base.
 
@@ -26,6 +38,7 @@ use crate::git::run_git_silent as run_git;
 use mergify_core::CliError;
 use mergify_core::HttpClient;
 use serde_json::Value;
+use url::Url;
 
 use crate::change_id;
 use crate::remote_changes::{self, RemoteChange};
@@ -50,25 +63,116 @@ pub enum Outcome {
         created: bool,
         local_branch: String,
         upstream: String,
+        /// The remote stack branch the target resolved to. Worth
+        /// echoing back: when the target was a PR URL, the user
+        /// never typed it.
+        stack_branch: String,
+        /// Whether the stack sits under this machine's stack
+        /// branch prefix. When it doesn't, the other stack
+        /// commands — which still scope themselves to the local
+        /// user's own prefix and login — won't reach these pull
+        /// requests from the branch just created.
+        under_local_prefix: bool,
     },
     NoStackedPrs,
+}
+
+/// What the user pointed `stack checkout` at.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Target {
+    /// A stack branch, already stripped of any trailing Change-Id
+    /// segment.
+    Branch(String),
+    /// A pull request, identified by the `<owner>/<repo>/pull/<n>`
+    /// part of its URL. The host is deliberately ignored — requests
+    /// go to the configured API endpoint either way, and demanding
+    /// a match would only reject working input on the GHES setups
+    /// where the web host and the API host differ.
+    Pull {
+        owner: String,
+        repo: String,
+        number: u64,
+    },
+}
+
+/// Classify the raw CLI argument.
+///
+/// An `http(s)://` target has to be a pull request URL — letting a
+/// wrong one through as a "branch" would only produce a baffling
+/// "no stacked PRs" further down. A schemeless target is read as a
+/// pull request URL too when it carries a host-looking first
+/// segment (`github.com/o/r/pull/12`, what a copied chat link
+/// usually looks like); anything else is a branch name.
+pub fn parse_target(raw: &str) -> Result<Target, CliError> {
+    let invalid = || {
+        CliError::InvalidState(format!(
+            "`{raw}` is not a pull request URL — expected `http(s)://<host>/<owner>/<repo>/pull/<number>`",
+        ))
+    };
+
+    if raw.starts_with("https://") || raw.starts_with("http://") {
+        let url = Url::parse(raw).map_err(|_| invalid())?;
+        let segments: Vec<&str> = url
+            .path_segments()
+            .map(Iterator::collect)
+            .unwrap_or_default();
+        // A scheme is an unambiguous "this is a URL", so a shape
+        // that doesn't match is an error rather than a branch.
+        return match_pull(&segments).ok_or_else(invalid);
+    }
+
+    // Trailing slashes come from shell completion on a remote ref;
+    // left in place they'd survive into an empty final segment.
+    let raw = raw.trim_end_matches('/');
+    // `<host>/<owner>/<repo>/pull/<n>` — the leading dot-bearing
+    // segment is what separates a pasted link from a branch that
+    // merely contains a `pull` segment.
+    if let [host, rest @ ..] = raw.split('/').collect::<Vec<_>>().as_slice()
+        && host.contains('.')
+        && let Some(target) = match_pull(rest)
+    {
+        return Ok(target);
+    }
+    Ok(Target::Branch(change_id::strip_branch_suffix(raw)))
+}
+
+/// Match `<owner>/<repo>/pull/<number>` at the head of `segments`.
+/// Trailing segments (`/files`, `/commits/<sha>`, …) and any
+/// fragment are what a browser address bar hands you, so they are
+/// matched past and ignored.
+fn match_pull(segments: &[&str]) -> Option<Target> {
+    match segments {
+        [owner, repo, "pull", number, ..] if !owner.is_empty() && !repo.is_empty() => {
+            Some(Target::Pull {
+                owner: (*owner).to_string(),
+                repo: (*repo).to_string(),
+                number: number.parse().ok()?,
+            })
+        }
+        _ => None,
+    }
 }
 
 pub struct Options<'a> {
     pub repo_dir: Option<&'a Path>,
     pub client: &'a HttpClient,
-    pub user: &'a str,
-    pub repo: &'a str,
-    pub author: &'a str,
-    /// `Some(prefix)` when the user passed `--branch-prefix`; the
-    /// caller resolves the default (`stack/<author>` or the git
-    /// config override) via [`crate::stack_context::resolve_default_branch_prefix`].
-    pub branch_prefix: &'a str,
-    /// Raw `NAME` argument from the CLI. Normalised inside [`run`].
-    pub name: &'a str,
-    /// Local branch name override. `None` defaults to the
-    /// normalised remote stack name.
+    /// `--repository` override, in `owner/repo` form. `None` reads
+    /// the remote's URL. Consulted only for a branch target — a PR
+    /// URL carries its own owner and repo, and resolving the local
+    /// remote for it could fail on a repository that has nothing to
+    /// do with the target.
+    pub repository: Option<&'a str>,
+    /// Raw target argument from the CLI — a stack branch or a pull
+    /// request URL. Classified by [`parse_target`].
+    pub target: &'a str,
+    /// Local branch name override. `None` derives one from the
+    /// stack branch — see [`derive_local_branch`].
     pub local_branch: Option<&'a str>,
+    /// This machine's stack branch prefix, as the other stack
+    /// commands would compute it. Used only to name the local
+    /// branch, and to tell a stack of your own from someone
+    /// else's; `None` when the caller couldn't determine one.
+    pub local_stack_prefix: Option<&'a str>,
     /// Remote name to fetch from — typically `origin`. Comes from
     /// the trunk's first segment.
     pub remote: &'a str,
@@ -76,30 +180,19 @@ pub struct Options<'a> {
 }
 
 pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
-    // Normalise the stack name. Python:
-    //   name = changes.CHANGEID_SUFFIX_RE.sub("", name)
-    //   if branch_prefix and name.startswith(f"{branch_prefix}/"):
-    //       name = name.removeprefix(f"{branch_prefix}/")
-    let mut name = change_id::strip_branch_suffix(opts.name);
-    let prefix_with_slash = format!("{}/", opts.branch_prefix);
-    if !opts.branch_prefix.is_empty() && name.starts_with(&prefix_with_slash) {
-        name = name[prefix_with_slash.len()..].to_string();
-    }
-    let local_branch = opts.local_branch.unwrap_or(&name).to_string();
-    let stack_branch = if opts.branch_prefix.is_empty() {
-        name.clone()
-    } else {
-        format!("{}/{}", opts.branch_prefix, name)
+    let (owner, repo, stack_branch) = resolve_stack_branch(opts).await?;
+
+    let below_prefix = opts
+        .local_stack_prefix
+        .and_then(|prefix| stack_branch.strip_prefix(&format!("{prefix}/")));
+    let under_local_prefix = below_prefix.is_some();
+    let local_branch = match opts.local_branch {
+        Some(branch) => branch.to_string(),
+        None => derive_local_branch(&stack_branch, below_prefix),
     };
 
-    let remote_changes = remote_changes::get_remote_changes(
-        opts.client,
-        opts.user,
-        opts.repo,
-        &stack_branch,
-        opts.author,
-    )
-    .await?;
+    let remote_changes =
+        remote_changes::get_remote_changes(opts.client, &owner, &repo, &stack_branch, None).await?;
 
     let chain = build_chain(&remote_changes, &stack_branch)?;
     if chain.is_empty() {
@@ -118,6 +211,8 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
             created: false,
             local_branch,
             upstream,
+            stack_branch,
+            under_local_prefix,
         });
     }
 
@@ -134,7 +229,69 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         created: true,
         local_branch,
         upstream,
+        stack_branch,
+        under_local_prefix,
     })
+}
+
+/// Name the local branch for a stack branch the user didn't name
+/// one for.
+///
+/// `below_prefix` is what's left of the stack branch after this
+/// machine's stack prefix — `Some` only when the stack sits under
+/// it. That remainder is the branch the stack was pushed from, and
+/// restoring it exactly is what lets a later `stack push` find the
+/// same stack instead of opening a duplicate set of pull requests:
+/// push recomposes `<prefix>/<branch>`, so a multi-segment name
+/// like `feature/login` has to survive whole.
+///
+/// Without that (someone else's stack, or no prefix to compare
+/// against) there's no way to tell where the prefix ends, and the
+/// last segment is the closest thing to the name a human chose.
+fn derive_local_branch(stack_branch: &str, below_prefix: Option<&str>) -> String {
+    below_prefix.map_or_else(
+        || {
+            stack_branch
+                .rsplit('/')
+                .next()
+                .unwrap_or(stack_branch)
+                .to_string()
+        },
+        ToString::to_string,
+    )
+}
+
+/// Turn the raw target into `(owner, repo, stack_branch)`. A PR
+/// URL costs one extra request and names its own repository; a
+/// branch target resolves the local one, which is why that lookup
+/// happens here and not before the target is classified.
+async fn resolve_stack_branch(opts: &Options<'_>) -> Result<(String, String, String), CliError> {
+    let (owner, repo, stack_branch) = match parse_target(opts.target)? {
+        Target::Branch(branch) => {
+            let slug =
+                crate::stack_context::resolve_repo(opts.repo_dir, opts.repository, opts.remote)?;
+            (slug.owner, slug.repo, branch)
+        }
+        Target::Pull {
+            owner,
+            repo,
+            number,
+        } => {
+            let pull: Value = opts
+                .client
+                .get(&format!("/repos/{owner}/{repo}/pulls/{number}"))
+                .await?;
+            let head_ref = pull_field(&pull, "head", "ref")?;
+            let stack_branch = change_id::strip_branch_suffix(&head_ref);
+            (owner, repo, stack_branch)
+        }
+    };
+    if stack_branch.is_empty() {
+        return Err(CliError::InvalidState(
+            "empty stack branch — pass the stack's branch name or a pull request URL".to_string(),
+        ));
+    }
+    Ok((owner, repo, stack_branch))
 }
 
 /// Walk the remote-changes graph and return the open-PR chain
@@ -323,11 +480,9 @@ mod tests {
         let outcome = run(&Options {
             repo_dir: None,
             client: &client,
-            user: "user",
-            repo: "repo",
-            author: "author",
-            branch_prefix: "stack/author",
-            name: "my-branch",
+            repository: Some("user/repo"),
+            local_stack_prefix: None,
+            target: "stack/author/my-branch",
             local_branch: None,
             remote: "origin",
             dry_run: true,
@@ -392,11 +547,9 @@ mod tests {
         let outcome = run(&Options {
             repo_dir: None,
             client: &client,
-            user: "user",
-            repo: "repo",
-            author: "author",
-            branch_prefix: "stack/author",
-            name: "my-branch",
+            repository: Some("user/repo"),
+            local_stack_prefix: None,
+            target: "stack/author/my-branch",
             local_branch: None,
             remote: "origin",
             dry_run: true,
@@ -409,6 +562,7 @@ mod tests {
                 created,
                 local_branch,
                 upstream,
+                ..
             } => {
                 let nums: Vec<u64> = chain.iter().map(|p| p.number).collect();
                 assert_eq!(nums, [1, 2]);
@@ -421,11 +575,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_strips_changeid_suffix_and_branch_prefix_from_name() {
-        // The user pastes a leaf branch name with both the
-        // `<prefix>/` prefix and a trailing `/I<40hex>` suffix.
-        // We expect the search to be issued against the stem
-        // `stack/author/my-branch`.
+    async fn run_strips_changeid_suffix_from_a_pasted_leaf_ref() {
+        // The user pastes a leaf branch ref verbatim, current
+        // `<slug>--<8 hex>` naming included. The search has to be
+        // issued against the stack stem, not the leaf.
         use mergify_core::ApiFlavor;
         use url::Url;
         use wiremock::matchers::{method, path, query_param_contains};
@@ -451,11 +604,9 @@ mod tests {
         let outcome = run(&Options {
             repo_dir: None,
             client: &client,
-            user: "user",
-            repo: "repo",
-            author: "author",
-            branch_prefix: "stack/author",
-            name: "stack/author/my-branch/Iaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            repository: Some("user/repo"),
+            local_stack_prefix: None,
+            target: "stack/author/my-branch/feat-b--bbbbbbbb",
             local_branch: None,
             remote: "origin",
             dry_run: true,
@@ -463,5 +614,344 @@ mod tests {
         .await
         .unwrap();
         assert!(matches!(outcome, Outcome::NoStackedPrs));
+    }
+
+    #[test]
+    fn parse_target_reads_owner_repo_and_number_from_a_pull_url() {
+        assert_eq!(
+            parse_target("https://github.com/Mergifyio/mergify-cli/pull/1774").unwrap(),
+            Target::Pull {
+                owner: "Mergifyio".to_string(),
+                repo: "mergify-cli".to_string(),
+                number: 1774,
+            },
+        );
+    }
+
+    #[test]
+    fn parse_target_accepts_a_pull_url_with_tab_suffix_and_fragment() {
+        // What you get from a browser address bar mid-review.
+        assert_eq!(
+            parse_target("https://github.com/o/r/pull/12/files#diff-abc").unwrap(),
+            Target::Pull {
+                owner: "o".to_string(),
+                repo: "r".to_string(),
+                number: 12,
+            },
+        );
+    }
+
+    #[test]
+    fn parse_target_accepts_a_pull_url_on_an_enterprise_host() {
+        assert_eq!(
+            parse_target("https://ghe.example.com/o/r/pull/7").unwrap(),
+            Target::Pull {
+                owner: "o".to_string(),
+                repo: "r".to_string(),
+                number: 7,
+            },
+        );
+    }
+
+    #[test]
+    fn parse_target_treats_anything_else_as_a_branch_and_strips_the_changeid() {
+        assert_eq!(
+            parse_target("stack/author/my-branch/feat-b--bbbbbbbb").unwrap(),
+            Target::Branch("stack/author/my-branch".to_string()),
+        );
+        assert_eq!(
+            parse_target("my-feature").unwrap(),
+            Target::Branch("my-feature".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_target_accepts_a_pull_url_pasted_without_its_scheme() {
+        // Copying a PR link out of a chat message routinely loses
+        // the scheme. Treating it as a branch would search for a
+        // stack that cannot exist and report "no stacked PRs".
+        assert_eq!(
+            parse_target("github.com/Mergifyio/mergify-cli/pull/1774").unwrap(),
+            Target::Pull {
+                owner: "Mergifyio".to_string(),
+                repo: "mergify-cli".to_string(),
+                number: 1774,
+            },
+        );
+    }
+
+    #[test]
+    fn parse_target_keeps_a_branch_whose_segments_merely_resemble_a_pull_url() {
+        // No host-looking first segment, so this is a branch that
+        // happens to contain `pull`, not a URL.
+        assert_eq!(
+            parse_target("team/repo/pull/12").unwrap(),
+            Target::Branch("team/repo/pull/12".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_target_trims_trailing_slashes_from_a_branch() {
+        // Shell tab-completion on a remote ref adds the slash. It
+        // would otherwise survive into an empty last segment and
+        // make `git checkout -b ''` fail with a git-level error.
+        assert_eq!(
+            parse_target("stack/author/my-branch/").unwrap(),
+            Target::Branch("stack/author/my-branch".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_target_rejects_a_url_that_is_not_a_pull_request() {
+        // Treating this as a branch name would send the user into
+        // a confusing "no stacked PRs" instead of naming the
+        // mistake.
+        let err = parse_target("https://github.com/o/r/issues/12").unwrap_err();
+        match err {
+            CliError::InvalidState(msg) => assert!(msg.contains("pull request URL"), "got: {msg}"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_checks_out_the_whole_stack_from_a_middle_pull_url() {
+        // A PR URL from the middle of a three-PR stack must yield
+        // the full root→leaf chain, not just that PR and below.
+        use mergify_core::ApiFlavor;
+        use url::Url;
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        fn pr_body(number: u64, base: &str, head: &str) -> serde_json::Value {
+            serde_json::json!({
+                "number": number,
+                "title": format!("feat: {number}"),
+                "html_url": format!("https://github.com/user/repo/pull/{number}"),
+                "state": "open",
+                "base": {"ref": base},
+                "head": {"ref": head},
+                "merged_at": null,
+            })
+        }
+
+        let stack = "stack/author/my-branch";
+        let heads = [
+            format!("{stack}/feat-a--aaaaaaaa"),
+            format!("{stack}/feat-b--bbbbbbbb"),
+            format!("{stack}/feat-c--cccccccc"),
+        ];
+        let bodies = [
+            pr_body(1, "main", &heads[0]),
+            pr_body(2, &heads[0], &heads[1]),
+            pr_body(3, &heads[1], &heads[2]),
+        ];
+
+        let server = MockServer::start().await;
+        // No `author:` qualifier — checkout reaches anyone's stack.
+        Mock::given(method("GET"))
+            .and(path("/search/issues"))
+            .and(query_param(
+                "q",
+                "repo:user/repo is:pull-request head:stack/author/my-branch/",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "items": [{"number": 1}, {"number": 2}, {"number": 3}],
+            })))
+            .mount(&server)
+            .await;
+        for (i, body) in bodies.iter().enumerate() {
+            Mock::given(method("GET"))
+                .and(path(format!("/repos/user/repo/pulls/{}", i + 1)))
+                .respond_with(ResponseTemplate::new(200).set_body_json(body.clone()))
+                .mount(&server)
+                .await;
+        }
+
+        let client = HttpClient::new(
+            Url::parse(&server.uri()).unwrap(),
+            "tok".to_string(),
+            ApiFlavor::GitHub,
+        )
+        .unwrap();
+
+        let outcome = run(&Options {
+            repo_dir: None,
+            client: &client,
+            // Deliberately wrong — the PR URL's owner/repo wins.
+            repository: Some("somebody-else/other-repo"),
+            local_stack_prefix: None,
+            target: "https://github.com/user/repo/pull/2",
+            local_branch: None,
+            remote: "origin",
+            dry_run: true,
+        })
+        .await
+        .unwrap();
+
+        match outcome {
+            Outcome::CheckedOut {
+                chain,
+                local_branch,
+                upstream,
+                stack_branch,
+                ..
+            } => {
+                let nums: Vec<u64> = chain.iter().map(|p| p.number).collect();
+                assert_eq!(nums, [1, 2, 3]);
+                assert_eq!(stack_branch, stack);
+                // Local branch defaults to the stack's last segment.
+                assert_eq!(local_branch, "my-branch");
+                assert_eq!(upstream, "origin/main");
+            }
+            Outcome::NoStackedPrs => panic!("unexpected NoStackedPrs"),
+        }
+    }
+
+    /// Mount a two-PR stack under `stack_branch` and return the
+    /// client pointed at it. The server has to outlive the call,
+    /// so it comes back with the client.
+    async fn stack_server(stack_branch: &str) -> (wiremock::MockServer, HttpClient) {
+        use mergify_core::ApiFlavor;
+        use url::Url;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let heads = [
+            format!("{stack_branch}/feat-a--aaaaaaaa"),
+            format!("{stack_branch}/feat-b--bbbbbbbb"),
+        ];
+        let bodies = [
+            serde_json::json!({
+                "number": 1, "title": "feat: A", "state": "open",
+                "html_url": "https://github.com/user/repo/pull/1",
+                "base": {"ref": "main"}, "head": {"ref": heads[0]}, "merged_at": null,
+            }),
+            serde_json::json!({
+                "number": 2, "title": "feat: B", "state": "open",
+                "html_url": "https://github.com/user/repo/pull/2",
+                "base": {"ref": heads[0]}, "head": {"ref": heads[1]}, "merged_at": null,
+            }),
+        ];
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search/issues"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "items": [{"number": 1}, {"number": 2}],
+            })))
+            .mount(&server)
+            .await;
+        for (i, body) in bodies.iter().enumerate() {
+            Mock::given(method("GET"))
+                .and(path(format!("/repos/user/repo/pulls/{}", i + 1)))
+                .respond_with(ResponseTemplate::new(200).set_body_json(body.clone()))
+                .mount(&server)
+                .await;
+        }
+
+        let client = HttpClient::new(
+            Url::parse(&server.uri()).unwrap(),
+            "tok".to_string(),
+            ApiFlavor::GitHub,
+        )
+        .unwrap();
+        (server, client)
+    }
+
+    #[tokio::test]
+    async fn run_keeps_the_whole_branch_name_below_the_local_stack_prefix() {
+        // `stack new feature/login` pushes to
+        // `<prefix>/feature/login/…`. Checking that back out has to
+        // restore `feature/login` — a local branch of just `login`
+        // would make the next `stack push` compute
+        // `<prefix>/login`, match nothing, and open a duplicate set
+        // of pull requests for the same commits.
+        let (_server, client) = stack_server("devs/jd/feature/login").await;
+
+        let outcome = run(&Options {
+            repo_dir: None,
+            client: &client,
+            repository: Some("user/repo"),
+            local_stack_prefix: Some("devs/jd"),
+            target: "devs/jd/feature/login",
+            local_branch: None,
+            remote: "origin",
+            dry_run: true,
+        })
+        .await
+        .unwrap();
+
+        match outcome {
+            Outcome::CheckedOut {
+                local_branch,
+                under_local_prefix,
+                ..
+            } => {
+                assert_eq!(local_branch, "feature/login");
+                assert!(under_local_prefix);
+            }
+            Outcome::NoStackedPrs => panic!("unexpected NoStackedPrs"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_flags_a_stack_that_is_not_under_the_local_prefix() {
+        // Someone else's stack: there's no prefix to strip, so the
+        // last segment is the best local name — and `stack push`
+        // from it would not reach their pull requests, which the
+        // caller needs to be able to say.
+        let (_server, client) = stack_server("devs/alice/feat").await;
+
+        let outcome = run(&Options {
+            repo_dir: None,
+            client: &client,
+            repository: Some("user/repo"),
+            local_stack_prefix: Some("devs/jd"),
+            target: "devs/alice/feat",
+            local_branch: None,
+            remote: "origin",
+            dry_run: true,
+        })
+        .await
+        .unwrap();
+
+        match outcome {
+            Outcome::CheckedOut {
+                local_branch,
+                under_local_prefix,
+                ..
+            } => {
+                assert_eq!(local_branch, "feat");
+                assert!(!under_local_prefix);
+            }
+            Outcome::NoStackedPrs => panic!("unexpected NoStackedPrs"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_does_not_resolve_the_repository_for_a_pull_url_target() {
+        // A PR URL carries its own owner/repo, so an unparseable
+        // `--repository` must not be consulted at all.
+        let (_server, client) = stack_server("stack/author/my-branch").await;
+
+        let outcome = run(&Options {
+            repo_dir: None,
+            client: &client,
+            repository: Some("not-a-slug"),
+            local_stack_prefix: None,
+            target: "https://github.com/user/repo/pull/2",
+            local_branch: None,
+            remote: "origin",
+            dry_run: true,
+        })
+        .await
+        .unwrap();
+
+        match outcome {
+            Outcome::CheckedOut { stack_branch, .. } => {
+                assert_eq!(stack_branch, "stack/author/my-branch");
+            }
+            Outcome::NoStackedPrs => panic!("unexpected NoStackedPrs"),
+        }
     }
 }

--- a/crates/mergify-stack/src/commands/list.rs
+++ b/crates/mergify-stack/src/commands/list.rs
@@ -112,7 +112,7 @@ pub async fn run(opts: &Options<'_>) -> Result<StackListOutput, CliError> {
         opts.user,
         opts.repo,
         &stack_prefix,
-        opts.author,
+        Some(opts.author),
     )
     .await?;
     let local = local_commits::read(&repo_dir, &base_commit_sha, "HEAD")?;

--- a/crates/mergify-stack/src/commands/push.rs
+++ b/crates/mergify-stack/src/commands/push.rs
@@ -206,7 +206,7 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
         opts.user,
         opts.repo,
         &stack_prefix,
-        opts.author,
+        Some(opts.author),
         move |number| reading_writer.store(number, Ordering::Relaxed),
     );
     let (owner, repo_name) = (opts.user, opts.repo);

--- a/crates/mergify-stack/src/commands/sync.rs
+++ b/crates/mergify-stack/src/commands/sync.rs
@@ -104,7 +104,7 @@ pub async fn run(opts: &Options<'_>) -> Result<Outcome, CliError> {
                 opts.user,
                 opts.repo,
                 &stack_prefix,
-                opts.author,
+                Some(opts.author),
             )
             .await?
         }

--- a/crates/mergify-stack/src/remote_changes.rs
+++ b/crates/mergify-stack/src/remote_changes.rs
@@ -60,14 +60,17 @@ pub struct RemoteChange {
 /// `user` / `repo` form the search scope (`repo:user/repo`).
 /// `stack_prefix` filters the search to PRs whose head branch
 /// starts with `prefix/`. `author` restricts the search to PRs
-/// the current user opened (Mergify only manages PRs the local
-/// user owns).
+/// one user opened — `Some(me)` for the commands that only ever
+/// manage the local user's own stack, `None` for `stack checkout`,
+/// which has to reach anyone's stack. Branch names are unique
+/// within a repo, so the branch filter alone already pins the
+/// result set.
 pub async fn get_remote_changes(
     client: &Client,
     user: &str,
     repo: &str,
     stack_prefix: &str,
-    author: &str,
+    author: Option<&str>,
 ) -> Result<Vec<RemoteChange>, CliError> {
     get_remote_changes_reporting(client, user, repo, stack_prefix, author, |_| {}).await
 }
@@ -81,10 +84,13 @@ pub async fn get_remote_changes_reporting(
     user: &str,
     repo: &str,
     stack_prefix: &str,
-    author: &str,
+    author: Option<&str>,
     mut on_pull: impl FnMut(u64),
 ) -> Result<Vec<RemoteChange>, CliError> {
-    let q = format!("repo:{user}/{repo} author:{author} is:pull-request head:{stack_prefix}/");
+    // Omitted entirely rather than left empty when there's no
+    // author — GitHub rejects a bare `author:` qualifier.
+    let author_filter = author.map_or_else(String::new, |a| format!("author:{a} "));
+    let q = format!("repo:{user}/{repo} {author_filter}is:pull-request head:{stack_prefix}/");
     let search: SearchResponse = client
         .get_with_query(
             "/search/issues",
@@ -385,7 +391,7 @@ mod tests {
             ApiFlavor::GitHub,
         )
         .unwrap();
-        let got = get_remote_changes(&client, "user", "repo", "prefix", "author")
+        let got = get_remote_changes(&client, "user", "repo", "prefix", Some("author"))
             .await
             .unwrap();
 
@@ -394,5 +400,41 @@ mod tests {
         assert_eq!(got[0].pull["number"], 11);
         assert_eq!(got[1].change_id, "bbbbbbbb");
         assert_eq!(got[1].pull["number"], 22);
+    }
+
+    #[tokio::test]
+    async fn get_remote_changes_omits_author_filter_when_author_is_none() {
+        // `stack checkout` works on anyone's stack, so it searches
+        // the branch alone. The `author:` qualifier has to be
+        // absent entirely — an empty one (`author:`) is a search
+        // syntax error on GitHub's side.
+        use url::Url;
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search/issues"))
+            .and(query_param(
+                "q",
+                "repo:user/repo is:pull-request head:prefix/",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"items": []})),
+            )
+            .mount(&server)
+            .await;
+
+        let client = Client::new(
+            Url::parse(&server.uri()).unwrap(),
+            "tok".to_string(),
+            ApiFlavor::GitHub,
+        )
+        .unwrap();
+        let got = get_remote_changes(&client, "user", "repo", "prefix", None)
+            .await
+            .unwrap();
+
+        assert!(got.is_empty());
     }
 }

--- a/crates/mergify-stack/src/stack_context.rs
+++ b/crates/mergify-stack/src/stack_context.rs
@@ -204,21 +204,34 @@ pub fn resolve_github_server(repo_dir: Option<&Path>) -> Result<Url, CliError> {
     Ok(url)
 }
 
-/// Resolve the default branch prefix from
-/// `mergify-cli.stack-branch-prefix`, falling back to
-/// `stack/<author>`. Mirrors `utils.get_default_branch_prefix`.
+/// The explicitly configured `mergify-cli.stack-branch-prefix`,
+/// or `None` when the repo leaves it to the default.
+///
+/// Split out from [`resolve_default_branch_prefix`] for the caller
+/// that has no author to fall back on and would rather pay for a
+/// `GET /user` only when the config is silent.
 #[must_use]
-pub fn resolve_default_branch_prefix(repo_dir: Option<&Path>, author: &str) -> String {
+pub fn configured_branch_prefix(repo_dir: Option<&Path>) -> Option<String> {
     let configured = run_git_capture(
         repo_dir,
         &["config", "--get", "mergify-cli.stack-branch-prefix"],
     )
     .unwrap_or_default();
-    if configured.is_empty() {
-        format!("stack/{author}")
-    } else {
-        configured
-    }
+    (!configured.is_empty()).then_some(configured)
+}
+
+/// The branch prefix used when nothing is configured.
+#[must_use]
+pub fn default_branch_prefix(author: &str) -> String {
+    format!("stack/{author}")
+}
+
+/// Resolve the default branch prefix from
+/// `mergify-cli.stack-branch-prefix`, falling back to
+/// `stack/<author>`. Mirrors `utils.get_default_branch_prefix`.
+#[must_use]
+pub fn resolve_default_branch_prefix(repo_dir: Option<&Path>, author: &str) -> String {
+    configured_branch_prefix(repo_dir).unwrap_or_else(|| default_branch_prefix(author))
 }
 
 /// `mergify-cli.stack-create-as-draft`, defaulting to `false`.

--- a/skills/mergify-stack/SKILL.md
+++ b/skills/mergify-stack/SKILL.md
@@ -59,7 +59,8 @@ A branch is a stack. Keep stacks short and focused:
 mergify stack new NAME       # Create a new stack/branch for new work
 mergify stack push           # Push and create/update PRs
 mergify stack push --github-native  # ...and register it as a GitHub-native stack (opt-in)
-mergify stack checkout NAME  # Checkout an existing stack from GitHub (e.g. someone else's)
+mergify stack checkout BRANCH    # Checkout an existing stack from GitHub (e.g. someone else's)
+mergify stack checkout PR_URL    # Same, from any PR in the stack — middle included
 mergify stack sync           # Fetch trunk, remove merged commits, rebase
 mergify stack list           # Show commit <-> PR mapping for current stack
 mergify stack list --json    # Same, but machine-readable JSON output
@@ -83,7 +84,9 @@ mergify stack note --append -m "more"                  # Append to an existing n
 mergify stack note --remove                            # Remove the note from a commit
 ```
 
-Use `mergify stack checkout NAME` to check out a stack that exists on GitHub (e.g. a colleague's stack). NAME is the remote branch name of the stack. It fetches all stacked PRs, creates a local branch, and sets up tracking. Use `--branch` to override the local branch name.
+Use `mergify stack checkout` to check out a stack that exists on GitHub (e.g. a colleague's stack). The argument is either the stack's remote branch name — whatever prefix it uses, no assumption that it contains an author — or the URL of any pull request in the stack, including one from the middle. It fetches all stacked PRs, creates a local branch, and sets up tracking.
+
+The local branch defaults to the stack branch with your own stack branch prefix removed, so a stack you pushed from `feature/login` comes back as `feature/login` and a later `mergify stack push` updates the same PRs. For a stack that is not under your prefix — a colleague's — the last segment is used and checkout warns you: you can work on those commits, but `mergify stack push` from that branch would create a separate stack rather than update their pull requests. Use `--branch` to override the name. A pull request URL carries its own `owner/repo`, so `--repository` is ignored in that form.
 
 Use `mergify stack sync` to bring your stack up to date. It fetches the latest trunk, detects which PRs have been merged, removes those commits from your local branch, and rebases the remaining commits. Run this before starting new work on an existing stack.
 


### PR DESCRIPTION
`stack checkout` derived everything from a login: `--author`, or a
`GET /user` fallback, feeding both the `author:` search filter and a
`stack/<author>` branch prefix. That only works for stacks whose
branch prefix embeds an author — ours are `devs/<author>/…`, and
nothing forces a prefix to name anyone at all. Checking out a
colleague's stack, which the skill already advertised, meant knowing
to pass `--author` and getting the prefix to line up.

The argument is now the stack itself:

- a remote branch name, whatever prefix it uses, with a leaf ref
  pasted verbatim resolving back to the stem;
- or the URL of any pull request in the stack, with or without its
  scheme. Its `head.ref` gives the stack branch, so a URL from the
  middle checks out the whole stack, and the owner/repo in the URL
  win over `--repository` — which is no longer resolved at all for
  that form, so an unparseable remote can't fail a checkout that
  never needed it.

The search drops the `author:` qualifier — a branch name is unique
within a repo, so the branch filter alone already pins the result set.
`get_remote_changes` takes `Option<&str>` for it; push, sync and list
keep passing their own login, since those genuinely only ever manage
the local user's stack.

Removes `--author` and `--branch-prefix` from `stack checkout`; the
prefix is part of the branch name now. Your own prefix is still read,
but only to name the local branch: the stack branch minus that prefix,
so a stack pushed from `feature/login` comes back as `feature/login`
and the next push updates the same pull requests instead of opening a
parallel set. A stack that isn't under your prefix falls back to the
last segment and says so, because the rest of the stack commands still
scope themselves to your own login and prefix and would not reach
those pull requests. Reading the prefix costs a `GET /user` only when
`mergify-cli.stack-branch-prefix` is unset and `--branch` was not
given.

Breaking: a bare name is no longer expanded to `stack/<you>/<name>`.
Pass the stack's branch name as it exists on the remote.

Depends-On: #1775