### PR TITLE
fix(ci): write git-refs base/head through the heredoc writer

### DIFF
--- a/crates/mergify-ci/src/git_refs.rs
+++ b/crates/mergify-ci/src/git_refs.rs
@@ -239,20 +239,28 @@ fn detect_from_pull_request_event(
     }
 
     if let Some(meta) = extract_from_event(event, output)? {
-        if let Some(base) = checking_base_sha(&meta) {
-            return Ok(Some(References {
-                base: Some(base),
-                head,
-                source: ReferencesSource::MergeQueue,
-            }));
+        // Anyone who can open a pull request writes this body, so the
+        // value only becomes a base once it looks like one. Either way
+        // a payload we can't use is not metadata: fall through to the
+        // PR base below, which is the *wrong* base for a genuine batch
+        // build, so warn rather than let it be diagnosed silently.
+        match checking_base_sha(&meta) {
+            Some(base) if is_object_name(&base) => {
+                return Ok(Some(References {
+                    base: Some(base),
+                    head,
+                    source: ReferencesSource::MergeQueue,
+                }));
+            }
+            Some(rejected) => output.status(&format!(
+                "WARNING: MQ pull request checking_base_sha {} is not a git object name, skipping metadata extraction",
+                elided(&rejected),
+            ))?,
+            // No such key — the shape a future engine rename produces.
+            None => output.status(
+                "WARNING: MQ pull request metadata without checking_base_sha, skipping metadata extraction",
+            )?,
         }
-        // MQ metadata is present but carries no `checking_base_sha`
-        // (e.g. a future engine renamed it). We fall through to the PR
-        // base below, but that would be the *wrong* base for a batch
-        // build — warn so it isn't diagnosed silently.
-        output.status(
-            "WARNING: MQ pull request metadata without checking_base_sha, skipping metadata extraction",
-        )?;
     }
 
     if let Some(pr) = &event.pull_request
@@ -330,21 +338,71 @@ pub fn real_notes_reader(branch: &str, head_sha: &str) -> Option<String> {
     checking_base_sha(&crate::git::read_note(&notes_ref_short, head_sha)?)
 }
 
+/// Whether `value` is a full git object name: 40 lowercase hex
+/// digits (SHA-1) or 64 (SHA-256).
+///
+/// The gate this backs is on the *pull request body* payload alone,
+/// and that asymmetry is the point. `queue_metadata::extract_from_event`
+/// admits a body on the title prefix `merge queue: ` and nothing
+/// else, so whoever opens a pull request writes the value; the git
+/// note comes from the engine, over a push to `origin`. A value
+/// admitted here leaves the CLI as `base`: into `$GITHUB_OUTPUT` and
+/// the `--format=shell` eval for the caller's workflow, into
+/// `ci scopes`' git invocations, and onto stderr, which GitHub
+/// Actions also scans for `::` workflow commands. Something like
+/// `--output=/tmp/x` is read as an *option* by whichever of those
+/// gets it first (MRGFY-8845).
+///
+/// Gating the note as well would be worse, not better: a note the
+/// check rejected would fall through to the body path, handing the
+/// untrusted payload the precedence the note is supposed to hold, and
+/// with no warning since `real_notes_reader` has no `Output`.
+///
+/// Full object names only, no abbreviations. The engine types the
+/// field `github_types.SHAType` and writes a full SHA, and
+/// `scopes_detect::changed_files::is_sha` routes only full SHAs as
+/// revisions — an abbreviated one is fetched as a branch name and
+/// fails the run, so accepting it would buy nothing.
+fn is_object_name(value: &str) -> bool {
+    matches!(value.len(), 40 | 64)
+        && value
+            .bytes()
+            .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
 /// Pull `checking_base_sha` out of an engine merge-queue payload —
 /// either the git note ([`real_notes_reader`]) or the YAML block in
 /// the MQ draft PR body (`queue_metadata`), which carry the same dump.
 /// Both read it through here so neither is coupled to the payload's
 /// other keys, which the engine renames independently.
 ///
-/// Accepts the YAML scalar as either a string or (defensively) a
-/// number — a SHA is always a string in practice, but reading it
-/// tolerantly avoids silently dropping a payload over a formatting
-/// quirk.
+/// The value is returned as the payload spells it. The body path
+/// holds it to [`is_object_name`] before use; see there for why the
+/// note path does not.
 fn checking_base_sha(note: &serde_json::Value) -> Option<String> {
     match note.get("checking_base_sha")? {
         serde_json::Value::String(s) => Some(s.clone()),
-        serde_json::Value::Number(n) => Some(n.to_string()),
         _ => None,
+    }
+}
+
+/// Render an untrusted scalar for a warning: `{:?}`-escaped, and cut
+/// to a length a log can hold.
+///
+/// Both halves are load-bearing. `output.status` writes to stderr,
+/// which GitHub Actions scans for `::` workflow commands, and `{:?}`
+/// escapes the newline that would be needed to start one. Nothing
+/// upstream bounds the scalar — `queue_metadata::parse_yaml_block`
+/// joins the whole fenced block — and `{:?}` expands a control
+/// character to six chars, so the cut keeps a rejected value from
+/// filling the log.
+fn elided(value: &str) -> String {
+    const LIMIT: usize = 64;
+    let head: String = value.chars().take(LIMIT).collect();
+    if head.len() == value.len() {
+        format!("{head:?}")
+    } else {
+        format!("{head:?} ({} bytes total)", value.len())
     }
 }
 
@@ -443,30 +501,81 @@ fn buildkite_meta_data_set(key: &str, value: &str) -> std::io::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use mergify_test_support::Captured;
     use tempfile::TempDir;
 
     use super::*;
+
+    /// Full object names, since that is now all `is_object_name`
+    /// admits and the engine only ever writes one.
+    const MQ_BASE: &str = "cafef00dcafef00dcafef00dcafef00dcafef00d";
+    const NOTE_BASE: &str = "0badc0de0badc0de0badc0de0badc0de0badc0de";
 
     fn no_notes(_branch: &str, _sha: &str) -> Option<String> {
         None
     }
 
     #[test]
-    fn checking_base_sha_extracts_string_or_number() {
+    fn checking_base_sha_reads_the_scalar_as_the_payload_spells_it() {
         use serde_json::json;
         assert_eq!(
-            checking_base_sha(&json!({"checking_base_sha": "deadbeef", "scopes": ["x"]})),
-            Some("deadbeef".to_string()),
+            checking_base_sha(&json!({"checking_base_sha": MQ_BASE, "scopes": ["x"]})),
+            Some(MQ_BASE.to_string()),
         );
-        // A numeric-looking SHA is read tolerantly, matching the
-        // direct-YAML coercion the typed parse used to do.
+        // Read verbatim: the shape check is `is_object_name`, applied
+        // by the pull request body path and not by the note path.
         assert_eq!(
-            checking_base_sha(&json!({"checking_base_sha": 1_234_567})),
-            Some("1234567".to_string()),
+            checking_base_sha(&json!({"checking_base_sha": "--output=/tmp/x"})),
+            Some("--output=/tmp/x".to_string()),
         );
-        // No field → None, so detection falls back to the PR body.
+        // No field, or one the engine nulled because the batch has no
+        // checking base → None, so detection falls through.
         assert_eq!(checking_base_sha(&json!({"pull_requests": []})), None);
+        assert_eq!(checking_base_sha(&json!({"checking_base_sha": null})), None);
+    }
+
+    #[test]
+    fn is_object_name_admits_only_full_hex_object_names() {
+        // Anyone who can open a pull request writes the body this
+        // gates, and the value ends up as `base` in the caller's
+        // workflow. A leading `-` above all: every consumer of `base`
+        // reads it as an option (MRGFY-8845).
+        for value in [
+            "--output=/home/runner/.gitconfig",
+            "-x",
+            "main",
+            "HEAD^",
+            "../etc/passwd",
+            &format!("{MQ_BASE}\nbase=pwned"),
+            &format!("{MQ_BASE} pwned"),
+            // Abbreviated: `changed_files::is_sha` would fetch it as a
+            // branch name. Off by one either way. Uppercase, which the
+            // engine never writes. Empty.
+            "cafef00d",
+            &"a".repeat(39),
+            &"a".repeat(41),
+            &MQ_BASE.to_uppercase(),
+            "",
+        ] {
+            assert!(!is_object_name(value), "should reject {value:?}");
+        }
+        // SHA-1 and the SHA-256 spelling a future engine would write.
+        assert!(is_object_name(MQ_BASE));
+        assert!(is_object_name(&"b2".repeat(32)));
+    }
+
+    #[test]
+    fn elided_escapes_and_bounds_an_untrusted_scalar() {
+        // A newline must not survive as one, or the warning could
+        // start a `::` workflow command on GitHub Actions.
+        assert_eq!(elided("a\nb"), r#""a\nb""#);
+        // Nothing upstream bounds the scalar, so a long one is cut and
+        // says so rather than filling the log.
+        let rendered = elided(&"x".repeat(300));
+        assert!(rendered.ends_with(" (300 bytes total)"), "got: {rendered}");
+        assert!(rendered.len() < 100, "got: {rendered}");
     }
 
     fn write_event(dir: &TempDir, payload: &serde_json::Value) -> PathBuf {
@@ -542,7 +651,7 @@ mod tests {
             &serde_json::json!({
                 "pull_request": {
                     "title": "merge queue: batch",
-                    "body": "prelude\n```yaml\nchecking_base_sha: mq-base\n```",
+                    "body": format!("prelude\n```yaml\nchecking_base_sha: {MQ_BASE}\n```"),
                     "head": {"sha": "mq-head", "ref": "mq/main/0"},
                 },
             }),
@@ -556,7 +665,7 @@ mod tests {
             ],
             || detect(&mut cap.output, &no_notes).unwrap(),
         );
-        assert_eq!(refs.base.as_deref(), Some("mq-base"));
+        assert_eq!(refs.base.as_deref(), Some(MQ_BASE));
         assert_eq!(refs.head, "mq-head");
         assert_eq!(refs.source, ReferencesSource::MergeQueue);
     }
@@ -577,7 +686,7 @@ mod tests {
             &serde_json::json!({
                 "pull_request": {
                     "title": "merge queue: batch",
-                    "body": "```yaml\nchecking_base_sha: mq-base\nprevious_failed_batches:\n  - batch_pr_number: 42\n    checked_pull_requests:\n      - 7\n```",
+                    "body": format!("```yaml\nchecking_base_sha: {MQ_BASE}\nprevious_failed_batches:\n  - batch_pr_number: 42\n    checked_pull_requests:\n      - 7\n```"),
                     "head": {"sha": "mq-head", "ref": "mq/main/0"},
                     "base": {"sha": "wrong-base"},
                 },
@@ -592,7 +701,7 @@ mod tests {
             ],
             || detect(&mut cap.output, &no_notes).unwrap(),
         );
-        assert_eq!(refs.base.as_deref(), Some("mq-base"));
+        assert_eq!(refs.base.as_deref(), Some(MQ_BASE));
         assert_eq!(refs.source, ReferencesSource::MergeQueue);
     }
 
@@ -633,6 +742,83 @@ mod tests {
     }
 
     #[test]
+    fn mq_body_with_option_like_base_warns_and_falls_through() {
+        // MRGFY-8845: `extract_from_event` admits any pull request
+        // whose title starts with "merge queue: ", so the reporter's
+        // fork PR put `--output=<path>` in the body and git-refs
+        // emitted it as `base`, where the workflow's next git call
+        // read it as an option. A value that is not an object name is
+        // not metadata: fall through to the PR base and say so.
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_event(
+            &dir,
+            &serde_json::json!({
+                "pull_request": {
+                    "title": "merge queue: batch",
+                    "body": "```yaml\nchecking_base_sha: --output=/home/runner/.gitconfig\n```",
+                    "head": {"sha": "mq-head", "ref": "mq/main/0"},
+                    "base": {"sha": "pr-base"},
+                },
+            }),
+        );
+        let mut cap = Captured::human();
+        let refs = temp_env::with_vars(
+            [
+                ("GITHUB_EVENT_NAME", Some("pull_request")),
+                ("GITHUB_EVENT_PATH", Some(path.to_str().unwrap())),
+                ("BUILDKITE", None),
+            ],
+            || detect(&mut cap.output, &no_notes).unwrap(),
+        );
+        assert_eq!(refs.base.as_deref(), Some("pr-base"));
+        assert_eq!(refs.source, ReferencesSource::GithubEventPullRequest);
+        assert!(
+            cap.stderr().contains("is not a git object name"),
+            "got: {:?}",
+            cap.stderr()
+        );
+    }
+
+    #[test]
+    fn rejected_checking_base_sha_cannot_inject_a_workflow_command() {
+        // The warning echoes the rejected value, and GitHub Actions
+        // scans a step's stderr for `::` workflow commands — so the
+        // escaping matters as much as the rejection. A newline in the
+        // value must not start a line of its own.
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_event(
+            &dir,
+            &serde_json::json!({
+                "pull_request": {
+                    "title": "merge queue: batch",
+                    "body": "```yaml\nchecking_base_sha: \"cafef00d\\n::error::pwned\"\n```",
+                    "head": {"sha": "mq-head", "ref": "mq/main/0"},
+                    "base": {"sha": "pr-base"},
+                },
+            }),
+        );
+        let mut cap = Captured::human();
+        let refs = temp_env::with_vars(
+            [
+                ("GITHUB_EVENT_NAME", Some("pull_request")),
+                ("GITHUB_EVENT_PATH", Some(path.to_str().unwrap())),
+                ("BUILDKITE", None),
+            ],
+            || detect(&mut cap.output, &no_notes).unwrap(),
+        );
+        assert_eq!(refs.base.as_deref(), Some("pr-base"));
+        let stderr = cap.stderr();
+        assert!(
+            !stderr.lines().any(|l| l.starts_with("::")),
+            "got: {stderr:?}",
+        );
+        assert!(
+            stderr.contains(r"cafef00d\n::error::pwned"),
+            "got: {stderr:?}",
+        );
+    }
+
+    #[test]
     fn mq_notes_beat_body_yaml() {
         let dir = tempfile::tempdir().unwrap();
         let path = write_event(
@@ -640,14 +826,14 @@ mod tests {
             &serde_json::json!({
                 "pull_request": {
                     "title": "merge queue: batch",
-                    "body": "```yaml\nchecking_base_sha: body-sha\n```",
+                    "body": format!("```yaml\nchecking_base_sha: {MQ_BASE}\n```"),
                     "head": {"sha": "mq-head", "ref": "mq/main/0"},
                 },
             }),
         );
         let note_reader = |branch: &str, sha: &str| {
             if branch == "mq/main/0" && sha == "mq-head" {
-                Some("note-sha".to_string())
+                Some(NOTE_BASE.to_string())
             } else {
                 None
             }
@@ -661,7 +847,7 @@ mod tests {
             ],
             || detect(&mut cap.output, &note_reader).unwrap(),
         );
-        assert_eq!(refs.base.as_deref(), Some("note-sha"));
+        assert_eq!(refs.base.as_deref(), Some(NOTE_BASE));
     }
 
     #[test]

--- a/crates/mergify-ci/src/git_refs.rs
+++ b/crates/mergify-ci/src/git_refs.rs
@@ -21,13 +21,14 @@
 //! - `json`: one JSON object on a single line.
 //!
 //! Side-effects: when `$GITHUB_OUTPUT` is set the command appends
-//! `base=` / `head=` lines. When `BUILDKITE=true` it invokes
-//! `buildkite-agent meta-data set` for base/head/source.
+//! the `base` and `head` step outputs through the crate's
+//! `github_output` module, which writes them in the runner's heredoc
+//! form so no value can declare an output of its own. When
+//! `BUILDKITE=true` it invokes `buildkite-agent meta-data set` for
+//! base/head/source.
 
 use std::env;
-use std::fs::OpenOptions;
 use std::io::Write;
-use std::path::PathBuf;
 use std::process::Command;
 
 use mergify_core::CliError;
@@ -462,17 +463,11 @@ fn shell_quote(value: &str) -> String {
     format!("'{escaped}'")
 }
 
-fn write_github_output(refs: &References) -> std::io::Result<()> {
-    let Some(path) = env::var("GITHUB_OUTPUT").ok().filter(|s| !s.is_empty()) else {
-        return Ok(());
-    };
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(PathBuf::from(path))?;
-    writeln!(file, "base={}", refs.base.as_deref().unwrap_or(""))?;
-    writeln!(file, "head={}", refs.head)?;
-    Ok(())
+fn write_github_output(refs: &References) -> Result<(), CliError> {
+    crate::github_output::append(&[
+        ("base", refs.base.as_deref().unwrap_or("")),
+        ("head", &refs.head),
+    ])
 }
 
 fn write_buildkite_metadata(refs: &References) -> std::io::Result<()> {
@@ -953,6 +948,49 @@ mod tests {
         assert_eq!(
             stdout.trim_end(),
             r#"{"base":null,"head":"HEAD","source":"github_event_other"}"#
+        );
+    }
+
+    #[test]
+    fn github_output_never_lets_base_declare_another_output() {
+        // `base` is the one reference that can come from a payload
+        // written by hand, so the step outputs go out in heredoc form
+        // rather than as `base=<value>` lines a newline could split
+        // (MRGFY-8845). `checking_base_sha` validation already keeps
+        // this value out, so the newline here stands in for whatever
+        // reaches `base` next.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gha_output");
+        let refs = References {
+            base: Some(format!("{MQ_BASE}\nevil=1")),
+            head: NOTE_BASE.into(),
+            source: ReferencesSource::MergeQueue,
+        };
+        temp_env::with_var("GITHUB_OUTPUT", Some(path.to_str().unwrap()), || {
+            write_github_output(&refs).unwrap();
+        });
+        let written = std::fs::read_to_string(&path).unwrap();
+        // Parse it the way the runner does, so the assertion is about
+        // the outputs the step declares rather than about the bytes.
+        let mut lines = written.lines();
+        let mut outputs: Vec<(String, String)> = Vec::new();
+        while let Some(line) = lines.next() {
+            let (name, delimiter) = line.split_once("<<").expect("heredoc form");
+            let mut value = Vec::new();
+            for body in lines.by_ref() {
+                if body == delimiter {
+                    break;
+                }
+                value.push(body);
+            }
+            outputs.push((name.to_string(), value.join("\n")));
+        }
+        assert_eq!(
+            outputs,
+            [
+                ("base".to_string(), format!("{MQ_BASE}\nevil=1")),
+                ("head".to_string(), NOTE_BASE.to_string()),
+            ],
         );
     }
 

--- a/crates/mergify-ci/src/github_output.rs
+++ b/crates/mergify-ci/src/github_output.rs
@@ -1,0 +1,161 @@
+//! Append step outputs to `$GITHUB_OUTPUT`.
+//!
+//! A GitHub Actions step publishes its outputs by appending them to
+//! the file named by `$GITHUB_OUTPUT`. The obvious `name=value` line
+//! has no escape: a newline inside `value` ends the assignment, and
+//! every following line is parsed as another output — so whatever
+//! chose the value also chooses how many outputs the step declares.
+//! The runner's own answer is the heredoc form
+//!
+//! ```text
+//! name<<ghadelimiter_<32 hex>
+//! value
+//! ghadelimiter_<32 hex>
+//! ```
+//!
+//! which is what [`append`] always emits. The delimiter is drawn from
+//! the OS RNG per output, so a value cannot contain it and no call
+//! site has to reason about what its value may hold. GitHub parses
+//! both forms into the same output value, so consuming workflows see
+//! no difference.
+//!
+//! One writer in the crate does not go through here:
+//! `junit_process::command::maybe_write_github_output` writes
+//! `test_results_upload=<status>` in the bare form. Its value is one
+//! of three `&'static str` literals, and it is deliberately
+//! best-effort ("reporting plumbing must never break the run") where
+//! [`append`] propagates a `CliError`. Make that status dynamic and
+//! it has to move here first.
+//!
+//! The heredoc protects the value half of the pair; the name half is
+//! protected by its type. `&'static str` cannot hold a name derived
+//! from a payload, and a name is the other place a newline (or an `=`
+//! ahead of the `<<`) would let the runner read the block as
+//! something else.
+
+use std::env;
+use std::fmt::Write as _;
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::path::PathBuf;
+
+use mergify_core::CliError;
+
+/// Append each `(name, value)` pair to `$GITHUB_OUTPUT` as a step
+/// output. No-op when the variable is unset or empty — i.e. anywhere
+/// but a GitHub Actions runner.
+pub(crate) fn append(outputs: &[(&'static str, &str)]) -> Result<(), CliError> {
+    let Some(path) = env::var("GITHUB_OUTPUT").ok().filter(|s| !s.is_empty()) else {
+        return Ok(());
+    };
+    // Assembled first, then written once. Three `writeln!` calls on an
+    // unbuffered `File` are several `write_all` syscalls each, and a
+    // sequence cut in the middle leaves an unterminated heredoc, which
+    // fails the step outright ("Matching delimiter not found") — a
+    // worse outcome than the truncated line the `name=value` form
+    // would have left.
+    let mut block = String::new();
+    for (name, value) in outputs {
+        let delimiter = format!("ghadelimiter_{}", random_delimiter_suffix()?);
+        // Writing to a String is infallible.
+        let _ = writeln!(block, "{name}<<{delimiter}\n{value}\n{delimiter}");
+    }
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(PathBuf::from(path))?
+        .write_all(block.as_bytes())?;
+    Ok(())
+}
+
+/// 16 random bytes rendered as 32 lowercase hex chars — enough
+/// entropy to be unguessable inside one GitHub Actions step, which is
+/// all the heredoc delimiter needs (it just has to be absent from the
+/// value). `getrandom` reads the OS RNG directly; we don't need the
+/// parsing/formatting plumbing `uuid` adds on top.
+fn random_delimiter_suffix() -> Result<String, CliError> {
+    let mut buf = [0u8; 16];
+    getrandom::fill(&mut buf).map_err(|e| CliError::wrap("draw a $GITHUB_OUTPUT delimiter", e))?;
+    let mut hex = String::with_capacity(buf.len() * 2);
+    for b in buf {
+        // Writing to a String is infallible.
+        let _ = write!(hex, "{b:02x}");
+    }
+    Ok(hex)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn append_is_a_noop_outside_github_actions() {
+        temp_env::with_var("GITHUB_OUTPUT", None::<&str>, || {
+            append(&[("k", "v")]).unwrap();
+        });
+        // An empty value is treated the same as unset: the runner
+        // exports `GITHUB_OUTPUT=` in some contexts, and an empty
+        // path is not openable.
+        temp_env::with_var("GITHUB_OUTPUT", Some(""), || {
+            append(&[("k", "v")]).unwrap();
+        });
+    }
+
+    #[test]
+    fn append_wraps_every_output_in_its_own_heredoc() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gha_output");
+        temp_env::with_var("GITHUB_OUTPUT", Some(path.to_str().unwrap()), || {
+            append(&[("base", "cafef00d"), ("head", "0badc0de")]).unwrap();
+        });
+        let written = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = written.lines().collect();
+        assert_eq!(lines.len(), 6, "got: {written:?}");
+        assert!(
+            lines[0].starts_with("base<<ghadelimiter_"),
+            "got: {written:?}"
+        );
+        assert_eq!(lines[1], "cafef00d");
+        assert_eq!(lines[2], &lines[0]["base<<".len()..]);
+        assert!(
+            lines[3].starts_with("head<<ghadelimiter_"),
+            "got: {written:?}"
+        );
+        assert_eq!(lines[4], "0badc0de");
+        assert_eq!(lines[5], &lines[3]["head<<".len()..]);
+        // Each output draws its own delimiter.
+        assert_ne!(lines[2], lines[5]);
+    }
+
+    #[test]
+    fn a_newline_in_a_value_cannot_declare_another_output() {
+        // The whole point of the heredoc: the injected `evil=` line
+        // sits inside `base`'s body rather than becoming a second
+        // step output (MRGFY-8845).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gha_output");
+        temp_env::with_var("GITHUB_OUTPUT", Some(path.to_str().unwrap()), || {
+            append(&[("base", "cafef00d\nevil=1")]).unwrap();
+        });
+        let written = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = written.lines().collect();
+        let delimiter = &lines[0]["base<<".len()..];
+        assert_eq!(lines.len(), 4, "got: {written:?}");
+        assert_eq!(&lines[1..3], ["cafef00d", "evil=1"]);
+        assert_eq!(lines[3], delimiter);
+    }
+
+    #[test]
+    fn append_keeps_earlier_content() {
+        // The runner accumulates every step's outputs in one file, so
+        // the write must append rather than truncate.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gha_output");
+        std::fs::write(&path, "earlier=1\n").unwrap();
+        temp_env::with_var("GITHUB_OUTPUT", Some(path.to_str().unwrap()), || {
+            append(&[("base", "cafef00d")]).unwrap();
+        });
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.starts_with("earlier=1\n"), "got: {written:?}");
+    }
+}

--- a/crates/mergify-ci/src/lib.rs
+++ b/crates/mergify-ci/src/lib.rs
@@ -11,6 +11,7 @@ pub mod detector;
 mod git;
 pub mod git_refs;
 pub mod github_event;
+mod github_output;
 pub mod junit_process;
 pub mod queue_info;
 pub mod queue_metadata;

--- a/crates/mergify-ci/src/queue_info.rs
+++ b/crates/mergify-ci/src/queue_info.rs
@@ -18,10 +18,7 @@
 //! `ghadelimiter_<uuid>` heredoc, matching the pattern the workflow
 //! runtime expects for multi-line outputs.
 
-use std::env;
-use std::fs::OpenOptions;
 use std::io::Write;
-use std::path::PathBuf;
 
 use mergify_core::CliError;
 use mergify_core::Output;
@@ -104,38 +101,9 @@ fn emit_json(output: &mut dyn Output, metadata: &Value) -> std::io::Result<()> {
 }
 
 fn write_github_output(metadata: &Value) -> Result<(), CliError> {
-    let Some(path) = env::var("GITHUB_OUTPUT").ok().filter(|s| !s.is_empty()) else {
-        return Ok(());
-    };
-    let delimiter = format!("ghadelimiter_{}", random_delimiter_suffix()?);
     let compact = serde_json::to_string(metadata)
         .map_err(|e| CliError::Generic(format!("failed to serialize queue metadata: {e}")))?;
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(PathBuf::from(path))?;
-    writeln!(file, "queue_metadata<<{delimiter}")?;
-    writeln!(file, "{compact}")?;
-    writeln!(file, "{delimiter}")?;
-    Ok(())
-}
-
-/// 16 random bytes rendered as 32 lowercase hex chars — enough
-/// entropy to be unguessable inside one GitHub Actions step, which
-/// is all the heredoc delimiter needs (it just has to be absent
-/// from the metadata payload). `getrandom` reads from the OS RNG
-/// directly; we don't need the UUID parsing/formatting plumbing
-/// that `uuid` adds on top.
-fn random_delimiter_suffix() -> Result<String, CliError> {
-    let mut buf = [0u8; 16];
-    getrandom::fill(&mut buf)
-        .map_err(|e| CliError::Generic(format!("OS random source unavailable: {e}")))?;
-    let mut hex = String::with_capacity(buf.len() * 2);
-    for b in buf {
-        use std::fmt::Write as _;
-        write!(hex, "{b:02x}").expect("writing to String is infallible");
-    }
-    Ok(hex)
+    crate::github_output::append(&[("queue_metadata", &compact)])
 }
 
 #[cfg(test)]

--- a/crates/mergify-ci/src/scopes_detect/outputs.rs
+++ b/crates/mergify-ci/src/scopes_detect/outputs.rs
@@ -54,19 +54,8 @@ pub fn maybe_write_github_outputs(
     all: &BTreeSet<String>,
     hit: &BTreeSet<String>,
 ) -> Result<(), CliError> {
-    let Some(path) = env::var("GITHUB_OUTPUT").ok().filter(|s| !s.is_empty()) else {
-        return Ok(());
-    };
-    let delimiter = format!("ghadelimiter_{}", random_delimiter_suffix()?);
     let payload = scopes_dict_json(all, hit);
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(PathBuf::from(path))?;
-    writeln!(file, "{GITHUB_ACTIONS_OUTPUT_NAME}<<{delimiter}")?;
-    writeln!(file, "{payload}")?;
-    writeln!(file, "{delimiter}")?;
-    Ok(())
+    crate::github_output::append(&[(GITHUB_ACTIONS_OUTPUT_NAME, &payload)])
 }
 
 /// `buildkite-agent meta-data set mergify-ci.scopes <json>` when
@@ -206,21 +195,6 @@ pub fn maybe_write_buildkite_annotation(
             );
         }
     }
-}
-
-/// 32 random hex chars from the OS RNG. Same approach as
-/// `ci queue-info` for the heredoc delimiter — `uuid` would do
-/// the job but carries more crate surface than we need for a
-/// throwaway delimiter.
-fn random_delimiter_suffix() -> Result<String, CliError> {
-    let mut buf = [0u8; 16];
-    getrandom::fill(&mut buf)
-        .map_err(|e| CliError::Generic(format!("OS random source unavailable: {e}")))?;
-    let mut hex = String::with_capacity(buf.len() * 2);
-    for b in buf {
-        let _ = write!(hex, "{b:02x}");
-    }
-    Ok(hex)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`write_github_output` emitted `base=<value>` and `head=<value>` as bare
lines. GitHub Actions has no escape in that form: a newline in the
value ends the assignment and every following line becomes another
step output, so whatever chose the value also chose how many outputs
the step declares. `head` was the only one that could not be
overwritten, because the genuine `head=` line follows and the last
assignment wins.

Route both through `github_output::append`, which writes the runner's
heredoc form under a random delimiter. Consuming workflows see the same
values, GitHub parses both forms identically.

Validating `checking_base_sha` already keeps a newline out of `base`
today. This is the layer under that: it holds whatever reaches these
outputs next, without the next author having to notice.

Fixes MRGFY-8845

Depends-On: #1786