### PR TITLE
fix(live-tests): use the admin token for the test-search smoke test

### DIFF
--- a/.github/workflows/func-tests-live.yaml
+++ b/.github/workflows/func-tests-live.yaml
@@ -37,11 +37,12 @@ jobs:
           #   junit-process). ci git-refs / queue-info are
           #   locally evaluated and need no token at all.
           # - _ADMIN exercises every endpoint under /merge-queue/
-          #   (status, show, pause, unpause) and the
+          #   (status, show, pause, unpause), the
           #   /scheduled_freeze endpoints (list, create, update,
-          #   delete). The CI token is rejected with 403 on these,
-          #   so they all share the queue-management-scoped admin
-          #   token.
+          #   delete) and the test search behind `tests show`. The
+          #   CI token is rejected with 403 on all of them — the
+          #   `ci` application key is scoped to what an unattended
+          #   job needs, so they share the admin token.
           # Tests early-return with `SKIP:` when their token is
           # unset rather than failing — local runs without secrets
           # still produce a useful subset.

--- a/crates/mergify-cli/tests/live_smoke.rs
+++ b/crates/mergify-cli/tests/live_smoke.rs
@@ -199,10 +199,12 @@ fn live_token() -> Option<String> {
     (!token.is_empty()).then_some(token)
 }
 
-/// Token for queue-admin endpoints (pause/unpause, freeze CRUD,
-/// queue status/show). Separated from [`live_token`] because the
-/// CI-scoped token is rejected with 403 by the queue-management
-/// family — keeping the CI token narrow is intentional.
+/// Token for every endpoint the CI-scoped key deliberately cannot
+/// reach: the queue-admin family (pause/unpause, freeze CRUD,
+/// queue status/show) and the interactive test-search endpoint
+/// behind `tests show`. Separated from [`live_token`] because the
+/// CI token is rejected with 403 on all of them — keeping it
+/// narrow is intentional, so a 403 here is the product working.
 fn live_admin_token() -> Option<String> {
     let token = std::env::var("LIVE_TEST_MERGIFY_TOKEN_ADMIN")
         .unwrap_or_default()
@@ -770,7 +772,14 @@ fn tests_show_no_match() {
     // routing, and JSON deserialization for the search endpoint
     // — the empty-match path returns exit 0 with a
     // `{"tests": []}` payload on stdout.
-    let token = skip_if_unset!(live_token());
+    //
+    // Admin token, not the CI one: `tests show` is an interactive
+    // developer command, and cutting the `ci` application key down
+    // to what an unattended job needs dropped this endpoint from
+    // its scope (Mergifyio/monorepo#39768). The endpoint now takes
+    // an admin key or a user token only, so the CI token gets a
+    // 403 here by design.
+    let token = skip_if_unset!(live_admin_token());
 
     let result = cli(&[
         "tests",


### PR DESCRIPTION
`tests_show_no_match` has failed on every pull request in this repo
since 2026-09-03, with a 403 on
`GET /v1/ci/{owner}/repositories/{repo}/search/tests`. Nothing in
this repo caused it and nothing here can be blamed for it: the
last green run was 2026-09-02 13:27Z, and
Mergifyio/monorepo#39768 — "cut the ci application key down to
least privilege" — merged 2026-09-03 08:40Z.

That change dropped `search/tests` from the `ci` application key's
scope on purpose. `mergify tests show` is an interactive developer
command, run from a laptop by someone with their own credential;
it is not work an unattended CI job does, so a token that sits in
CI config should not reach it. The endpoint's `security` in the
public OpenAPI is now `AdminApplicationKey`, `MergifyTokenBearerAuth`
and `GitHubTokenBearerAuth` — no `ApplicationKey`. The 403 is the
product working.

So the test is wrong, not the API: it passes
`LIVE_TEST_MERGIFY_TOKEN_CI` at an endpoint the CI key is
deliberately barred from. Switch it to
`LIVE_TEST_MERGIFY_TOKEN_ADMIN`, which is the admin application
key the queue-admin and freeze tests already use and which the
endpoint still accepts, and widen the comments on
`live_admin_token` and in the workflow so the next reader knows
the split is about what a CI token may reach, not about
merge-queue endpoints specifically.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018bo8M8rLudvf22poAaxLfY