### PR TITLE
refactor(core): split Mergify and GitHub token resolution

### DIFF
--- a/crates/mergify-ci/src/junit_process/command.rs
+++ b/crates/mergify-ci/src/junit_process/command.rs
@@ -85,7 +85,7 @@ async fn run_with_cap(
     // surfacing as exit code 2 when a required flag is missing,
     // before the command body runs.
     let api_url = auth::resolve_api_url(opts.api_url)?;
-    let token = auth::resolve_token(opts.token)?;
+    let token = auth::resolve_mergify_token(opts.token)?;
     let repository = detector::resolve_repository(opts.repository)?;
     let tests_target_branch = resolve_tests_target_branch(opts.tests_target_branch)?;
     let test_exit_code = resolve_test_exit_code(opts.test_exit_code)?;

--- a/crates/mergify-ci/src/scopes_send.rs
+++ b/crates/mergify-ci/src/scopes_send.rs
@@ -73,7 +73,7 @@ pub async fn run(opts: ScopesSendOptions<'_>, output: &mut dyn Output) -> Result
     };
 
     let repository = detector::resolve_repository(opts.repository)?;
-    let token = auth::resolve_token(opts.token)?;
+    let token = auth::resolve_mergify_token(opts.token)?;
     let api_url = auth::resolve_api_url(opts.api_url)?;
 
     // Whenever the deprecated `--file` flag is supplied, surface

--- a/crates/mergify-ci/src/tests_quarantine.rs
+++ b/crates/mergify-ci/src/tests_quarantine.rs
@@ -77,7 +77,7 @@ pub async fn quarantine(
 ) -> Result<ExitCode, CliError> {
     let repository = resolve_repository(opts.repository)?;
     let (owner, repo) = split_owner_repo(&repository)?;
-    let token = auth::resolve_token(opts.token)?;
+    let token = auth::resolve_mergify_token(opts.token)?;
     let api_url = auth::resolve_api_url(opts.api_url)?;
     let client = HttpClient::new(api_url, token, ApiFlavor::Mergify)?;
 
@@ -108,7 +108,7 @@ pub async fn unquarantine(
 ) -> Result<ExitCode, CliError> {
     let repository = resolve_repository(opts.repository)?;
     let (owner, repo) = split_owner_repo(&repository)?;
-    let token = auth::resolve_token(opts.token)?;
+    let token = auth::resolve_mergify_token(opts.token)?;
     let api_url = auth::resolve_api_url(opts.api_url)?;
     let client = HttpClient::new(api_url, token, ApiFlavor::Mergify)?;
 
@@ -183,7 +183,7 @@ async fn fetch_quarantines(
 ) -> Result<Vec<QuarantinedTest>, CliError> {
     let repository = resolve_repository(repository)?;
     let (owner, repo) = split_owner_repo(&repository)?;
-    let token = auth::resolve_token(token)?;
+    let token = auth::resolve_mergify_token(token)?;
     let api_url = auth::resolve_api_url(api_url)?;
     let client = HttpClient::new(api_url, token, ApiFlavor::Mergify)?;
 

--- a/crates/mergify-ci/src/tests_show.rs
+++ b/crates/mergify-ci/src/tests_show.rs
@@ -47,7 +47,7 @@ pub async fn run(
 ) -> Result<ExitCode, CliError> {
     let repository = resolve_repository(opts.repository)?;
     let (owner, repo) = split_owner_repo(&repository)?;
-    let token = auth::resolve_token(opts.token)?;
+    let token = auth::resolve_mergify_token(opts.token)?;
     let api_url = auth::resolve_api_url(opts.api_url)?;
     let client = Arc::new(HttpClient::new(api_url, token, ApiFlavor::Mergify)?);
 

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -338,7 +338,7 @@ struct StackCheckoutOpts {
     /// `Some((remote, branch))` from `--trunk REMOTE/BRANCH`;
     /// `None` falls back to `trunk::get_trunk` at runtime.
     trunk: Option<(String, String)>,
-    /// GitHub token; resolved via `mergify_core::auth::resolve_token`
+    /// GitHub token; resolved via `mergify_core::auth::resolve_github_token`
     /// when None.
     token: Option<String>,
 }
@@ -1177,7 +1177,7 @@ async fn resolve_stack_context(
     trunk: Option<(String, String)>,
     branch_prefix: Option<String>,
 ) -> Result<StackContext, mergify_core::CliError> {
-    let token = mergify_core::auth::resolve_token(token)?;
+    let token = mergify_core::auth::resolve_github_token(token)?;
     let github_server = mergify_stack::stack_context::resolve_github_server(None)?;
     let client = mergify_stack::remote_changes::default_client(github_server, &token)?;
     let trunk = if let Some((remote, branch)) = trunk {
@@ -2088,7 +2088,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 Ok(mergify_core::ExitCode::Success)
             }
             NativeCommand::StackCheckout(opts) => {
-                let token = mergify_core::auth::resolve_token(opts.token.as_deref())?;
+                let token = mergify_core::auth::resolve_github_token(opts.token.as_deref())?;
                 let github_server =
                     mergify_stack::stack_context::resolve_github_server(None)?;
                 let client = mergify_stack::remote_changes::default_client(
@@ -2191,7 +2191,7 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
                 }
             }
             NativeCommand::StackSync(opts) => {
-                let token = mergify_core::auth::resolve_token(opts.token.as_deref())?;
+                let token = mergify_core::auth::resolve_github_token(opts.token.as_deref())?;
                 let github_server = mergify_stack::stack_context::resolve_github_server(None)?;
                 let client =
                     mergify_stack::remote_changes::default_client(github_server, &token)?;
@@ -2631,17 +2631,17 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
             }
             NativeCommand::InternalStackRemoteChanges(opts) => {
                 // Search GitHub for PRs belonging to the stack and
-                // group them by Change-Id. The Python `stack/changes.py`
-                // consumer deserializes the JSON array back into the
-                // `RemoteChanges` dict it always built itself.
+                // group them by Change-Id, printed as a JSON array of
+                // `{change_id, pull}` records for whoever invoked this
+                // hidden command.
                 //
                 // Token comes from `--token` when supplied; otherwise
-                // `auth::resolve_token` reads `MERGIFY_TOKEN` /
-                // `GITHUB_TOKEN` / `gh auth token` so the Python
-                // caller can pass it via the subprocess env and keep
+                // `auth::resolve_github_token` reads `MERGIFY_TOKEN` /
+                // `GITHUB_TOKEN` / `gh auth token`, so a caller can
+                // pass it through the subprocess environment and keep
                 // it out of `ps`/process listings.
                 let token =
-                    mergify_core::auth::resolve_token(opts.token.as_deref())?;
+                    mergify_core::auth::resolve_github_token(opts.token.as_deref())?;
                 let client = mergify_stack::remote_changes::default_client(
                     opts.github_server,
                     &token,
@@ -3671,11 +3671,11 @@ struct InternalStackRemoteChangesArgs {
     #[arg(long = "github-server")]
     github_server: url::Url,
     /// Bearer token. Optional — when omitted the binary falls
-    /// back to `mergify_core::auth::resolve_token` (which reads
-    /// `MERGIFY_TOKEN` / `GITHUB_TOKEN` / `gh auth token`). The
-    /// Python caller should prefer setting `MERGIFY_TOKEN` in
-    /// the subprocess env over passing `--token` so the value
-    /// doesn't surface in `ps`/process listings.
+    /// back to `mergify_core::auth::resolve_github_token` (which reads
+    /// `MERGIFY_TOKEN` / `GITHUB_TOKEN` / `gh auth token`). Prefer
+    /// setting `MERGIFY_TOKEN` in the subprocess environment over
+    /// passing `--token`, so the value doesn't surface in
+    /// `ps`/process listings.
     #[arg(long)]
     token: Option<String>,
     /// Repository owner.

--- a/crates/mergify-config/src/simulate.rs
+++ b/crates/mergify-config/src/simulate.rs
@@ -55,7 +55,7 @@ pub async fn run(opts: SimulateOptions<'_>, output: &mut dyn Output) -> Result<(
         CliError::Configuration(format!("cannot read {}: {e}", config_path.display()))
     })?;
 
-    let token = auth::resolve_token(opts.token)?;
+    let token = auth::resolve_mergify_token(opts.token)?;
     let api_url = auth::resolve_api_url(opts.api_url)?;
 
     output.status(&format!("Simulating against {api_url}…"))?;

--- a/crates/mergify-core/src/auth.rs
+++ b/crates/mergify-core/src/auth.rs
@@ -5,6 +5,16 @@
 //! env → `gh auth token` (the GitHub CLI). Mirrors Python's
 //! `utils.get_default_token`.
 //!
+//! That one chain feeds two unrelated services: the Mergify API
+//! ([`resolve_mergify_token`]) and, for the `stack` command group,
+//! the GitHub REST API ([`resolve_github_token`]). They resolve
+//! identically today and are still two functions, because only one
+//! of them is going to grow — the Mergify side gains the credential
+//! `mergify auth login` stores and deprecates the two GitHub
+//! fallbacks, while `stack` keeps sending GitHub exactly what it
+//! sends it now. A single resolver could not do one without doing
+//! the other.
+//!
 //! Repository: `--repository` flag → `GITHUB_REPOSITORY` env →
 //! `git config --get remote.origin.url` parsed into `<owner>/<repo>`.
 //! Mirrors Python's `utils.get_default_repository` + `utils.get_slug`.
@@ -27,12 +37,29 @@ use crate::env::var_non_empty;
 
 const DEFAULT_API_URL: &str = "https://api.mergify.com";
 
-/// Resolve the Mergify API bearer token.
+/// Resolve the bearer token for **Mergify API** calls.
 ///
 /// Precedence: explicit `--token`, then `MERGIFY_TOKEN`, then
 /// `GITHUB_TOKEN`, then the output of `gh auth token`. Errors when
 /// none of those produce a non-empty value.
-pub fn resolve_token(explicit: Option<&str>) -> Result<String, CliError> {
+pub fn resolve_mergify_token(explicit: Option<&str>) -> Result<String, CliError> {
+    resolve_token_chain(explicit)
+}
+
+/// Resolve the bearer token for **GitHub REST** calls — the
+/// `ApiFlavor::GitHub` client the `stack` command group talks to
+/// `api.github.com` with.
+///
+/// Same precedence as [`resolve_mergify_token`]: explicit
+/// `--token`, then `MERGIFY_TOKEN`, then `GITHUB_TOKEN`, then the
+/// output of `gh auth token`.
+pub fn resolve_github_token(explicit: Option<&str>) -> Result<String, CliError> {
+    resolve_token_chain(explicit)
+}
+
+/// The shared `--token` → `MERGIFY_TOKEN` → `GITHUB_TOKEN` →
+/// `gh auth token` chain both resolvers currently answer with.
+fn resolve_token_chain(explicit: Option<&str>) -> Result<String, CliError> {
     if let Some(value) = explicit.filter(|s| !s.is_empty()) {
         return Ok(value.to_string());
     }
@@ -168,7 +195,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn resolve_token_prefers_explicit_over_env() {
+    fn resolve_mergify_token_prefers_explicit_over_env() {
         temp_env::with_vars(
             [
                 ("MERGIFY_TOKEN", Some("env-mergify")),
@@ -176,7 +203,7 @@ mod tests {
             ],
             || {
                 assert_eq!(
-                    resolve_token(Some("explicit-token")).unwrap(),
+                    resolve_mergify_token(Some("explicit-token")).unwrap(),
                     "explicit-token",
                 );
             },
@@ -184,33 +211,33 @@ mod tests {
     }
 
     #[test]
-    fn resolve_token_falls_back_to_mergify_env() {
+    fn resolve_mergify_token_falls_back_to_mergify_env() {
         temp_env::with_vars(
             [
                 ("MERGIFY_TOKEN", Some("env-mergify")),
                 ("GITHUB_TOKEN", Some("env-github")),
             ],
             || {
-                assert_eq!(resolve_token(None).unwrap(), "env-mergify");
+                assert_eq!(resolve_mergify_token(None).unwrap(), "env-mergify");
             },
         );
     }
 
     #[test]
-    fn resolve_token_falls_back_to_github_env_when_mergify_unset() {
+    fn resolve_mergify_token_falls_back_to_github_env_when_mergify_unset() {
         temp_env::with_vars(
             [
                 ("MERGIFY_TOKEN", None),
                 ("GITHUB_TOKEN", Some("env-github")),
             ],
             || {
-                assert_eq!(resolve_token(None).unwrap(), "env-github");
+                assert_eq!(resolve_mergify_token(None).unwrap(), "env-github");
             },
         );
     }
 
     #[test]
-    fn resolve_token_error_message_mentions_gh() {
+    fn resolve_mergify_token_error_message_mentions_gh() {
         // When env vars are unset and `gh auth token` is unavailable
         // (or fails), the user-facing error must mention the gh
         // fallback so the user knows there's a third option.
@@ -223,10 +250,57 @@ mod tests {
                 ("PATH", Some("/nonexistent-directory-for-test")),
             ],
             || {
-                let err = resolve_token(None).unwrap_err();
+                let err = resolve_mergify_token(None).unwrap_err();
                 let msg = err.to_string();
                 assert!(msg.contains("MERGIFY_TOKEN"), "got {msg:?}");
                 assert!(msg.contains("gh client"), "got {msg:?}");
+            },
+        );
+    }
+
+    // The GitHub resolver is what `stack` sends to `api.github.com`.
+    // Pinning its whole chain here — rather than asserting it equals
+    // whatever the Mergify one returns — is the point: the two
+    // diverge on the Mergify side, and this test has to keep failing
+    // if that divergence ever reaches the GitHub side.
+    #[test]
+    fn resolve_github_token_prefers_explicit_over_env() {
+        temp_env::with_vars(
+            [
+                ("MERGIFY_TOKEN", Some("env-mergify")),
+                ("GITHUB_TOKEN", Some("env-github")),
+            ],
+            || {
+                assert_eq!(
+                    resolve_github_token(Some("explicit-token")).unwrap(),
+                    "explicit-token",
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_github_token_falls_back_to_mergify_env() {
+        temp_env::with_vars(
+            [
+                ("MERGIFY_TOKEN", Some("env-mergify")),
+                ("GITHUB_TOKEN", Some("env-github")),
+            ],
+            || {
+                assert_eq!(resolve_github_token(None).unwrap(), "env-mergify");
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_github_token_falls_back_to_github_env_when_mergify_unset() {
+        temp_env::with_vars(
+            [
+                ("MERGIFY_TOKEN", None),
+                ("GITHUB_TOKEN", Some("env-github")),
+            ],
+            || {
+                assert_eq!(resolve_github_token(None).unwrap(), "env-github");
             },
         );
     }

--- a/crates/mergify-core/src/command_context.rs
+++ b/crates/mergify-core/src/command_context.rs
@@ -52,7 +52,7 @@ impl CommandContext {
     ) -> Result<Self, CliError> {
         Ok(Self {
             repository: auth::resolve_repository(repository)?,
-            token: auth::resolve_token(token)?,
+            token: auth::resolve_mergify_token(token)?,
             api_url: auth::resolve_api_url(api_url)?,
         })
     }


### PR DESCRIPTION
`auth::resolve_token` answered one chain -- `--token`, `MERGIFY_TOKEN`,
`GITHUB_TOKEN`, `gh auth token` -- for two unrelated services. `stack`
sends the result to `api.github.com`; every other command group sends it
to `api.mergify.com`.

Only the Mergify side is going to move. It gains the credential
`mergify auth login` stores, and its two GitHub fallbacks get a
deprecation warning. `stack` keeps sending GitHub exactly what it sends
it today, warns about nothing, and never sees a Mergify-issued token.
One resolver cannot do the first without doing the second, so this
splits it in two before anything changes.

No behavior change: both resolvers answer the same chain, and each side
pins its own precedence in tests rather than asserting the two agree --
they are about to stop agreeing, and the GitHub test has to keep failing
if the divergence ever reaches it.

Fixes MRGFY-8703