### PR TITLE
fix(deps): update h2 to 0.4.17 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
`cargo-deny` fails on every pull request in the repository: h2 0.4.14
accepts and queues empty DATA frames without limit, which can grow
memory without bound or panic on overflow (RUSTSEC-2026-0258, low
severity). It reaches us transitively through reqwest → hyper.

Patched in 0.4.16; `cargo update -p h2` takes the lockfile to 0.4.17.
Lockfile only — no manifest or code change.