### PR TITLE
feat(ci): report scopes against the pull request head

### DIFF
--- a/crates/mergify-ci/src/detector.rs
+++ b/crates/mergify-ci/src/detector.rs
@@ -213,8 +213,9 @@ fn read_github_event_pull_request_number() -> Result<Option<u64>, CliError> {
     // it's the only signal that decides whether `scopes-send` runs
     // at all — silently swallowing a parse error there would hide
     // a misconfigured workflow. The head-SHA lookup (see
-    // [`read_github_event_pull_request_head_sha`]) has a sane
-    // fallback (`GITHUB_SHA`), so it stays lenient.
+    // [`read_github_event_pull_request_head_sha`]) stays lenient
+    // because every one of its callers has somewhere to go without
+    // an answer.
     let Some(event_path) = env::var("GITHUB_EVENT_PATH").ok().filter(|s| !s.is_empty()) else {
         return Ok(None);
     };
@@ -233,6 +234,70 @@ fn read_github_event_pull_request_number() -> Result<Option<u64>, CliError> {
     Ok(event
         .pointer("/pull_request/number")
         .and_then(serde_json::Value::as_u64))
+}
+
+/// Whether `value` is a full 40-character hex SHA-1 object name, in
+/// either case.
+///
+/// Sibling to `git_refs::is_object_name`, which also admits a
+/// 64-character SHA-256 name and rejects uppercase: that one gates an
+/// untrusted pull request body being spliced into a git invocation,
+/// where the narrowest spelling wins. This one answers "did the
+/// provider name a revision", and GitHub reports pull request heads as
+/// SHA-1 in lowercase while a hand-passed value may be uppercase.
+pub(crate) fn is_sha1_object_name(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Head SHA of the pull request the build is for. `None` unless a
+/// provider names one as a full 40-character hex SHA — anything else
+/// (`BUILDKITE_COMMIT` unset, which `git_refs` reads as the literal
+/// `HEAD`) is not a revision and is dropped here, so callers can use
+/// the answer without re-checking its shape.
+///
+/// Deliberately not [`get_head_sha`], which answers the different
+/// question "which revision did the tests run against" and falls back
+/// to `GITHUB_SHA`. That fallback is wrong for identifying a pull
+/// request head: on a `pull_request` event `GITHUB_SHA` is the
+/// synthetic merge commit, and on `pull_request_target` it is the base
+/// branch. Neither is any pull request's head, so a report keyed on
+/// one would be stored where nothing ever reads it — a silent no-op,
+/// worse than having no SHA at all and saying so.
+///
+/// Jenkins is the one provider left uncovered, and deliberately: the
+/// GitHub Branch Source plugin builds a pull request by merging it into
+/// its target by default, so `GIT_COMMIT` is that merge commit rather
+/// than the head — the same trap as `GITHUB_SHA`, with no second env
+/// var to tell the two configurations apart.
+#[must_use]
+pub fn get_github_pull_request_head_sha() -> Option<String> {
+    let sha = match get_ci_provider()? {
+        CIProvider::GithubActions => read_github_event_pull_request_head_sha(),
+        // Buildkite and CircleCI both build a pull request from its head
+        // commit, so their revision var *is* that head (`git_refs` reads
+        // `BUILDKITE_COMMIT` for the same purpose).
+        CIProvider::Buildkite => non_empty_env("BUILDKITE_COMMIT"),
+        CIProvider::CircleCi => non_empty_env("CIRCLE_SHA1"),
+        CIProvider::Jenkins => None,
+    }?;
+    is_sha1_object_name(&sha).then_some(sha)
+}
+
+/// Clap `value_parser` for a `--head-sha` flag. Returning
+/// `Result<_, String>` makes clap reject a bad value with exit code 2
+/// rather than letting it reach the API as a 422 — same treatment as
+/// [`parse_owner_repo`].
+///
+/// # Errors
+///
+/// Returns a message when `value` is not a full 40-character hex SHA.
+pub fn parse_head_sha(value: &str) -> Result<String, String> {
+    if is_sha1_object_name(value) {
+        return Ok(value.to_string());
+    }
+    Err(format!(
+        "invalid head SHA {value:?}: expected 40 hexadecimal characters",
+    ))
 }
 
 /// `cicd.pipeline.name` resource attribute. None when the
@@ -397,8 +462,10 @@ fn get_github_actions_head_sha() -> Option<String> {
 /// Read `GITHUB_EVENT_PATH` and pluck the
 /// `pull_request.head.sha` out of the JSON. Returns `None` for
 /// every "not applicable" case — env unset, file missing, file
-/// not JSON, key not present — so the caller can quietly fall
-/// back to `GITHUB_SHA` without surfacing an error to the user.
+/// not JSON, key not present — so a caller can quietly take its own
+/// no-answer branch without surfacing an error to the user. That is
+/// `GITHUB_SHA` for [`get_head_sha`] and no head at all for
+/// [`get_github_pull_request_head_sha`].
 fn read_github_event_pull_request_head_sha() -> Option<String> {
     let event = read_github_event_json()?;
     event
@@ -434,6 +501,7 @@ pub fn get_tests_target_branch() -> Option<String> {
 mod tests {
     use super::*;
     use crate::testing::with_ci_env;
+    use crate::testing::write_github_event;
 
     #[test]
     fn ci_provider_jenkins_takes_precedence() {
@@ -653,6 +721,163 @@ mod tests {
             ],
             || {
                 assert_eq!(get_github_pull_request_number().unwrap(), None);
+            },
+        );
+    }
+
+    #[test]
+    fn parse_head_sha_accepts_a_full_sha_in_either_case() {
+        let lower = "feedface00000000000000000000000000000000";
+        assert_eq!(parse_head_sha(lower).unwrap(), lower);
+        // The engine folds case, so an uppercase spelling names the
+        // same revision rather than a different one.
+        let upper = lower.to_uppercase();
+        assert_eq!(parse_head_sha(&upper).unwrap(), upper);
+    }
+
+    #[test]
+    fn parse_head_sha_rejects_anything_that_is_not_a_full_sha1() {
+        for bad in [
+            "",
+            "HEAD",
+            // Abbreviated: never equal to a stored full-length head.
+            "feedface",
+            // 40 characters, but not hex.
+            "zeedface00000000000000000000000000000000",
+            // A SHA-256 object name: `git_refs::is_object_name` takes
+            // one, this does not — GitHub reports pull request heads
+            // as SHA-1.
+            &"a".repeat(64),
+        ] {
+            assert!(parse_head_sha(bad).is_err(), "accepted {bad:?}");
+        }
+    }
+
+    #[test]
+    fn pull_request_head_sha_reads_the_github_event_payload() {
+        let tmp = tempfile::tempdir().unwrap();
+        let event_path = write_github_event(
+            tmp.path(),
+            &serde_json::json!({
+                "pull_request": {"head": {"sha": "feedface00000000000000000000000000000000"}},
+            }),
+        );
+
+        for event_name in ["pull_request", "pull_request_target"] {
+            with_ci_env(
+                &[
+                    ("GITHUB_ACTIONS", Some("true")),
+                    ("GITHUB_EVENT_NAME", Some(event_name)),
+                    ("GITHUB_EVENT_PATH", Some(event_path.to_str().unwrap())),
+                    // Never the answer, on either event — see
+                    // `get_github_pull_request_head_sha`.
+                    (
+                        "GITHUB_SHA",
+                        Some("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+                    ),
+                ],
+                || {
+                    assert_eq!(
+                        get_github_pull_request_head_sha().as_deref(),
+                        Some("feedface00000000000000000000000000000000"),
+                        "event {event_name}",
+                    );
+                },
+            );
+        }
+    }
+
+    #[test]
+    fn pull_request_head_sha_is_none_without_a_pull_request_in_the_payload() {
+        // Where `get_head_sha` falls back to `GITHUB_SHA`, this must
+        // not.
+        let tmp = tempfile::tempdir().unwrap();
+        let event_path = write_github_event(tmp.path(), &serde_json::json!({}));
+        with_ci_env(
+            &[
+                ("GITHUB_ACTIONS", Some("true")),
+                ("GITHUB_EVENT_NAME", Some("push")),
+                ("GITHUB_EVENT_PATH", Some(event_path.to_str().unwrap())),
+                (
+                    "GITHUB_SHA",
+                    Some("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+                ),
+            ],
+            || {
+                assert_eq!(get_github_pull_request_head_sha(), None);
+            },
+        );
+    }
+
+    #[test]
+    fn pull_request_head_sha_uses_buildkite_commit() {
+        with_ci_env(
+            &[
+                ("BUILDKITE", Some("true")),
+                (
+                    "BUILDKITE_COMMIT",
+                    Some("0123456789abcdef0123456789abcdef01234567"),
+                ),
+            ],
+            || {
+                assert_eq!(
+                    get_github_pull_request_head_sha().as_deref(),
+                    Some("0123456789abcdef0123456789abcdef01234567"),
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn pull_request_head_sha_drops_a_value_that_is_not_a_revision() {
+        // An unset `BUILDKITE_COMMIT` is what `git_refs` reads as the
+        // literal `HEAD`; callers must not have to re-check the shape.
+        with_ci_env(
+            &[
+                ("BUILDKITE", Some("true")),
+                ("BUILDKITE_COMMIT", Some("HEAD")),
+            ],
+            || {
+                assert_eq!(get_github_pull_request_head_sha(), None);
+            },
+        );
+    }
+
+    #[test]
+    fn pull_request_head_sha_uses_circle_sha1() {
+        with_ci_env(
+            &[
+                ("CIRCLECI", Some("true")),
+                (
+                    "CIRCLE_SHA1",
+                    Some("0123456789abcdef0123456789abcdef01234567"),
+                ),
+            ],
+            || {
+                assert_eq!(
+                    get_github_pull_request_head_sha().as_deref(),
+                    Some("0123456789abcdef0123456789abcdef01234567"),
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn pull_request_head_sha_is_none_on_jenkins() {
+        // `GIT_COMMIT` is the merge commit whenever the Branch Source
+        // plugin builds a pull request merged into its target, which is
+        // its default, and nothing distinguishes that from the head-only
+        // configuration. No answer beats the wrong one.
+        with_ci_env(
+            &[
+                ("JENKINS_URL", Some("http://ci")),
+                (
+                    "GIT_COMMIT",
+                    Some("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+                ),
+            ],
+            || {
+                assert_eq!(get_github_pull_request_head_sha(), None);
             },
         );
     }

--- a/crates/mergify-ci/src/scopes_send.rs
+++ b/crates/mergify-ci/src/scopes_send.rs
@@ -1,4 +1,4 @@
-//! `mergify ci scopes-send` — POST the scopes detected for a pull
+//! `mergify ci scopes-send` — report the scopes detected for a pull
 //! request to Mergify.
 //!
 //! Scopes can come from three sources (combined):
@@ -23,6 +23,16 @@
 //! pull-request number the command prints a skip message and
 //! returns success — matches Python's "no PR, nothing to send"
 //! behavior.
+//!
+//! The report is addressed by the pull request's **head SHA**
+//! (``--head-sha``, else the CI environment) so it says which
+//! revision it was computed for: scopes computed for one head do not
+//! describe another, and the number-addressed record cannot tell the
+//! difference — whichever upload lands last wins (MRGFY-8884). The
+//! number-addressed endpoint stays the fallback for the two cases
+//! where the SHA route is not available: no head SHA could be
+//! resolved, or the Mergify deployment is older than the endpoint and
+//! answers 404.
 //!
 //! Auth + API URL resolution goes through `mergify_core::auth`,
 //! which adds a `gh auth token` fallback (matches Python's
@@ -52,6 +62,7 @@ pub struct ScopesSendOptions<'a> {
     pub scopes_file: Option<&'a Path>,
     pub deprecated_file: Option<&'a Path>,
     pub all_scopes: bool,
+    pub head_sha: Option<&'a str>,
 }
 
 /// Run the `ci scopes-send` command.
@@ -86,31 +97,86 @@ pub async fn run(opts: ScopesSendOptions<'_>, output: &mut dyn Output) -> Result
         scopes.extend(read_scopes_text_file(path)?);
     }
 
-    if all_scopes {
-        output.status(&format!(
-            "Sending {} scope(s) (impacting all scopes) to {api_url}…",
-            scopes.len(),
-        ))?;
-    } else {
-        output.status(&format!("Sending {} scope(s) to {api_url}…", scopes.len()))?;
+    let head_sha = resolve_head_sha(opts.head_sha);
+    if head_sha.is_none() {
+        output.status(
+            "No pull request head SHA detected, reporting against the pull \
+             request number instead: the scopes will not say which revision \
+             they were computed for.",
+        )?;
     }
 
+    let all_scopes_note = if all_scopes {
+        " (impacting all scopes)"
+    } else {
+        ""
+    };
+    let target = match &head_sha {
+        Some(sha) => format!("commit {sha}"),
+        None => format!("pull request #{pull_request}"),
+    };
+    output.status(&format!(
+        "Sending {} scope(s){all_scopes_note} for {target} to {api_url}…",
+        scopes.len(),
+    ))?;
+
     let client = HttpClient::new(api_url, token, ApiFlavor::Mergify)?;
+    let body = SendScopesRequest {
+        scopes: &scopes,
+        all_scopes,
+    };
+
+    // Both calls below discard the response: each endpoint answers an
+    // empty body on success, which a `::<Value>` variant would surface
+    // as "parse response JSON: error decoding response body".
+    if let Some(sha) = &head_sha {
+        let path = format!("/v1/repos/{repository}/commits/{sha}/scopes");
+        let reported_against_the_commit = client.put_no_response_if_exists(&path, &body).await?;
+        if reported_against_the_commit {
+            return Ok(());
+        }
+        // A Mergify older than the endpoint answers 404, and so does
+        // one that cannot see the repository — the message reports what
+        // was observed rather than diagnosing which, and the fallback
+        // surfaces the second case as its own error when the
+        // pull-request route 404s too.
+        output.status(
+            "The commit scopes endpoint answered 404, falling back to the \
+             pull request one: the scopes will not say which revision they \
+             were computed for.",
+        )?;
+    }
+
+    // The fallback stays on POST rather than the pull-request route's
+    // own PUT: a deployment old enough to 404 the commit endpoint may
+    // be old enough to 404 that PUT too (it landed four months
+    // earlier), which would defeat the point of falling back.
     let path = format!("/v1/repos/{repository}/pulls/{pull_request}/scopes");
-    // The endpoint returns an empty body on success — `post::<Value>`
-    // would surface that as "parse response JSON: error decoding
-    // response body". We only need to know the request was 2xx.
-    client
-        .post_no_response(
-            &path,
-            &SendScopesRequest {
-                scopes: &scopes,
-                all_scopes,
-            },
-        )
-        .await?;
+    client.post_no_response(&path, &body).await?;
 
     Ok(())
+}
+
+/// The pull request head SHA to report the scopes against, or `None`
+/// when nothing names one.
+///
+/// Both sources are re-checked here rather than trusted. Detection
+/// filters its own result and clap's `parse_head_sha` rejects a bad
+/// `--head-sha`, but `ScopesSendOptions` is public: the value lands in
+/// a request path, and `Client::join` resolves `..` segments, so this
+/// is the same rule `detector::resolve_repository` applies to every
+/// source of its own path segment.
+///
+/// Lowercased for the same reason `tests_quarantine` normalizes an id
+/// before pathing it: the engine folds case, but a row stored under a
+/// spelling no reader looks for is worse than a rejected one, and only
+/// one of the two spellings should ever be sent.
+fn resolve_head_sha(explicit: Option<&str>) -> Option<String> {
+    explicit
+        .map(ToString::to_string)
+        .or_else(detector::get_github_pull_request_head_sha)
+        .filter(|sha| detector::is_sha1_object_name(sha))
+        .map(|sha| sha.to_lowercase())
 }
 
 fn resolve_pull_request(explicit: Option<u64>) -> Result<Option<u64>, CliError> {
@@ -174,6 +240,7 @@ mod tests {
     use super::*;
     use crate::testing::with_ci_env;
     use crate::testing::with_ci_env_async;
+    use crate::testing::write_github_event;
 
     #[test]
     fn resolve_pull_request_prefers_explicit() {
@@ -232,6 +299,7 @@ mod tests {
                     scopes_file: None,
                     deprecated_file: None,
                     all_scopes: false,
+                    head_sha: None,
                 },
                 &mut cap.output,
             )
@@ -281,6 +349,7 @@ mod tests {
                         scopes_file: None,
                         deprecated_file: None,
                         all_scopes: false,
+                        head_sha: None,
                     },
                     &mut cap.output,
                 )
@@ -289,6 +358,14 @@ mod tests {
             },
         )
         .await;
+
+        // No `BUILDKITE_COMMIT`, so nothing names the head: the report
+        // falls back to the pull request number, and says so.
+        let err = cap.stderr();
+        assert!(
+            err.contains("No pull request head SHA detected"),
+            "got: {err:?}"
+        );
     }
 
     #[tokio::test]
@@ -327,6 +404,7 @@ mod tests {
                 scopes_file: Some(&txt_path),
                 deprecated_file: None,
                 all_scopes: false,
+                head_sha: None,
             },
             &mut cap.output,
         )
@@ -363,6 +441,7 @@ mod tests {
                 scopes_file: None,
                 deprecated_file: None,
                 all_scopes: true,
+                head_sha: None,
             },
             &mut cap.output,
         )
@@ -408,6 +487,7 @@ mod tests {
                 scopes_file: None,
                 deprecated_file: None,
                 all_scopes: false,
+                head_sha: None,
             },
             &mut cap.output,
         )
@@ -443,11 +523,183 @@ mod tests {
                 scopes_file: None,
                 deprecated_file: None,
                 all_scopes: false,
+                head_sha: None,
             },
             &mut cap.output,
         )
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn run_reports_against_the_head_sha_from_the_github_event() {
+        let head = "feedface00000000000000000000000000000000";
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path(format!("/v1/repos/owner/repo/commits/{head}/scopes")))
+            .and(body_json(
+                serde_json::json!({"scopes": ["a"], "all_scopes": false}),
+            ))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let event_path = write_github_event(
+            tmp.path(),
+            &serde_json::json!({"pull_request": {"number": 42, "head": {"sha": head}}}),
+        );
+        let mut cap = Captured::human();
+        let api_url = server.uri();
+        let direct = vec!["a".to_string()];
+
+        with_ci_env_async(
+            &[
+                ("GITHUB_ACTIONS", Some("true")),
+                ("GITHUB_EVENT_NAME", Some("pull_request")),
+                ("GITHUB_EVENT_PATH", Some(event_path.to_str().unwrap())),
+                ("GITHUB_REPOSITORY", Some("owner/repo")),
+                // The merge commit, not the head — see
+                // `detector::get_github_pull_request_head_sha`.
+                (
+                    "GITHUB_SHA",
+                    Some("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+                ),
+            ],
+            async {
+                run(
+                    ScopesSendOptions {
+                        repository: None,
+                        pull_request: None,
+                        token: Some("t"),
+                        api_url: Some(&api_url),
+                        scopes: &direct,
+                        scopes_json: None,
+                        scopes_file: None,
+                        deprecated_file: None,
+                        all_scopes: false,
+                        head_sha: None,
+                    },
+                    &mut cap.output,
+                )
+                .await
+                .unwrap();
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn run_prefers_the_explicit_head_sha_over_detection() {
+        let detected = "feedface00000000000000000000000000000000";
+        // Uppercase on the way in: the path segment must still be the one
+        // spelling a reader looks for.
+        let explicit = "0123456789ABCDEF0123456789ABCDEF01234567";
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path(format!(
+                "/v1/repos/owner/repo/commits/{}/scopes",
+                explicit.to_lowercase(),
+            )))
+            .and(body_json(serde_json::json!({
+                "scopes": ["backend"],
+                "all_scopes": true,
+            })))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let event_path = write_github_event(
+            tmp.path(),
+            &serde_json::json!({"pull_request": {"number": 42, "head": {"sha": detected}}}),
+        );
+        let mut cap = Captured::human();
+        let api_url = server.uri();
+        let direct = vec!["backend".to_string()];
+
+        with_ci_env_async(
+            &[
+                ("GITHUB_ACTIONS", Some("true")),
+                ("GITHUB_EVENT_NAME", Some("pull_request")),
+                ("GITHUB_EVENT_PATH", Some(event_path.to_str().unwrap())),
+                ("GITHUB_REPOSITORY", Some("owner/repo")),
+            ],
+            async {
+                run(
+                    ScopesSendOptions {
+                        repository: None,
+                        pull_request: None,
+                        token: Some("t"),
+                        api_url: Some(&api_url),
+                        scopes: &direct,
+                        scopes_json: None,
+                        scopes_file: None,
+                        deprecated_file: None,
+                        all_scopes: true,
+                        head_sha: Some(explicit),
+                    },
+                    &mut cap.output,
+                )
+                .await
+                .unwrap();
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn run_falls_back_to_the_pull_request_when_the_commit_endpoint_is_unknown() {
+        // A Mergify older than the commit endpoint 404s the route. The
+        // upload has to keep working there, at the precision that
+        // deployment already had.
+        let head = "feedface00000000000000000000000000000000";
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path(format!("/v1/repos/owner/repo/commits/{head}/scopes")))
+            .respond_with(ResponseTemplate::new(404))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/repos/owner/repo/pulls/42/scopes"))
+            .and(body_json(
+                serde_json::json!({"scopes": ["a"], "all_scopes": false}),
+            ))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut cap = Captured::human();
+        let api_url = server.uri();
+        let direct = vec!["a".to_string()];
+
+        run(
+            ScopesSendOptions {
+                repository: Some("owner/repo"),
+                pull_request: Some(42),
+                token: Some("t"),
+                api_url: Some(&api_url),
+                scopes: &direct,
+                scopes_json: None,
+                scopes_file: None,
+                deprecated_file: None,
+                all_scopes: false,
+                head_sha: Some(head),
+            },
+            &mut cap.output,
+        )
+        .await
+        .unwrap();
+
+        let err = cap.stderr();
+        assert!(
+            err.contains("commit scopes endpoint answered 404"),
+            "got: {err:?}"
+        );
     }
 
     #[tokio::test]
@@ -477,6 +729,7 @@ mod tests {
                 scopes_file: None,
                 deprecated_file: Some(&json_path),
                 all_scopes: false,
+                head_sha: None,
             },
             &mut cap.output,
         )
@@ -524,6 +777,7 @@ mod tests {
                 scopes_file: None,
                 deprecated_file: Some(&deprecated_path),
                 all_scopes: false,
+                head_sha: None,
             },
             &mut cap.output,
         )

--- a/crates/mergify-ci/src/testing.rs
+++ b/crates/mergify-ci/src/testing.rs
@@ -9,6 +9,8 @@
 //! (used by the `#[tokio::test]` cases).
 
 use std::future::Future;
+use std::path::Path;
+use std::path::PathBuf;
 
 /// Env vars the CI-provider detection chain inspects. Clear every
 /// one of them before applying the test-specific overrides, so the
@@ -121,6 +123,17 @@ where
     F: Future<Output = R>,
 {
     temp_env::async_with_vars(merged_overrides(extra), f).await
+}
+
+/// Write `payload` as a GitHub Actions event file under `dir` and
+/// return its path, ready to point `GITHUB_EVENT_PATH` at. The
+/// payload-reading helpers across `detector` and `scopes_send` all
+/// need one, and each spelling it out obscures which key the test is
+/// actually about.
+pub(crate) fn write_github_event(dir: &Path, payload: &serde_json::Value) -> PathBuf {
+    let path = dir.join("event.json");
+    std::fs::write(&path, payload.to_string()).expect("write event payload");
+    path
 }
 
 /// A high-entropy alphanumeric string of `len` chars, seeded so

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -505,6 +505,7 @@ struct CiScopesSendOpts {
     scopes_file: Option<PathBuf>,
     file_deprecated: Option<PathBuf>,
     all_scopes: bool,
+    head_sha: Option<String>,
 }
 
 struct CiJunitProcessOpts {
@@ -930,6 +931,7 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
                     scopes_file,
                     file_deprecated,
                     all,
+                    head_sha,
                 }),
         }) => Dispatch::Native(NativeCommand::CiScopesSend(CiScopesSendOpts {
             repository,
@@ -941,6 +943,7 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
             scopes_file,
             file_deprecated,
             all_scopes: all,
+            head_sha,
         })),
         Subcommands::Ci(CiArgs {
             command: CiSubcommand::GitRefs(GitRefsCliArgs { format }),
@@ -1549,6 +1552,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                     scopes_file: opts.scopes_file.as_deref(),
                     deprecated_file: opts.file_deprecated.as_deref(),
                     all_scopes: opts.all_scopes,
+                    head_sha: opts.head_sha.as_deref(),
                 },
                 &mut output,
             )
@@ -3910,6 +3914,17 @@ struct ScopesSendCliArgs {
     /// still sent alongside the flag.
     #[arg(long = "all")]
     all: bool,
+
+    /// Head SHA the scopes were computed for, as 40 hexadecimal
+    /// characters, so a result computed for an older head is not
+    /// taken for the current one. When omitted it is detected from
+    /// the CI environment: under GitHub Actions from the event
+    /// payload (``.pull_request.head.sha`` in ``GITHUB_EVENT_PATH``),
+    /// under Buildkite from ``BUILDKITE_COMMIT``. Pass the pull
+    /// request's head, not the revision the job checked out — on a
+    /// ``pull_request`` event those differ.
+    #[arg(long = "head-sha", value_parser = mergify_ci::detector::parse_head_sha)]
+    head_sha: Option<String>,
 }
 
 #[derive(clap::Args)]

--- a/crates/mergify-cli/src/snapshots/mergify__tests__cli_schema_golden.snap
+++ b/crates/mergify-cli/src/snapshots/mergify__tests__cli_schema_golden.snap
@@ -349,6 +349,24 @@ expression: schema
                 "short": null,
                 "valueHint": null,
                 "valueNames": []
+              },
+              {
+                "default": null,
+                "env": null,
+                "global": false,
+                "help": "Head SHA the scopes were computed for, as 40 hexadecimal characters, so a result computed for an older head is not taken for the current one. When omitted it is detected from the CI environment: under GitHub Actions from the event payload (``.pull_request.head.sha`` in ``GITHUB_EVENT_PATH``), under Buildkite from ``BUILDKITE_COMMIT``. Pass the pull request's head, not the revision the job checked out — on a ``pull_request`` event those differ",
+                "id": "head_sha",
+                "kind": "option",
+                "long": "head-sha",
+                "longHelp": "Head SHA the scopes were computed for, as 40 hexadecimal characters, so a result computed for an older head is not taken for the current one. When omitted it is detected from the CI environment: under GitHub Actions from the event payload (``.pull_request.head.sha`` in ``GITHUB_EVENT_PATH``), under Buildkite from ``BUILDKITE_COMMIT``. Pass the pull request's head, not the revision the job checked out — on a ``pull_request`` event those differ",
+                "numArgs": "1",
+                "possibleValues": [],
+                "required": false,
+                "short": null,
+                "valueHint": null,
+                "valueNames": [
+                  "HEAD_SHA"
+                ]
               }
             ],
             "commands": [],

--- a/crates/mergify-cli/tests/live_smoke.rs
+++ b/crates/mergify-cli/tests/live_smoke.rs
@@ -686,8 +686,57 @@ fn ci_scopes_select_all_when_no_base() {
 // ---------------------------------------------------------------
 
 #[test]
+fn scopes_send_commit() {
+    // `PUT /v1/repos/{owner}/{repo}/commits/{sha}/scopes`, the route
+    // `scopes-send` takes whenever it can name the head.
+    //
+    // Worth its own live case precisely because the command falls back
+    // to the pull-request route on a 404: a misspelled path or an
+    // endpoint that never shipped would degrade silently and no
+    // offline test would notice. The SHA is arbitrary — the endpoint
+    // stores a report for a revision no open pull request heads, which
+    // it documents as a normal outcome — so this asserts auth and URL
+    // routing without depending on the canary repository's history.
+    let token = skip_if_unset!(live_token());
+
+    let result = cli(&[
+        "ci",
+        "scopes-send",
+        "--api-url",
+        API_URL,
+        "--token",
+        &token,
+        "--repository",
+        REPOSITORY,
+        "--pull-request",
+        PULL_REQUEST,
+        "--head-sha",
+        "f00d5c0be5f00d5c0be5f00d5c0be5f00d5c0be5",
+        "--scope",
+        "func-tests-live-smoke",
+    ]);
+    assert_eq!(
+        result.returncode,
+        0,
+        "scopes-send --head-sha failed{}",
+        result.context()
+    );
+    // Exit 0 is also what a 404-and-fall-back produces, so the status
+    // alone would pass against the very absence this case exists to
+    // catch. The fallback narrates itself; require that it stayed quiet.
+    assert!(
+        !result
+            .stderr
+            .contains("commit scopes endpoint answered 404"),
+        "scopes-send fell back to the pull request route{}",
+        result.context()
+    );
+}
+
+#[test]
 fn scopes_send() {
-    // `POST /v1/repos/{owner}/{repo}/pulls/{n}/scopes`.
+    // `POST /v1/repos/{owner}/{repo}/pulls/{n}/scopes` — the fallback
+    // route, taken when no head SHA can be named.
     let token = skip_if_unset!(live_token());
 
     let result = cli(&[

--- a/crates/mergify-core/src/http.rs
+++ b/crates/mergify-core/src/http.rs
@@ -311,6 +311,29 @@ impl Client {
         self.decode_json(resp).await
     }
 
+    /// PUT `body` as JSON to `path`, discard the response body, and
+    /// report whether the endpoint exists: `Ok(false)` on 404.
+    ///
+    /// For probing a route a Mergify deployment older than the CLI
+    /// does not serve yet, so the caller can fall back to one it does
+    /// — `ci scopes-send` is the first caller. 404 is terminal (never
+    /// retried), so the probe costs exactly one request.
+    ///
+    /// Distinct from [`Self::put`], which treats 404 as a failure like
+    /// any other 4xx, and from [`Self::post_no_response`], which does
+    /// the same for POST.
+    pub async fn put_no_response_if_exists<B: Serialize + ?Sized>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<bool, CliError> {
+        let url = self.join(path)?;
+        Ok(self
+            .execute_request_optional(self.inner.put(url).json(body))
+            .await?
+            .is_some())
+    }
+
     /// PATCH `body` as JSON to `path` and deserialize the JSON
     /// response as `T`. Mirrors [`Self::put`] but for endpoints that
     /// use the more permissive PATCH semantics (partial update) —
@@ -858,6 +881,62 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, CliError::MergifyApi(_)));
         assert!(err.to_string().contains("404"));
+    }
+
+    #[tokio::test]
+    async fn put_no_response_if_exists_reports_whether_the_route_answered() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/present"))
+            .and(body_json(serde_json::json!({"bar": 1})))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/absent"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("no such route"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = fast_client(&server, ApiFlavor::Mergify);
+        assert!(
+            client
+                .put_no_response_if_exists("/present", &Foo { bar: 1 })
+                .await
+                .unwrap()
+        );
+        // 404 is the caller's branch, and terminal — one request, no
+        // backoff, so the probe stays cheap.
+        assert!(
+            !client
+                .put_no_response_if_exists("/absent", &Foo { bar: 1 })
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn put_no_response_if_exists_propagates_other_4xx() {
+        // Only 404 is an answer about the route. A 403 is a real
+        // failure, and swallowing it as `false` would silently downgrade
+        // an auth problem into a fallback.
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/forbidden"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("denied"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = fast_client(&server, ApiFlavor::Mergify);
+        let err = client
+            .put_no_response_if_exists("/forbidden", &Foo { bar: 1 })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CliError::MergifyApi(_)));
+        assert!(err.to_string().contains("403"));
     }
 
     #[tokio::test]

--- a/skills/mergify-ci/SKILL.md
+++ b/skills/mergify-ci/SKILL.md
@@ -16,7 +16,7 @@ mergify ci junit-process FILES...         # Upload JUnit XML + evaluate quaranti
 mergify ci junit-upload FILES...          # (Deprecated) Use junit-process instead
 mergify ci git-refs                       # Detect base/head git references for the current PR
 mergify ci scopes --config PATH           # Detect scopes impacted by changed files
-mergify ci scopes-send -s SCOPE           # Send scopes tied to a pull request to Mergify
+mergify ci scopes-send -s SCOPE           # Report scopes against the pull request's head commit
 mergify ci queue-info                     # Output the current build's merge queue batch metadata (from the git note)
 mergify tests show NAME...                # Look up tests by name and print health, ratios, last failure
 mergify tests quarantines add NAME        # Add a test to the CI Insights quarantine
@@ -131,6 +131,8 @@ A renamed file counts against **both** of its paths, same as the engine: `git mv
 
 Sends scopes tied to a pull request to the Mergify API. Used when scopes are determined manually or from a file rather than auto-detected.
 
+The report is addressed by the pull request's **head SHA**, so it says which revision it was computed for and a result computed for an older head cannot be taken for the current one. The head is detected from the CI environment (GitHub Actions event payload, or `BUILDKITE_COMMIT`); pass `--head-sha` to name it explicitly. When no head SHA can be resolved -- or the Mergify deployment predates the commit endpoint -- the command falls back to reporting against the pull request number alone, which is what it always did.
+
 ```bash
 # Send specific scopes
 mergify ci scopes-send -s frontend -s backend -p 123
@@ -144,6 +146,10 @@ mergify ci scopes-send --scopes-file scopes.txt -p 123
 # Declare the PR impacts every scope (merge-queue barrier),
 # e.g. a build-system or CI-workflow change
 mergify ci scopes-send -s build-system --all -p 123
+
+# Name the revision explicitly (the pull request head, not the
+# revision a `pull_request` job checked out)
+mergify ci scopes-send -s frontend -p 123 --head-sha "$PR_HEAD_SHA"
 ```
 
 **Key options:**
@@ -153,6 +159,7 @@ mergify ci scopes-send -s build-system --all -p 123
 - `--scope` / `-s` -- Scope name (repeatable)
 - `--scopes-json` -- JSON file containing scopes (output of `mergify ci scopes --write`)
 - `--scopes-file` -- Plain-text file with one scope per line
+- `--head-sha` -- Head SHA the scopes were computed for, 40 hexadecimal characters (auto-detected from the CI environment)
 - `--all` -- Declare the pull request impacts every scope. The merge queue treats it as a barrier: never batched or run in parallel with other pull requests. The concrete scopes are still sent alongside the flag.
 
 ## Tests Show (`tests show`)


### PR DESCRIPTION
`ci scopes-send` addressed its report by pull request number alone, so
nothing tied an uploaded scope set to the head it was computed for and
whichever upload landed last won. A cancelled job, a failed upload step,
or a replayed workflow run therefore left an obsolete head's scopes
authoritative, and the merge queue batched on them.

It now reports against the pull request's head SHA, through the engine's
`PUT /v1/repos/{owner}/{repository}/commits/{sha}/scopes`, so the report
says which revision produced it.

The head comes from `--head-sha`, else from the CI environment: the
GitHub Actions event payload's `.pull_request.head.sha`, or the head
commit Buildkite and CircleCI check out. Not `get_head_sha`, which
answers the different question "which revision did the tests run
against" and falls back to `GITHUB_SHA` — on a `pull_request` event that
is the synthetic merge commit and on `pull_request_target` the base
branch, so a report keyed on either would be stored where nothing ever
reads it. Jenkins is left uncovered for the same reason: the Branch
Source plugin builds a pull request merged into its target by default,
and `GIT_COMMIT` is then that merge commit.

Whatever the source, the value is held to a full 40-character hex SHA
and lowercased before it reaches the path: the endpoint answers 422 to
any other shape, and a row stored under a spelling no reader looks for
is worse than a rejected one.

The number-addressed endpoint stays as the fallback for the two cases
the commit route cannot serve, rather than turning either into a failure
of a command that works today:

- No head SHA can be named. `scopes-send` runs on an explicit
  `--pull-request` from anywhere, and on Buildkite with `BUILDKITE_COMMIT`
  unset; neither names a revision.
- The deployment answers 404. The commit endpoint shipped in monorepo
  #39078; an on-prem Mergify older than that does not serve it, and
  breaking scope uploads there would degrade the queue far worse than
  reporting at the precision it already had. The fallback stays on POST
  rather than the pull-request route's own PUT, which landed only four
  months earlier and may be missing from the same deployments.

Both fallbacks say so on stderr, so a run never silently reports less
than it could.

The live smoke suite gains a case for the commit route. Its exit status
is not the assertion: a 404 and a fall back also exit 0, which is
exactly the absence the case exists to catch, so it requires that the
fallback stayed quiet.

Fixes MRGFY-8884

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MdqicbiJyjj1TNvYuVNL3b