### PR TITLE
feat(core): store the Mergify credential in the OS keychain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +114,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b350bfd03649e07aa05c0a81b3e15934374e585c98204a57e20b9d49f49bb9a"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +132,137 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -192,12 +345,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -229,10 +404,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -279,6 +469,16 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout",
 ]
 
 [[package]]
@@ -350,6 +550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +569,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -400,6 +615,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +646,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -454,6 +681,15 @@ dependencies = [
  "dispatch2",
  "nix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -510,6 +746,28 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -563,6 +821,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,7 +860,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -706,6 +1011,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -867,6 +1185,30 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "http"
@@ -1119,6 +1461,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
+]
+
+[[package]]
 name = "insta"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,6 +1636,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2270074a3d26bcac93c1dc5d2845eb4c089e8d761ccf6e0ea266a16004640627"
+dependencies = [
+ "apple-native-keyring-store",
+ "keyring-core",
+ "windows-native-keyring-store",
+ "zbus-secret-service-keyring-store",
+]
+
+[[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,6 +1667,15 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libredox"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1342,6 +1724,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mergify-ci"
@@ -1423,10 +1814,14 @@ dependencies = [
 name = "mergify-core"
 version = "0.0.0"
 dependencies = [
+ "chrono",
+ "dirs",
+ "keyring",
  "reqwest",
  "serde",
  "serde_json",
  "temp-env",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",
@@ -1733,10 +2128,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1817,6 +2234,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,6 +2280,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -2024,6 +2475,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2171,7 +2633,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2228,7 +2690,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2284,6 +2746,25 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secret-service"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5107b24b91445dd2aa449a258a1807b63240942157292354dc5bfdbeb8bc6db8"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "getrandom 0.4.3",
+ "hkdf",
+ "hybrid-array",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2 0.11.0",
+ "zbus",
+]
 
 [[package]]
 name = "security-framework"
@@ -2369,6 +2850,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2423,6 +2915,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -2575,7 +3077,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2692,6 +3194,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2802,6 +3334,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2854,6 +3397,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "uuid-simd"
@@ -3001,7 +3555,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3044,6 +3598,19 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
 
 [[package]]
 name = "windows-result"
@@ -3146,6 +3713,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3201,6 +3777,87 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74801d001b9e7729adb4f1825b67b398185fed424749aa3d8bacf70417137d9a"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3288,3 +3945,44 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.3",
+ "winnow",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,22 @@ clap_mangen = "0.3"
 console = "0.16"
 ctrlc = "3"
 dialoguer = { version = "0.12", default-features = false, features = ["fuzzy-select"] }
+dirs = "6"
 flate2 = "1"
 getrandom = "0.4"
 glob = "0.3"
 globset = "0.4"
 iana-time-zone = "0.1"
 jsonschema = { version = "0.49", default-features = false }
+# OS credential store for the token `mergify auth login` mints. The
+# default feature set is the one that keeps the Linux build free of C:
+# `zbus-secret-service-keyring-store` talks to the Secret Service over
+# pure-Rust D-Bus, so the manylinux wheel needs no libsecret at build
+# time and the user's machine needs no `.so` at run time. macOS and
+# Windows use their native stores. Every one of them can be absent —
+# a container has no D-Bus session — and the store falls back to a
+# 0600 file, which is why no keychain failure is fatal.
+keyring = "4"
 opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic-messages", "trace"] }
 prost = "0.14"
 quick-xml = "0.41"

--- a/crates/mergify-core/Cargo.toml
+++ b/crates/mergify-core/Cargo.toml
@@ -9,10 +9,20 @@ authors.workspace = true
 description = "Shared foundations for mergify-cli: HTTP, auth, errors, output, git, config, prompts."
 publish = false
 
+[features]
+# Credential stores that model one specific keychain failure, for a
+# caller whose own error paths are otherwise unreachable. Turned on
+# by a dev-dependency only.
+test-support = []
+
 [dependencies]
+chrono = { workspace = true }
+dirs = { workspace = true }
+keyring = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/mergify-core/src/credentials.rs
+++ b/crates/mergify-core/src/credentials.rs
@@ -1,0 +1,1083 @@
+//! Where the CLI keeps the Mergify credential `mergify auth login`
+//! mints.
+//!
+//! Two backends, in this order:
+//!
+//! 1. **The OS keychain** — macOS Keychain, the Windows credential
+//!    manager, or a freedesktop Secret Service over D-Bus.
+//! 2. **A `0600` JSON file** under the user's configuration
+//!    directory, used whenever the keychain is absent or refuses.
+//!    A container, a CI runner, or an SSH session on a headless box
+//!    has no D-Bus session at all, and `auth login` has to work
+//!    there — so a machine with no credential store falls back
+//!    silently.
+//!
+//! A keychain that *exists* and refuses is the one fatal case. `get`
+//! reads the keychain before the file, so an entry left in it would
+//! shadow whatever the fallback stored: `set` and `delete` verify
+//! the keychain no longer holds the key, and refuse rather than
+//! leave the user on a credential they think they replaced. "Locked"
+//! and "empty" are told apart by [`KeychainState`], because a
+//! read-back that cannot distinguish them verifies nothing.
+//!
+//! Entries are keyed by **API URL**, not by "the Mergify token":
+//! one machine can legitimately hold a credential for the hosted
+//! service and one for an on-premise install at the same time, and
+//! each has to survive the other's `logout`.
+//!
+//! Nothing here logs a secret. The `Debug` impls below exist so
+//! callers can trace *where* a credential came from without the
+//! token itself reaching a log line.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+
+use chrono::DateTime;
+use chrono::Utc;
+use serde::Deserialize;
+use serde::Serialize;
+use url::Url;
+
+use crate::error::CliError;
+
+/// Keychain service name every entry is filed under. The account
+/// within it is the API URL.
+const KEYRING_SERVICE: &str = "mergify-cli";
+
+/// Directory under the platform config directory, and the file in
+/// it. Named for its content so a future `config.json` next to it
+/// stays obviously non-secret.
+const CONFIG_SUBDIR: &str = "mergify";
+const CREDENTIALS_FILE: &str = "credentials.json";
+
+/// A stored Mergify credential.
+///
+/// `expires_at` is what the server said when it minted the token,
+/// and it is advisory: a token can be revoked from the dashboard
+/// long before it expires, so a client that trusts this field
+/// instead of the API's answer will be wrong. It is here so
+/// `auth status` can say when the credential runs out without a
+/// round trip.
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct Credential {
+    pub token: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+/// Hand-written, because a derived one prints the token. Every
+/// `Debug` in this module exists to trace *where* a credential came
+/// from, and the first `?credential` in a `tracing` call would have
+/// put the secret itself in a log file.
+impl std::fmt::Debug for Credential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Credential")
+            .field("token", &"<redacted>")
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
+}
+
+/// Which backend a credential was read from or written to.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Location {
+    Keychain,
+    File(PathBuf),
+}
+
+impl std::fmt::Display for Location {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Keychain => f.write_str("the system keychain"),
+            Self::File(path) => write!(f, "{}", path.display()),
+        }
+    }
+}
+
+/// A credential together with the backend it came out of, so
+/// `auth status` can tell the user where their secret actually
+/// lives.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StoredCredential {
+    pub credential: Credential,
+    pub location: Location,
+}
+
+/// The two-backend credential store.
+pub struct CredentialStore {
+    /// [`KeychainBackend::Off`] skips the keychain entirely, so a
+    /// unit test never reaches — or worse, writes to — the
+    /// developer's real keychain.
+    keychain: KeychainBackend,
+    /// `None` when the platform offers no configuration directory.
+    /// Only the *fallback* needs a path, so a machine without one
+    /// still uses its keychain — and that is exactly the kind of
+    /// machine that has one: a Windows service account, a systemd
+    /// unit with `ProtectHome=`, anything running without a home.
+    file: Option<PathBuf>,
+}
+
+impl CredentialStore {
+    /// The store the binary uses: OS keychain first, then a `0600`
+    /// file under the platform configuration directory.
+    ///
+    /// Infallible on purpose. A machine with no configuration
+    /// directory has no *fallback*, which is not the same as having
+    /// no store: failing here would refuse to read a keychain entry
+    /// that is sitting right there.
+    #[must_use]
+    pub fn discover() -> Self {
+        Self {
+            keychain: KeychainBackend::Os,
+            file: credentials_file(),
+        }
+    }
+
+    /// A keychain-free store whose file lives directly at `path`.
+    /// Tests use it; so does any caller that has already decided
+    /// the keychain is not an option.
+    #[must_use]
+    pub fn file_at(path: PathBuf) -> Self {
+        Self {
+            keychain: KeychainBackend::Off,
+            file: Some(path),
+        }
+    }
+
+    /// Read the credential stored for `api_url`, if there is one.
+    ///
+    /// Checks the keychain first and the file second, so a machine
+    /// that once fell back to the file and later gained a working
+    /// keychain reads the newer entry.
+    pub fn get(&self, api_url: &Url) -> Result<Option<StoredCredential>, CliError> {
+        let key = key_for(api_url);
+        if let Some(raw) = self.keychain.get(&key) {
+            let credential = parse_secret(&raw)?;
+            return Ok(Some(StoredCredential {
+                credential,
+                location: Location::Keychain,
+            }));
+        }
+        let Some(file) = &self.file else {
+            return Ok(None);
+        };
+        let Some(credential) = read_file(file)?.remove(&key) else {
+            return Ok(None);
+        };
+        Ok(Some(StoredCredential {
+            credential,
+            location: Location::File(file.clone()),
+        }))
+    }
+
+    /// Store `credential` for `api_url` and report where it landed.
+    ///
+    /// The backend that did *not* take it is cleared, so a machine
+    /// that logged in once without a keychain and once with it does
+    /// not leave the older secret readable on disk.
+    ///
+    /// # Errors
+    ///
+    /// [`CliError::Configuration`] when neither backend is
+    /// available: no keychain answered and there is nowhere to put a
+    /// file.
+    pub fn set(&self, api_url: &Url, credential: &Credential) -> Result<Location, CliError> {
+        let key = key_for(api_url);
+        let secret = serde_json::to_string(credential)
+            .map_err(|e| CliError::wrap("serialize the credential", e))?;
+        if self.keychain.enabled() && self.keychain.set(&key, &secret) {
+            // Best effort: the credential is safely in the keychain,
+            // which `get` reads first, so a stale file copy is
+            // shadowed rather than dangerous. Failing here — a
+            // corrupt `credentials.json` makes this error — would
+            // report a failed login that in fact stored a token, and
+            // every retry would mint another one nobody revokes.
+            if let Err(e) = self.remove_from_file(&key) {
+                tracing::debug!(error = %e, "could not clear the fallback credential file");
+            }
+            return Ok(Location::Keychain);
+        }
+        // The keychain refused the write, so the fallback has to
+        // take it. Everything that can refuse the fallback is
+        // resolved *before* the stale keychain entry is deleted: a
+        // delete followed by a failed write would leave the machine
+        // with no credential at all, and `login` revokes the token
+        // it just minted on this error path — so the user would end
+        // up logged out of a machine that was working a second ago.
+        let Some(file) = &self.file else {
+            return Err(CliError::Configuration(
+                "no system keychain answered, and this machine offers no configuration \
+                 directory to store the credential in — check that your user has a home \
+                 directory"
+                    .to_string(),
+            ));
+        };
+        let mut entries = read_file(file)?;
+        // If the keychain is nevertheless holding an older entry for
+        // this URL, writing the fallback would store a credential
+        // that can never be read: `get` checks the keychain first and
+        // would keep answering with the stale one. So read back
+        // rather than trust the delete, and refuse unless that
+        // read-back is conclusive: "the store refused" is not "there
+        // is nothing there".
+        if self.keychain.enabled() {
+            self.keychain.delete(&key);
+            match self.keychain.probe(&key) {
+                KeychainState::Absent => {}
+                KeychainState::Present => {
+                    return Err(CliError::Configuration(format!(
+                        "an older credential for {api_url} is in the system keychain and \
+                         could not be replaced or removed. Unlock your keychain and try \
+                         again.",
+                    )));
+                }
+                KeychainState::Unknown => {
+                    return Err(CliError::Configuration(format!(
+                        "the system keychain refused both the write and a read-back, so an \
+                         older credential for {api_url} may still be in it — and one there \
+                         would shadow anything stored on disk. Unlock your keychain and try \
+                         again.",
+                    )));
+                }
+            }
+        }
+        entries.insert(key.clone(), credential.clone());
+        write_file(file, &entries)?;
+        Ok(Location::File(file.clone()))
+    }
+
+    /// Forget the credential for `api_url` in both backends.
+    /// Returns whether either of them held one.
+    ///
+    /// # Errors
+    ///
+    /// [`CliError::Configuration`] when the keychain still holds
+    /// the credential afterwards, or will not say. A keychain locked
+    /// against a delete reports the same `false` as one that had
+    /// nothing, so the entry is read back rather than the delete
+    /// believed — and a read-back that cannot answer is an error
+    /// too, because `logout` promises a machine that no longer
+    /// carries the credential.
+    pub fn delete(&self, api_url: &Url) -> Result<bool, CliError> {
+        let key = key_for(api_url);
+        // The keychain first, and its verdict held back until the
+        // file has been tried too. The two backends fail
+        // independently: a corrupt `credentials.json` used to abort
+        // the whole call before the keychain was touched, which made
+        // `logout` a permanent no-op against the one backend that
+        // actually held the credential.
+        let mut from_keychain = false;
+        let mut keychain_verdict = Ok(());
+        if self.keychain.enabled() {
+            from_keychain = self.keychain.delete(&key);
+            keychain_verdict = match self.keychain.probe(&key) {
+                KeychainState::Absent => Ok(()),
+                KeychainState::Present => Err(CliError::Configuration(format!(
+                    "the credential for {api_url} is still in the system keychain: it could \
+                     not be removed. Unlock your keychain and run `mergify auth logout` \
+                     again.",
+                ))),
+                KeychainState::Unknown => Err(CliError::Configuration(format!(
+                    "the system keychain refused a read-back, so the credential for \
+                     {api_url} may still be in it. Unlock your keychain and run `mergify \
+                     auth logout` again.",
+                ))),
+            };
+        }
+        let from_file = self.remove_from_file(&key);
+        // The keychain's verdict first: a credential still live in it
+        // outranks a file this call could not rewrite. Then the
+        // file's own error -- not folded into the `||` below, where
+        // short-circuiting on a successful keychain delete would
+        // swallow it.
+        keychain_verdict?;
+        let from_file = from_file?;
+        Ok(from_keychain || from_file)
+    }
+
+    /// Path of the file backend, or `None` when this machine has no
+    /// configuration directory to put one in.
+    #[must_use]
+    pub fn file_path(&self) -> Option<&Path> {
+        self.file.as_deref()
+    }
+
+    fn remove_from_file(&self, key: &str) -> Result<bool, CliError> {
+        let Some(file) = &self.file else {
+            return Ok(false);
+        };
+        let mut entries = read_file(file)?;
+        if entries.remove(key).is_none() {
+            return Ok(false);
+        }
+        write_file(file, &entries)?;
+        Ok(true)
+    }
+}
+
+fn read_file(file: &Path) -> Result<BTreeMap<String, Credential>, CliError> {
+    let raw = match fs::read(file) {
+        Ok(raw) => raw,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
+        Err(e) => {
+            return Err(CliError::wrap(format!("read {}", file.display()), e));
+        }
+    };
+    serde_json::from_slice(&raw).map_err(|e| {
+        // Not "you are logged out": a corrupt store would send
+        // the user round `auth login` forever without ever
+        // saying which file to look at.
+        CliError::Configuration(format!(
+            "{} is not valid credential JSON ({e}). Delete it and run `mergify auth login` again.",
+            file.display(),
+        ))
+    })
+}
+
+fn write_file(file: &Path, entries: &BTreeMap<String, Credential>) -> Result<(), CliError> {
+    if let Some(parent) = file.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| CliError::wrap(format!("create {}", parent.display()), e))?;
+        restrict_to_owner(parent, 0o700)?;
+    }
+    // An empty store is a deleted file rather than `{}`: leaving
+    // an empty JSON object behind reads, to anyone auditing the
+    // machine, like a credential that failed to load.
+    if entries.is_empty() {
+        match fs::remove_file(file) {
+            Ok(()) => return Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => {
+                return Err(CliError::wrap(format!("remove {}", file.display()), e));
+            }
+        }
+    }
+    let rendered = serde_json::to_vec_pretty(entries)
+        .map_err(|e| CliError::wrap("serialize the credential store", e))?;
+    // Each write is atomic (temp file + rename) but the surrounding
+    // read-modify-write is not locked, so two `auth` commands racing
+    // on *different* API URLs can lose one entry. Not fixed here: the
+    // writers are `auth login` and `auth logout`, both driven by a
+    // person at a terminal, and a lock file is its own design — stale
+    // locks, no-home machines, Windows semantics. It is a real hole,
+    // just a narrow one.
+    // Written to a sibling temp file and renamed, so a crash
+    // mid-write cannot truncate a store that holds a second
+    // deployment's credential. `NamedTempFile` creates at 0600
+    // on Unix; the explicit chmod covers the umask-independent
+    // guarantee and documents the intent.
+    let mut tmp = tempfile::NamedTempFile::new_in(
+        file.parent()
+            .ok_or_else(|| CliError::Configuration("credential path has no parent".into()))?,
+    )
+    .map_err(|e| CliError::wrap("create a temporary credential file", e))?;
+    restrict_to_owner(tmp.path(), 0o600)?;
+    tmp.write_all(&rendered)
+        .map_err(|e| CliError::wrap("write the credential store", e))?;
+    tmp.flush()
+        .map_err(|e| CliError::wrap("flush the credential store", e))?;
+    tmp.persist(file)
+        .map_err(|e| CliError::wrap(format!("write {}", file.display()), e.error))?;
+    Ok(())
+}
+
+/// Restrict `path` to its owner. A no-op off Unix, where the file
+/// inherits the ACL of the user's profile directory and there is no
+/// mode to set.
+#[cfg(unix)]
+fn restrict_to_owner(path: &Path, mode: u32) -> Result<(), CliError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(mode))
+        .map_err(|e| CliError::wrap(format!("restrict permissions on {}", path.display()), e))
+}
+
+#[cfg(not(unix))]
+fn restrict_to_owner(_path: &Path, _mode: u32) -> Result<(), CliError> {
+    Ok(())
+}
+
+/// The account name an API URL is filed under, in both backends.
+///
+/// `Url::as_str` normalizes the scheme, the case, and the default
+/// port, but not a trailing slash on the path — and a trailing slash
+/// is not a different deployment. Every request the client makes
+/// joins an absolute path (`/v1/user`), which replaces the base
+/// path outright, so `https://host/api` and `https://host/api/`
+/// reach byte-identical endpoints. Two entries for them would tell a
+/// user who logged in with one spelling that they are not logged in
+/// with the other.
+fn key_for(api_url: &Url) -> String {
+    let raw = api_url.as_str();
+    raw.strip_suffix('/').unwrap_or(raw).to_string()
+}
+
+fn parse_secret(raw: &str) -> Result<Credential, CliError> {
+    serde_json::from_str(raw).map_err(|e| {
+        CliError::Configuration(format!(
+            "the credential in the system keychain is not valid JSON ({e}). \
+             Run `mergify auth logout` then `mergify auth login` again.",
+        ))
+    })
+}
+
+/// What the keychain says about one entry, when the answer has to
+/// be trusted.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum KeychainState {
+    /// The entry is there.
+    Present,
+    /// Nothing is there to read — either the store said so, or this
+    /// machine has no credential store at all, which for a caller
+    /// asking "could an entry here shadow the file?" is the same
+    /// answer.
+    Absent,
+    /// A store exists and refused to answer: locked, or a user who
+    /// clicked Deny. Nothing can be concluded from that.
+    Unknown,
+}
+
+/// The keychain half of the store.
+///
+/// An enum rather than four free functions because the branches that
+/// decide whether a failed `login` is *fatal* are the delicate part
+/// of this module, and they are unreachable in a test that cannot
+/// stand a keychain up. `Fake` is the seam; it exists only under
+/// `cfg(test)`, so the shipped binary has the two real arms.
+enum KeychainBackend {
+    /// The platform credential store, via `keyring`.
+    Os,
+    /// No keychain: what a file-only caller asks for.
+    Off,
+    #[cfg(any(test, feature = "test-support"))]
+    Fake(std::sync::Mutex<FakeKeychain>),
+}
+
+impl KeychainBackend {
+    /// Whether the keychain is consulted at all. `false` skips every
+    /// keychain leg, including the verification ones.
+    fn enabled(&self) -> bool {
+        !matches!(self, Self::Off)
+    }
+
+    /// Read one entry: `Ok(None)` is "nothing filed here", `Err` is
+    /// the store declining to answer.
+    fn read(&self, key: &str) -> Result<Option<String>, keyring::Error> {
+        match self {
+            Self::Os => {
+                match keyring::Entry::new(KEYRING_SERVICE, key).and_then(|e| e.get_password()) {
+                    Ok(secret) => Ok(Some(secret)),
+                    Err(keyring::Error::NoEntry) => Ok(None),
+                    Err(e) => Err(e),
+                }
+            }
+            // Consistently "there is no store here", so `get`
+            // answers `None`, `probe` answers `Absent`, and the two
+            // verification branches cannot fire on a file-only store.
+            Self::Off => Err(keyring::Error::NoDefaultStore),
+            #[cfg(any(test, feature = "test-support"))]
+            Self::Fake(fake) => fake.lock().unwrap().read(),
+        }
+    }
+
+    fn write(&self, key: &str, secret: &str) -> Result<(), keyring::Error> {
+        match self {
+            Self::Os => {
+                keyring::Entry::new(KEYRING_SERVICE, key).and_then(|e| e.set_password(secret))
+            }
+            Self::Off => Err(keyring::Error::NoDefaultStore),
+            #[cfg(any(test, feature = "test-support"))]
+            Self::Fake(fake) => fake.lock().unwrap().write(secret),
+        }
+    }
+
+    /// Remove one entry, reporting whether one was there.
+    fn remove(&self, key: &str) -> Result<bool, keyring::Error> {
+        match self {
+            Self::Os => match keyring::Entry::new(KEYRING_SERVICE, key)
+                .and_then(|e| e.delete_credential())
+            {
+                Ok(()) => Ok(true),
+                Err(keyring::Error::NoEntry) => Ok(false),
+                Err(e) => Err(e),
+            },
+            Self::Off => Err(keyring::Error::NoDefaultStore),
+            #[cfg(any(test, feature = "test-support"))]
+            Self::Fake(fake) => fake.lock().unwrap().remove(),
+        }
+    }
+
+    /// Read one entry for the *read path*. Every failure — no entry,
+    /// no keychain, a locked one, a user who clicked Deny —
+    /// collapses to `None`: the caller's next move is the file
+    /// backend either way, and the distinction is only worth a debug
+    /// line.
+    fn get(&self, key: &str) -> Option<String> {
+        match self.read(key) {
+            Ok(secret) => secret,
+            Err(e) => {
+                tracing::debug!(error = %e, "no credential read from the system keychain");
+                None
+            }
+        }
+    }
+
+    /// Write one entry, reporting whether it took. `false` means the
+    /// caller falls back to the file.
+    fn set(&self, key: &str, secret: &str) -> bool {
+        match self.write(key, secret) {
+            Ok(()) => true,
+            Err(e) => {
+                tracing::debug!(error = %e, "could not store the credential in the system keychain");
+                false
+            }
+        }
+    }
+
+    /// Delete one entry, reporting whether one was there. A store
+    /// that refused reports the same `false` as an empty one, which
+    /// is why every caller follows this with [`Self::probe`].
+    fn delete(&self, key: &str) -> bool {
+        match self.remove(key) {
+            Ok(removed) => removed,
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "could not delete the credential from the system keychain"
+                );
+                false
+            }
+        }
+    }
+
+    /// Ask about `key`, keeping the three answers apart.
+    ///
+    /// [`Self::get`] collapses every failure to `None` because its
+    /// caller reaches for the file either way. The two verification
+    /// points cannot afford that: they are deciding whether an entry
+    /// `get` reads *first* is about to shadow what they just wrote,
+    /// and "the store refused" is not "there is nothing there".
+    fn probe(&self, key: &str) -> KeychainState {
+        match self.read(key) {
+            Ok(Some(_)) => KeychainState::Present,
+            Ok(None) => KeychainState::Absent,
+            Err(e) => keychain_state_for(&e),
+        }
+    }
+}
+
+/// Split out from [`KeychainBackend::probe`] so the mapping that
+/// decides whether a failed login is fatal is testable on its own.
+fn keychain_state_for(error: &keyring::Error) -> KeychainState {
+    match error {
+        // `NoEntry` is the store answering "nothing filed here".
+        //
+        // `NoDefaultStore` is `keyring` failing to *initialize* a
+        // store, which it caches process-wide in a `LazyLock`. That
+        // covers both "this machine has no credential store" — a
+        // container, a systemd unit, an SSH session with no D-Bus,
+        // the case the whole file fallback exists for — and "the
+        // store is there but could not be reached just now". The
+        // crate does not tell the two apart (`Entry::store_status()`
+        // separates only an unsupported platform), and they want
+        // opposite answers, so this picks the one whose failure is
+        // recoverable: treating it as `Unknown` would make
+        // `auth login` fatal on every headless machine, while
+        // treating it as `Absent` costs a desktop whose session bus
+        // blinked one stale-credential 403 that the next
+        // `auth login` clears.
+        keyring::Error::NoEntry | keyring::Error::NoDefaultStore => KeychainState::Absent,
+        _ => {
+            tracing::debug!(error = %error, "could not verify the system keychain entry");
+            KeychainState::Unknown
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+impl CredentialStore {
+    /// A store whose keychain is [`FakeKeychain`], so the branches
+    /// that decide whether a login is fatal can be exercised.
+    fn with_fake(fake: FakeKeychain, file: Option<PathBuf>) -> Self {
+        Self {
+            keychain: KeychainBackend::Fake(std::sync::Mutex::new(fake)),
+            file,
+        }
+    }
+}
+
+#[cfg(test)]
+impl CredentialStore {
+    /// What the fake keychain is holding, for a test that has to
+    /// assert an entry survived — or did not.
+    fn fake_entry(&self) -> Option<String> {
+        match &self.keychain {
+            KeychainBackend::Fake(fake) => fake.lock().unwrap().entry.clone(),
+            _ => panic!("not a fake keychain"),
+        }
+    }
+}
+
+/// Stores that model one specific way a real keychain misbehaves,
+/// for a **caller's** tests — `auth logout`'s "removed but never
+/// read" branch is unreachable with a keychain-free store, and
+/// unreachable code is code an edit can break with the suite green.
+///
+/// Behind the `test-support` feature, which nothing but a
+/// dev-dependency turns on.
+#[cfg(feature = "test-support")]
+impl CredentialStore {
+    /// A store holding `secret` in a keychain that refuses every
+    /// *read* while still deleting on request. That is macOS with a
+    /// denied read ACL: deleting an item needs no decrypt, so
+    /// `logout` removes a credential it never saw and has nothing to
+    /// revoke.
+    #[must_use]
+    pub fn with_unreadable_keychain(secret: &str) -> Self {
+        Self::with_fake(
+            FakeKeychain {
+                entry: Some(secret.to_string()),
+                refuse_reads: true,
+                ..FakeKeychain::default()
+            },
+            None,
+        )
+    }
+}
+
+/// A keychain that can be locked, denied, or emptied on demand.
+///
+/// Models the three ways a real one misbehaves independently,
+/// because they are independent in practice: macOS will happily
+/// delete an item whose read ACL it refuses (deleting needs no
+/// decrypt), and a locked store refuses reads and writes while
+/// still existing.
+#[cfg(any(test, feature = "test-support"))]
+#[derive(Default)]
+struct FakeKeychain {
+    entry: Option<String>,
+    refuse_reads: bool,
+    refuse_writes: bool,
+    refuse_deletes: bool,
+}
+
+#[cfg(any(test, feature = "test-support"))]
+impl FakeKeychain {
+    fn locked(error: &str) -> keyring::Error {
+        keyring::Error::NoStorageAccess(error.into())
+    }
+
+    fn read(&self) -> Result<Option<String>, keyring::Error> {
+        if self.refuse_reads {
+            return Err(Self::locked("the keychain refused the read"));
+        }
+        Ok(self.entry.clone())
+    }
+
+    fn write(&mut self, secret: &str) -> Result<(), keyring::Error> {
+        if self.refuse_writes {
+            return Err(Self::locked("the keychain refused the write"));
+        }
+        self.entry = Some(secret.to_string());
+        Ok(())
+    }
+
+    fn remove(&mut self) -> Result<bool, keyring::Error> {
+        if self.refuse_deletes {
+            return Err(Self::locked("the keychain refused the delete"));
+        }
+        Ok(self.entry.take().is_some())
+    }
+}
+
+/// Where the file backend lives, or `None` on a machine that gives
+/// no configuration directory — which on every supported platform
+/// means the environment does not name a home.
+fn credentials_file() -> Option<PathBuf> {
+    let Some(dir) = dirs::config_dir() else {
+        tracing::debug!("no configuration directory; the credential store is keychain-only");
+        return None;
+    };
+    Some(dir.join(CONFIG_SUBDIR).join(CREDENTIALS_FILE))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store(dir: &tempfile::TempDir) -> CredentialStore {
+        CredentialStore::file_at(dir.path().join("mergify").join("credentials.json"))
+    }
+
+    fn url(raw: &str) -> Url {
+        Url::parse(raw).unwrap()
+    }
+
+    fn credential(token: &str) -> Credential {
+        Credential {
+            token: token.to_string(),
+            expires_at: None,
+        }
+    }
+
+    #[test]
+    fn get_returns_none_when_nothing_is_stored() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir);
+        assert_eq!(store.get(&url("https://api.mergify.com")).unwrap(), None);
+    }
+
+    #[test]
+    fn set_then_get_round_trips_through_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir);
+        let api = url("https://api.mergify.com");
+        let location = store.set(&api, &credential("mut_secret")).unwrap();
+        assert_eq!(
+            location,
+            Location::File(store.file_path().unwrap().to_path_buf())
+        );
+
+        let found = store.get(&api).unwrap().unwrap();
+        assert_eq!(found.credential, credential("mut_secret"));
+        assert_eq!(
+            found.location,
+            Location::File(store.file_path().unwrap().into())
+        );
+    }
+
+    #[test]
+    fn expiry_survives_the_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir);
+        let api = url("https://api.mergify.com");
+        let expires_at = DateTime::parse_from_rfc3339("2027-01-02T03:04:05Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let credential = Credential {
+            token: "mut_secret".to_string(),
+            expires_at: Some(expires_at),
+        };
+        store.set(&api, &credential).unwrap();
+        assert_eq!(store.get(&api).unwrap().unwrap().credential, credential);
+    }
+
+    // The whole point of keying by API URL: a laptop that talks to
+    // SaaS and to an on-premise install holds both, and neither
+    // login overwrites the other.
+    #[test]
+    fn credentials_are_keyed_by_api_url() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir);
+        let saas = url("https://api.mergify.com");
+        let onprem = url("https://mergify.internal.example/api");
+        store.set(&saas, &credential("mut_saas")).unwrap();
+        store.set(&onprem, &credential("mut_onprem")).unwrap();
+
+        assert_eq!(
+            store.get(&saas).unwrap().unwrap().credential.token,
+            "mut_saas",
+        );
+        assert_eq!(
+            store.get(&onprem).unwrap().unwrap().credential.token,
+            "mut_onprem",
+        );
+
+        assert!(store.delete(&saas).unwrap());
+        assert_eq!(store.get(&saas).unwrap(), None);
+        assert_eq!(
+            store.get(&onprem).unwrap().unwrap().credential.token,
+            "mut_onprem",
+            "deleting one deployment's credential must not touch another's",
+        );
+    }
+
+    // `https://api.mergify.com` and `https://api.mergify.com/` are
+    // the same deployment, and `--api-url` accepts both spellings.
+    // `Url` normalizes this pair on its own, which is why the
+    // on-premise pair below is the one that actually pins `key_for`.
+    #[test]
+    fn url_spellings_resolve_to_one_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir);
+        store
+            .set(&url("https://api.mergify.com"), &credential("mut_one"))
+            .unwrap();
+        assert_eq!(
+            store
+                .get(&url("https://api.mergify.com/"))
+                .unwrap()
+                .unwrap()
+                .credential
+                .token,
+            "mut_one",
+        );
+    }
+
+    // The pair `Url` does *not* normalize, and the one an
+    // on-premise deployment is actually spelled with. Both bases
+    // reach the same endpoint, because every request joins an
+    // absolute path over them.
+    #[test]
+    fn a_trailing_slash_on_the_path_is_the_same_deployment() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir);
+        store
+            .set(
+                &url("https://mergify.internal.example/api"),
+                &credential("mut_onprem"),
+            )
+            .unwrap();
+        assert_eq!(
+            store
+                .get(&url("https://mergify.internal.example/api/"))
+                .unwrap()
+                .unwrap()
+                .credential
+                .token,
+            "mut_onprem",
+        );
+    }
+
+    #[test]
+    fn delete_reports_whether_anything_was_stored() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir);
+        let api = url("https://api.mergify.com");
+        assert!(!store.delete(&api).unwrap());
+        store.set(&api, &credential("mut_secret")).unwrap();
+        assert!(store.delete(&api).unwrap());
+        assert_eq!(store.get(&api).unwrap(), None);
+    }
+
+    // An emptied store leaves no file behind, so `{}` on disk never
+    // has to be told apart from a credential that failed to load.
+    #[test]
+    fn deleting_the_last_credential_removes_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir);
+        let api = url("https://api.mergify.com");
+        store.set(&api, &credential("mut_secret")).unwrap();
+        assert!(store.file_path().unwrap().exists());
+        store.delete(&api).unwrap();
+        assert!(!store.file_path().unwrap().exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_file_and_its_directory_are_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir);
+        store
+            .set(&url("https://api.mergify.com"), &credential("mut_secret"))
+            .unwrap();
+
+        let file_mode = fs::metadata(store.file_path().unwrap())
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(file_mode & 0o777, 0o600, "got {file_mode:o}");
+        let dir_mode = fs::metadata(store.file_path().unwrap().parent().unwrap())
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(dir_mode & 0o777, 0o700, "got {dir_mode:o}");
+    }
+
+    // The state the lazy file path creates: no configuration
+    // directory, and a keychain that did not take the credential
+    // either. Reading is a clean "nothing stored"; writing has to
+    // say why it cannot.
+    #[test]
+    fn a_store_with_no_backend_reads_empty_and_refuses_to_write() {
+        let store = CredentialStore {
+            keychain: KeychainBackend::Off,
+            file: None,
+        };
+        let api = url("https://api.mergify.com");
+        assert_eq!(store.get(&api).unwrap(), None);
+        assert!(!store.delete(&api).unwrap());
+
+        let err = store.set(&api, &credential("mut_secret")).unwrap_err();
+        assert!(
+            err.to_string().contains("no configuration directory"),
+            "got {err}",
+        );
+    }
+
+    #[test]
+    fn a_corrupt_store_is_an_error_not_an_empty_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir);
+        fs::create_dir_all(store.file_path().unwrap().parent().unwrap()).unwrap();
+        fs::write(store.file_path().unwrap(), b"{ this is not json").unwrap();
+
+        let err = store.get(&url("https://api.mergify.com")).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("credentials.json"), "got {message:?}");
+        assert!(message.contains("auth login"), "got {message:?}");
+    }
+
+    #[test]
+    fn debug_never_prints_the_token() {
+        let stored = StoredCredential {
+            credential: credential("mut_secret"),
+            location: Location::Keychain,
+        };
+
+        // Both shapes, because `StoredCredential` derives `Debug`
+        // and would print the token through the inner one.
+        let rendered = format!("{:?} {:?}", stored.credential, stored);
+        assert!(
+            !rendered.contains("mut_secret"),
+            "the token reached debug output: {rendered}",
+        );
+        assert!(rendered.contains("<redacted>"), "got {rendered}");
+    }
+
+    #[test]
+    fn a_machine_with_no_credential_store_reads_as_absent() {
+        // The container / headless-SSH case. Classified `Absent` so
+        // the file fallback stays non-fatal: there is no store to
+        // hold an entry that could shadow it.
+        assert_eq!(
+            keychain_state_for(&keyring::Error::NoDefaultStore),
+            KeychainState::Absent,
+        );
+        assert_eq!(
+            keychain_state_for(&keyring::Error::NoEntry),
+            KeychainState::Absent,
+        );
+    }
+
+    #[test]
+    fn a_keychain_that_refuses_to_answer_is_not_read_as_empty() {
+        // The bug this mapping exists for: a locked keychain, or a
+        // user who clicked Deny, answers with an error — and a
+        // read-back that called that "empty" would report a
+        // credential removed while it is still there.
+        for error in [
+            keyring::Error::NoStorageAccess("locked".into()),
+            keyring::Error::PlatformFailure("dbus went away".into()),
+        ] {
+            assert_eq!(keychain_state_for(&error), KeychainState::Unknown);
+        }
+    }
+
+    /// The stored form of a credential, as the keychain holds it.
+    fn secret(token: &str) -> String {
+        serde_json::to_string(&credential(token)).unwrap()
+    }
+
+    #[test]
+    fn a_refused_write_over_a_stale_entry_refuses_the_login() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CredentialStore::with_fake(
+            FakeKeychain {
+                entry: Some(secret("mut_old")),
+                refuse_writes: true,
+                refuse_deletes: true,
+                ..FakeKeychain::default()
+            },
+            Some(dir.path().join("mergify").join("credentials.json")),
+        );
+        let api = url("https://api.mergify.com");
+
+        let err = store.set(&api, &credential("mut_new")).unwrap_err();
+        assert!(err.to_string().contains("older credential"), "got {err}");
+        // Nothing may reach the file: `get` reads the keychain first,
+        // so a file copy written here could never be read.
+        assert!(!store.file_path().unwrap().exists());
+    }
+
+    #[test]
+    fn a_refused_write_with_an_unreadable_keychain_refuses_the_login() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CredentialStore::with_fake(
+            FakeKeychain {
+                entry: Some(secret("mut_old")),
+                refuse_reads: true,
+                refuse_writes: true,
+                refuse_deletes: true,
+            },
+            Some(dir.path().join("mergify").join("credentials.json")),
+        );
+
+        let err = store
+            .set(&url("https://api.mergify.com"), &credential("mut_new"))
+            .unwrap_err();
+        assert!(err.to_string().contains("read-back"), "got {err}");
+    }
+
+    #[test]
+    fn a_refused_write_keeps_the_keychain_entry_when_there_is_nowhere_to_fall_back() {
+        // The delete used to run before the fallback was known to be
+        // available, so this machine ended up with no credential at
+        // all -- and `login` revokes the new token on this error.
+        let store = CredentialStore::with_fake(
+            FakeKeychain {
+                entry: Some(secret("mut_old")),
+                refuse_writes: true,
+                ..FakeKeychain::default()
+            },
+            None,
+        );
+
+        let err = store
+            .set(&url("https://api.mergify.com"), &credential("mut_new"))
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("no configuration directory"),
+            "got {err}",
+        );
+        assert_eq!(store.fake_entry(), Some(secret("mut_old")));
+    }
+
+    #[test]
+    fn logout_clears_the_keychain_even_when_the_credential_file_is_corrupt() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("mergify").join("credentials.json");
+        fs::create_dir_all(file.parent().unwrap()).unwrap();
+        fs::write(&file, b"{ this is not json").unwrap();
+        let store = CredentialStore::with_fake(
+            FakeKeychain {
+                entry: Some(secret("mut_stored")),
+                ..FakeKeychain::default()
+            },
+            Some(file),
+        );
+
+        // The file leg still reports its own failure...
+        let err = store.delete(&url("https://api.mergify.com")).unwrap_err();
+        assert!(err.to_string().contains("credentials.json"), "got {err}");
+        // ...but the keychain, which is where the credential actually
+        // was, has been cleared rather than skipped.
+        assert_eq!(store.fake_entry(), None);
+    }
+
+    #[test]
+    fn a_keychain_write_clears_the_file_copy() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("mergify").join("credentials.json");
+        let api = url("https://api.mergify.com");
+        CredentialStore::file_at(file.clone())
+            .set(&api, &credential("mut_on_disk"))
+            .unwrap();
+
+        let store = CredentialStore::with_fake(FakeKeychain::default(), Some(file.clone()));
+        assert_eq!(
+            store.set(&api, &credential("mut_new")).unwrap(),
+            Location::Keychain
+        );
+
+        assert_eq!(store.fake_entry(), Some(secret("mut_new")));
+        // The emptied store is removed outright, so there is no
+        // readable copy left behind on disk.
+        assert!(!file.exists());
+    }
+}

--- a/crates/mergify-core/src/lib.rs
+++ b/crates/mergify-core/src/lib.rs
@@ -11,12 +11,16 @@
 //!   and typed error mapping for the Mergify and GitHub APIs.
 //! - [`auth`] — resolve `--repository` / `--token` / `--api-url`
 //!   from the same flag → env → fallback chain the Python CLI uses.
+//! - [`credentials::CredentialStore`] — the OS keychain (or a
+//!   `0600` file) holding the token `mergify auth login` mints,
+//!   keyed by API URL.
 //! - [`command_context::CommandContext`] — bundle the resolved
 //!   trio + a pre-configured Mergify HTTP client for the
 //!   queue/freeze command preludes.
 
 pub mod auth;
 pub mod command_context;
+pub mod credentials;
 pub mod env;
 pub mod error;
 pub mod exit_code;
@@ -25,6 +29,7 @@ pub mod output;
 pub mod pull_request;
 
 pub use command_context::CommandContext;
+pub use credentials::{Credential, CredentialStore};
 pub use error::CliError;
 pub use exit_code::ExitCode;
 pub use http::{ApiFlavor, Client as HttpClient, DeleteOutcome, Page, RetryPolicy};


### PR DESCRIPTION
`mergify auth login` has to put the token it mints somewhere. This adds
that somewhere, keyed by API URL and nothing else -- one machine can
legitimately hold a credential for the hosted service and one for an
on-premise install, and each has to survive the other's `logout`.

Two backends. The OS keychain first: macOS Keychain, the Windows
credential manager, or a freedesktop Secret Service. Then a `0600` JSON
file under the platform configuration directory, used whenever the
keychain is absent or refuses -- a container, a CI runner, or an SSH
session on a headless box has no D-Bus session at all, and `auth login`
still has to work there. A machine with no credential store falls back
silently; a keychain that exists and refuses is the one fatal case, for
the reason below.

Two details worth the reviewer's attention:

- `keyring`'s default feature set resolves to
  `zbus-secret-service-keyring-store` on Linux, which speaks D-Bus in
  pure Rust. The libsecret-backed alternative would have added a C
  build dependency inside the manylinux container and a runtime `.so`
  on the user's machine, for the same functionality. The bill for
  avoiding that is 63 transitive crates, nearly all of them zbus and
  its async-io runtime, and nearly all of them Linux-only.
- `keyring` 4.2's MSRV is 1.88.0, which is exactly this workspace's
  floor. A patch release that raises it reddens the msrv job.

`discover()` is infallible on purpose. A machine with no configuration
directory has no *fallback*, which is not the same as having no store --
and that machine, a Windows service account or a systemd unit with
`ProtectHome=`, is often exactly the one whose OS credential manager
works. Failing there would refuse to read an entry sitting right in
front of it. Writing when neither backend is available is the one case
that errors, and it says which of the two is missing.

Two backends mean two ways to disagree, and both are handled by
reading back rather than trusting a write -- with the read-back itself
able to tell "refused" from "empty", which is the whole point of it.
`keyring::Error::NoEntry` is the store saying nothing is filed;
anything else is the store declining to answer, and `set` and `delete`
refuse rather than report a success they did not verify. An older
keychain entry that cannot be removed would shadow the file copy
forever, since `get` reads the keychain first, and a `logout` that
called an unreadable keychain clean would promise a machine it never
checked. Collapsing every keychain error to "empty" -- right on the
read path, where the next move is the file either way -- verifies
nothing here.

The exception is `NoDefaultStore`, which `keyring` returns when it
cannot *initialize* a store and then caches process-wide. It means
both "no credential store on this machine" and "the store did not
answer just now", the crate does not separate them, and they want
opposite answers. It is read as "absent", because the alternative
makes `auth login` fatal on every container and headless box -- the
machines the fallback exists for -- while this direction costs a
desktop whose session bus blinked one stale-credential 403 that the
next `auth login` clears.

Order matters as much as the check. Everything that can refuse the
file backend is resolved *before* the stale keychain entry is deleted:
a delete followed by a failed write would leave the machine with no
credential at all, and `login` revokes the token it just minted on
that error path. `delete` runs the keychain leg first and holds its
verdict until the file has been tried too, because a corrupt
`credentials.json` used to abort the call before the keychain -- the
backend actually holding the credential -- was ever touched.

The keychain is a `KeychainBackend` enum rather than four free
functions so those branches are reachable in a test: a `Fake` arm can
be locked, denied and emptied independently, which is how a real one
misbehaves (macOS deletes an item whose read ACL it refuses --
deleting needs no decrypt). The shipped binary has the two real arms;
the fake is `cfg(test)`, plus a `test-support` feature a
dev-dependency turns on so a *caller* can reach its own keychain
error paths -- `auth logout`'s "removed but never read" branch has no
other way in.

One hole left open deliberately: each write is atomic (temp file +
rename) but the surrounding read-modify-write is not locked, so two
`auth` commands racing on *different* API URLs can lose one entry. The
writers are `auth login` and `auth logout`, both driven by a person at
a terminal, and a lock file is its own design -- stale locks, no-home
machines, Windows semantics. Named in the code rather than left to be
rediscovered.

`Credential`'s `Debug` is hand-written and renders the token as
`<redacted>`. The derived one would have put the secret into the first
log line that traced where a credential came from, which is the only
reason these types are `Debug` at all.

A write goes to a sibling temp file and is renamed, so a crash cannot
truncate a store holding a second deployment's credential, and the
backend that did not take the credential is cleared, so logging in once
without a keychain and once with it leaves no readable copy behind. An
emptied store is deleted rather than left as `{}`: an empty object on
disk reads, to anyone auditing the machine, like a credential that
failed to load.

Nothing is wired to this yet.

Fixes MRGFY-8703