### PR TITLE
feat(cli): mergify auth login, logout and status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,9 +1738,14 @@ dependencies = [
 name = "mergify-auth"
 version = "0.0.0"
 dependencies = [
+ "chrono",
  "mergify-core",
+ "mergify-test-support",
+ "mergify-tui",
  "serde",
  "serde_json",
+ "temp-env",
+ "tempfile",
  "tokio",
  "tracing",
  "url",
@@ -1782,6 +1787,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "insta",
+ "mergify-auth",
  "mergify-ci",
  "mergify-config",
  "mergify-core",

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ for any command's flags.
 Every command group maps to a section of the
 [CLI reference](https://docs.mergify.com/cli/).
 
+- **`mergify auth`** — Sign in to Mergify and manage the stored
+  credential (`login`, `logout`, `status`).
 - **`mergify stack`** — Create and maintain stacked pull requests.
   [Docs](https://docs.mergify.com/stacks/)
 - **`mergify queue`** — Inspect and control the merge queue.
@@ -181,7 +183,7 @@ Commands return stable exit codes so scripts and runbooks can branch on them:
 | `5` | GitHub API request failed. |
 | `6` | Mergify API request failed. |
 | `7` | CLI invariant violated (e.g. run outside a valid context). |
-| `8` | Configuration missing, unparseable, or failing validation. |
+| `8` | Configuration or credentials missing, unparseable, or failing validation (including "not logged in"). |
 
 ## AI Agent Skills
 

--- a/crates/mergify-auth/Cargo.toml
+++ b/crates/mergify-auth/Cargo.toml
@@ -11,13 +11,22 @@ publish = false
 
 [dependencies]
 mergify-core = { path = "../mergify-core" }
+mergify-tui = { path = "../mergify-tui" }
+chrono = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+# `test-support` brings the credential stores that model one specific
+# keychain failure. `logout`'s "removed but never read" branch is
+# unreachable without one.
+mergify-core = { path = "../mergify-core", features = ["test-support"] }
+mergify-test-support = { path = "../mergify-test-support" }
 serde_json = { workspace = true }
+temp-env = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 wiremock = { workspace = true }
 

--- a/crates/mergify-auth/src/identity.rs
+++ b/crates/mergify-auth/src/identity.rs
@@ -1,0 +1,223 @@
+//! `GET /v1/user` — which account a credential belongs to.
+//!
+//! The device grant's token response says nothing about who
+//! approved it, and every other `user`-authenticated route on the
+//! API takes an `{owner}` or `{owner}/{repository}` path parameter,
+//! so there is no other way to turn a credential into a name.
+//!
+//! The three answers are three different sentences to the user, and
+//! reporting any of them as another would be a lie:
+//!
+//! - **200** — the credential is live, and this is whose it is.
+//! - **403** — refused. Revoked from the dashboard, expired, or not
+//!   a user credential at all (an application key lands here).
+//!   **401** counts as the same answer: it is what RFC 6750 says a
+//!   rejected bearer token gets, it is what this API's own device
+//!   endpoints answer for a bad client, and any gateway in front of
+//!   a self-hosted install can produce one on its own. Reporting it
+//!   as an unexpected status would replace "run `mergify auth
+//!   login`" with a sentence naming no remedy.
+//! - **404** — the deployment predates the route. Self-hosted
+//!   installs upgrade on their own schedule, so this is a normal
+//!   answer, not a broken one.
+
+use mergify_core::ApiFlavor;
+use mergify_core::ApiOutcome;
+use mergify_core::CliError;
+use mergify_core::HttpClient;
+use serde::Deserialize;
+use url::Url;
+
+const USER_PATH: &str = "/v1/user";
+
+/// The account a credential belongs to.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub struct User {
+    pub id: u64,
+    pub login: String,
+}
+
+/// What `GET /v1/user` had to say.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Identity {
+    Known(User),
+    /// The API refused the credential.
+    Refused,
+    /// This deployment does not serve the route.
+    Unsupported,
+}
+
+/// A rejection body. Every refusal from the API app carries
+/// `FastAPI`'s `detail`, and an unexpected status is the one case
+/// where the server's own sentence is all the caller has to go on.
+#[derive(Deserialize)]
+struct Rejection {
+    #[serde(default)]
+    detail: Option<String>,
+}
+
+/// Ask the API who `token` belongs to.
+pub async fn whoami(api_url: Url, token: &str) -> Result<Identity, CliError> {
+    let client = HttpClient::new(api_url, token, ApiFlavor::Mergify)?;
+    match client.get_outcome::<User, Rejection>(USER_PATH).await? {
+        ApiOutcome::Ok(user) => Ok(Identity::Known(user)),
+        ApiOutcome::Error {
+            status: 401 | 403, ..
+        } => Ok(Identity::Refused),
+        ApiOutcome::Error { status: 404, .. } => Ok(Identity::Unsupported),
+        ApiOutcome::Error { status, body } => Err(CliError::MergifyApi(match body.detail {
+            Some(detail) => format!("unexpected HTTP {status} from {USER_PATH}: {detail}"),
+            None => format!("unexpected HTTP {status} from {USER_PATH}"),
+        })),
+    }
+}
+
+/// The login name behind `token`, or `None` for every reason there
+/// might not be one — including a failure to ask.
+///
+/// For callers that only want to put a name in a sentence and have
+/// nothing to do with the difference: `auth login` has just minted
+/// the credential, so a network hiccup on the way to `/v1/user`
+/// must not turn a successful login into a failed command.
+pub async fn login_name(api_url: Url, token: &str) -> Option<String> {
+    match whoami(api_url, token).await {
+        Ok(Identity::Known(user)) => Some(user.login),
+        Ok(other) => {
+            tracing::debug!(?other, "the API did not name the credential's owner");
+            None
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "could not ask the API who the credential belongs to");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::header;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    use super::*;
+
+    fn url(server: &MockServer) -> Url {
+        Url::parse(&server.uri()).unwrap()
+    }
+
+    async fn mount(server: &MockServer, response: ResponseTemplate) {
+        Mock::given(method("GET"))
+            .and(path("/v1/user"))
+            .and(header("Authorization", "Bearer mut_secret"))
+            .respond_with(response)
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn a_live_credential_names_its_owner() {
+        let server = MockServer::start().await;
+        mount(
+            &server,
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"id": 42, "login": "sileht"})),
+        )
+        .await;
+
+        assert_eq!(
+            whoami(url(&server), "mut_secret").await.unwrap(),
+            Identity::Known(User {
+                id: 42,
+                login: "sileht".to_string(),
+            }),
+        );
+    }
+
+    // 403 is what every `/v1` route answers for a refused
+    // credential; 401 is below.
+    #[tokio::test]
+    async fn a_refused_credential_is_not_an_error() {
+        let server = MockServer::start().await;
+        mount(
+            &server,
+            ResponseTemplate::new(403).set_body_json(serde_json::json!({"detail": "forbidden"})),
+        )
+        .await;
+
+        assert_eq!(
+            whoami(url(&server), "mut_secret").await.unwrap(),
+            Identity::Refused,
+        );
+    }
+
+    // Not what the Mergify API itself answers, but what a gateway in
+    // front of a self-hosted install can. The user's move is the
+    // same either way, so the answer has to be too.
+    #[tokio::test]
+    async fn a_401_is_a_refusal_too() {
+        let server = MockServer::start().await;
+        mount(
+            &server,
+            ResponseTemplate::new(401).set_body_json(serde_json::json!({"detail": "expired"})),
+        )
+        .await;
+
+        assert_eq!(
+            whoami(url(&server), "mut_secret").await.unwrap(),
+            Identity::Refused,
+        );
+    }
+
+    // A self-hosted install older than the route. Normal, not broken.
+    #[tokio::test]
+    async fn a_deployment_without_the_route_is_not_an_error() {
+        let server = MockServer::start().await;
+        mount(
+            &server,
+            ResponseTemplate::new(404).set_body_json(serde_json::json!({"detail": "Not Found"})),
+        )
+        .await;
+
+        assert_eq!(
+            whoami(url(&server), "mut_secret").await.unwrap(),
+            Identity::Unsupported,
+        );
+    }
+
+    #[tokio::test]
+    async fn login_name_swallows_a_refusal() {
+        let server = MockServer::start().await;
+        mount(
+            &server,
+            ResponseTemplate::new(403).set_body_json(serde_json::json!({"detail": "forbidden"})),
+        )
+        .await;
+
+        assert_eq!(login_name(url(&server), "mut_secret").await, None);
+    }
+
+    // The arm that justifies `login` calling this at all: a request
+    // that fails outright must not turn a login the server already
+    // granted into a failed command. A 200 whose body is not a user
+    // reaches that arm without the three retries a 5xx would cost.
+    #[tokio::test]
+    async fn login_name_swallows_a_failure_to_ask() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/user"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"unexpected": true})),
+            )
+            .mount(&server)
+            .await;
+
+        assert_eq!(login_name(url(&server), "mut_secret").await, None);
+        // …and the typed call still surfaces it, so the swallowing is
+        // `login_name`'s decision rather than a hidden one.
+        assert!(whoami(url(&server), "mut_secret").await.is_err());
+    }
+}

--- a/crates/mergify-auth/src/lib.rs
+++ b/crates/mergify-auth/src/lib.rs
@@ -4,9 +4,48 @@
 //!   (RFC 8628) against the Mergify API, which is how the CLI gets
 //!   a credential without ever handling a password or a GitHub
 //!   token.
+//! - [`identity`] — `GET /v1/user`, the only way to turn a
+//!   credential into an account name and the only way to tell a
+//!   live one from a revoked one.
+//! - [`login`] / [`logout`] / [`status`] — the three commands.
 //!
 //! The credential itself is stored by
-//! [`mergify_core::CredentialStore`]; this crate only obtains and
-//! revokes it.
+//! [`mergify_core::CredentialStore`]; this crate obtains it,
+//! revokes it, and reports on it.
 
 pub mod device;
+pub mod identity;
+pub mod login;
+pub mod logout;
+pub mod status;
+
+#[cfg(test)]
+mod testing {
+    use mergify_core::CredentialStore;
+
+    /// A credential store that cannot reach the developer's real
+    /// keychain, rooted in a temporary directory the caller keeps
+    /// alive for the length of the test.
+    pub fn file_store() -> (tempfile::TempDir, CredentialStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CredentialStore::file_at(dir.path().join("credentials.json"));
+        (dir, store)
+    }
+
+    /// Run `body` to completion with `MERGIFY_TOKEN` forced to
+    /// `value`.
+    ///
+    /// `temp_env` cannot wrap an `.await`, so the future is driven
+    /// inside the closure instead. Without this the wiring that
+    /// reads the variable is untestable, and untestable wiring is
+    /// wiring a future edit can delete with the suite still green:
+    /// asserting on the renderer alone proves only that the renderer
+    /// can print a note, never that anything asks it to.
+    pub fn with_mergify_token<F: std::future::Future>(value: Option<&str>, body: F) -> F::Output {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        temp_env::with_var("MERGIFY_TOKEN", value, || runtime.block_on(body))
+    }
+}

--- a/crates/mergify-auth/src/login.rs
+++ b/crates/mergify-auth/src/login.rs
@@ -1,0 +1,542 @@
+//! `mergify auth login` — obtain a Mergify credential and store it.
+
+use std::io::Write;
+
+use chrono::DateTime;
+use chrono::Utc;
+use mergify_core::CliError;
+use mergify_core::Credential;
+use mergify_core::CredentialStore;
+use mergify_core::Output;
+use mergify_core::auth;
+use mergify_core::credentials::Location;
+use serde::Serialize;
+use url::Url;
+
+use crate::device;
+use crate::identity;
+
+pub struct LoginOptions<'a> {
+    pub api_url: Option<&'a str>,
+    pub store: &'a CredentialStore,
+}
+
+/// What `auth login` produced, for the JSON rendering `Output`
+/// requires. Deliberately without the token: nothing prints the
+/// secret, ever.
+#[derive(Serialize)]
+struct LoginResult {
+    api_url: String,
+    login: Option<String>,
+    stored_in: String,
+}
+
+/// Run the `auth login` command.
+pub async fn run(opts: LoginOptions<'_>, output: &mut dyn Output) -> Result<(), CliError> {
+    let api_url = auth::resolve_api_url(opts.api_url)?;
+    let client = device::client(api_url.clone())?;
+
+    // Before any grant exists, not merely before it is spent. A
+    // store this machine cannot read is a corrupt file or a keychain
+    // holding non-JSON, and reading it after the code is on screen
+    // means the user is already at the approval page when the
+    // command dies — and whatever they approve there mints a token
+    // nothing stores and nothing revokes. `authorize` needs no
+    // store, so this costs nothing.
+    let previous = opts.store.get(&api_url)?;
+
+    let authorization = device::authorize(&client).await?;
+    output.status(&instructions(&authorization))?;
+
+    let token = device::poll(
+        &client,
+        &authorization.device_code,
+        device::PollSchedule::from_authorization(&authorization),
+    )
+    .await?;
+
+    let credential = Credential {
+        expires_at: token
+            .expires_in
+            .and_then(|seconds| expires_at(Utc::now(), seconds)),
+        token: token.access_token,
+    };
+    let location = match opts.store.set(&api_url, &credential) {
+        Ok(location) => location,
+        Err(e) => {
+            // The server minted a token this machine cannot keep.
+            // Leaving it live would burn one of the user's twenty
+            // for nothing, and every retry would burn another.
+            revoke_quietly(&client, &credential.token).await;
+            return Err(e);
+        }
+    };
+
+    // The credential this one replaces is now unreachable from here
+    // and still live on the server for its full year. A user who
+    // logs in again on the same machine — after a token stopped
+    // working, or on a reprovisioned box — would otherwise leak one
+    // per login until they hit the cap and only the dashboard could
+    // clear it.
+    if let Some(previous) = previous
+        && let Err(e) = device::revoke(&client, &previous.credential.token).await
+    {
+        // Out loud, not a debug line. This is the leak the block
+        // above exists to prevent, and the user is the only one who
+        // can finish it: the old token is live for its full year and
+        // no longer reachable from this machine. `logout` says the
+        // same thing when its revocation fails.
+        output.status(&format!(
+            "Warning: the credential this login replaces could not be revoked ({e}). Revoke \
+             it from the CLI Tokens page of your Mergify dashboard — it stays valid, and \
+             counts against your token limit, until you do.",
+        ))?;
+    }
+    // After the credential is stored, never before: a name is a nice
+    // sentence, and losing the token the server already minted
+    // because the network blinked on the way to `/v1/user` is not a
+    // trade worth making.
+    let login = identity::login_name(api_url.clone(), &credential.token).await;
+
+    emit(output, &api_url, login.as_deref(), &location)
+}
+
+/// Ask the server to revoke a token this machine could not store,
+/// and say nothing if it will not.
+///
+/// The command is already returning its own error, and the user
+/// never asked about this token: it was minted a moment ago and
+/// never reached the store, so there is nothing they can do about it
+/// that the error above does not already lead to.
+async fn revoke_quietly(client: &mergify_core::HttpClient, token: &str) {
+    if let Err(e) = device::revoke(client, token).await {
+        tracing::debug!(error = %e, "could not revoke the credential we could not store");
+    }
+}
+
+/// What the user has to do, on stderr, while the poll loop waits.
+fn instructions(authorization: &device::Authorization) -> String {
+    let theme = mergify_tui::Theme::detect();
+    let url = authorization
+        .verification_uri_complete
+        .as_deref()
+        .unwrap_or(&authorization.verification_uri);
+    format!(
+        "Open this URL to authorize the Mergify CLI:\n\n    {url}\n\n\
+         and confirm this code:\n\n    {bold}{code}{reset}\n\n\
+         Waiting for approval…",
+        bold = theme.bold.render(),
+        code = authorization.user_code,
+        reset = theme.reset,
+    )
+}
+
+/// The absolute moment a token minted `now` runs out. `None` when
+/// the server's `expires_in` does not fit a timestamp, which is a
+/// server that has stopped making sense rather than a reason to
+/// throw the credential away.
+fn expires_at(now: DateTime<Utc>, expires_in_seconds: u64) -> Option<DateTime<Utc>> {
+    now.checked_add_signed(chrono::TimeDelta::try_seconds(
+        i64::try_from(expires_in_seconds).ok()?,
+    )?)
+}
+
+fn emit(
+    output: &mut dyn Output,
+    api_url: &Url,
+    login: Option<&str>,
+    location: &Location,
+) -> Result<(), CliError> {
+    let result = LoginResult {
+        api_url: api_url.to_string(),
+        login: login.map(str::to_owned),
+        stored_in: location.to_string(),
+    };
+    let theme = mergify_tui::Theme::detect();
+    output.emit(&result, &mut |w: &mut dyn Write| {
+        let who = match login {
+            Some(login) => format!(" as {login}"),
+            None => String::new(),
+        };
+        writeln!(
+            w,
+            "{green}✓{reset} Logged in to {api_url}{who}.",
+            green = theme.green.render(),
+            reset = theme.reset,
+        )?;
+        writeln!(w, "Credential stored in {location}.")
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use mergify_test_support::Captured;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::body_string_contains;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    use super::*;
+    use crate::testing::file_store;
+    use crate::testing::with_mergify_token;
+
+    fn authorization() -> device::Authorization {
+        device::Authorization {
+            device_code: "dev-secret".to_string(),
+            user_code: "BCDF-GHJK".to_string(),
+            verification_uri: "https://dashboard.mergify.com/device".to_string(),
+            verification_uri_complete: Some(
+                "https://dashboard.mergify.com/device?user_code=BCDF-GHJK".to_string(),
+            ),
+            expires_in: Some(600),
+            interval: Some(0),
+        }
+    }
+
+    async fn mount_flow(server: &MockServer, with_identity: bool) {
+        Mock::given(method("POST"))
+            .and(path("/v1/oauth/device/code"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "device_code": "dev-secret",
+                "user_code": "BCDF-GHJK",
+                "verification_uri": "https://dashboard.mergify.com/device",
+                "verification_uri_complete":
+                    "https://dashboard.mergify.com/device?user_code=BCDF-GHJK",
+                "expires_in": 600,
+                "interval": 0,
+            })))
+            .expect(1)
+            .mount(server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/oauth/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "mut_secret",
+                "token_type": "bearer",
+                "expires_in": 31_536_000,
+            })))
+            .expect(1)
+            .mount(server)
+            .await;
+        let user = if with_identity {
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": 42,
+                "login": "sileht",
+            }))
+        } else {
+            ResponseTemplate::new(404).set_body_json(serde_json::json!({"detail": "Not Found"}))
+        };
+        Mock::given(method("GET"))
+            .and(path("/v1/user"))
+            .respond_with(user)
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    #[test]
+    fn login_stores_the_credential_and_names_the_account() {
+        with_mergify_token(None, async {
+            let server = MockServer::start().await;
+            mount_flow(&server, true).await;
+            let (dir, store) = file_store();
+            let mut captured = Captured::human();
+
+            run(
+                LoginOptions {
+                    api_url: Some(&server.uri()),
+                    store: &store,
+                },
+                &mut captured.output,
+            )
+            .await
+            .unwrap();
+
+            let api_url = Url::parse(&server.uri()).unwrap();
+            let stored = store.get(&api_url).unwrap().unwrap();
+            assert_eq!(stored.credential.token, "mut_secret");
+            assert!(
+                stored.credential.expires_at.is_some(),
+                "the server's expires_in must become a stored expiry",
+            );
+
+            let stdout = captured.stdout();
+            assert!(stdout.contains("Logged in to"), "got {stdout:?}");
+            assert!(stdout.contains("as sileht."), "got {stdout:?}");
+            assert!(
+                !stdout.contains("mut_secret"),
+                "the token must never be printed, got {stdout:?}",
+            );
+            drop(dir);
+        });
+    }
+
+    // The verification URL and the code are the whole point of the
+    // command, and they go to stderr so stdout stays the result.
+    #[test]
+    fn the_code_and_url_are_printed_to_stderr() {
+        with_mergify_token(None, async {
+            let server = MockServer::start().await;
+            mount_flow(&server, true).await;
+            let (dir, store) = file_store();
+            let mut captured = Captured::human();
+
+            run(
+                LoginOptions {
+                    api_url: Some(&server.uri()),
+                    store: &store,
+                },
+                &mut captured.output,
+            )
+            .await
+            .unwrap();
+
+            let stderr = captured.stderr();
+            assert!(stderr.contains("BCDF-GHJK"), "got {stderr:?}");
+            assert!(
+                stderr.contains("https://dashboard.mergify.com/device?user_code=BCDF-GHJK"),
+                "got {stderr:?}",
+            );
+            drop(dir);
+        });
+    }
+
+    // A deployment too old to serve `/v1/user` still logs in; it just
+    // cannot say whose credential it minted.
+    #[test]
+    fn login_succeeds_when_the_deployment_cannot_name_the_account() {
+        with_mergify_token(None, async {
+            let server = MockServer::start().await;
+            mount_flow(&server, false).await;
+            let (dir, store) = file_store();
+            let mut captured = Captured::human();
+
+            run(
+                LoginOptions {
+                    api_url: Some(&server.uri()),
+                    store: &store,
+                },
+                &mut captured.output,
+            )
+            .await
+            .unwrap();
+
+            let api_url = Url::parse(&server.uri()).unwrap();
+            assert!(store.get(&api_url).unwrap().is_some());
+            let stdout = captured.stdout();
+            assert!(stdout.contains("Logged in to"), "got {stdout:?}");
+            assert!(!stdout.contains(" as "), "got {stdout:?}");
+            drop(dir);
+        });
+    }
+
+    // The credential a re-login replaces is unreachable from this
+    // machine afterwards and still live on the server for its full
+    // year. Leaking one per login walks the user into the token cap,
+    // which only the dashboard can clear.
+    #[test]
+    fn login_revokes_the_credential_it_replaces() {
+        let (dir, store) = file_store();
+        with_mergify_token(None, async {
+            let server = MockServer::start().await;
+            mount_flow(&server, true).await;
+            Mock::given(method("POST"))
+                .and(path("/v1/oauth/revoke"))
+                .and(body_string_contains("token=mut_previous"))
+                .respond_with(ResponseTemplate::new(200))
+                .expect(1)
+                .mount(&server)
+                .await;
+            let api_url = Url::parse(&server.uri()).unwrap();
+            store
+                .set(
+                    &api_url,
+                    &Credential {
+                        token: "mut_previous".to_string(),
+                        expires_at: None,
+                    },
+                )
+                .unwrap();
+            let mut captured = Captured::human();
+
+            run(
+                LoginOptions {
+                    api_url: Some(&server.uri()),
+                    store: &store,
+                },
+                &mut captured.output,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(
+                store.get(&api_url).unwrap().unwrap().credential.token,
+                "mut_secret",
+            );
+        });
+        drop(dir);
+    }
+
+    // A refusal from the server must leave nothing behind.
+    // The store is read before any grant exists, so an unreadable
+    // one fails before the user has a code in front of them. Read
+    // after, the command dies with the approval page already open,
+    // and whatever they approve there mints a token nothing stores
+    // and nothing can revoke.
+    #[test]
+    fn an_unreadable_store_fails_before_a_grant_is_opened() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("credentials.json");
+        std::fs::write(&file, b"{ this is not json").unwrap();
+        let store = mergify_core::CredentialStore::file_at(file);
+        with_mergify_token(None, async {
+            let server = MockServer::start().await;
+            let mut captured = Captured::human();
+
+            let err = run(
+                LoginOptions {
+                    api_url: Some(&server.uri()),
+                    store: &store,
+                },
+                &mut captured.output,
+            )
+            .await
+            .unwrap_err();
+
+            assert!(err.to_string().contains("credentials.json"), "got {err}");
+            assert!(
+                server.received_requests().await.unwrap().is_empty(),
+                "no grant may be opened before the store is known to be readable",
+            );
+            assert_eq!(captured.stderr(), "");
+        });
+        drop(dir);
+    }
+
+    // A revocation that fails leaves the replaced token live for its
+    // full year, reachable only from the dashboard. Saying so is the
+    // whole point of revoking it here.
+    #[test]
+    fn a_failed_revocation_of_the_replaced_credential_is_said_out_loud() {
+        let (dir, store) = file_store();
+        with_mergify_token(None, async {
+            let server = MockServer::start().await;
+            mount_flow(&server, true).await;
+            Mock::given(method("POST"))
+                .and(path("/v1/oauth/revoke"))
+                .respond_with(ResponseTemplate::new(429).append_header("retry-after", "0"))
+                .mount(&server)
+                .await;
+            let api_url = Url::parse(&server.uri()).unwrap();
+            store
+                .set(
+                    &api_url,
+                    &Credential {
+                        token: "mut_previous".to_string(),
+                        expires_at: None,
+                    },
+                )
+                .unwrap();
+            let mut captured = Captured::human();
+
+            run(
+                LoginOptions {
+                    api_url: Some(&server.uri()),
+                    store: &store,
+                },
+                &mut captured.output,
+            )
+            .await
+            .unwrap();
+
+            // The login itself still succeeded.
+            assert_eq!(
+                store.get(&api_url).unwrap().unwrap().credential.token,
+                "mut_secret",
+            );
+            let stderr = captured.stderr();
+            assert!(stderr.contains("could not be revoked"), "got {stderr:?}");
+            assert!(stderr.contains("CLI Tokens"), "got {stderr:?}");
+        });
+        drop(dir);
+    }
+
+    #[test]
+    fn a_denied_grant_stores_nothing() {
+        with_mergify_token(None, async {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/oauth/device/code"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "device_code": "dev-secret",
+                    "user_code": "BCDF-GHJK",
+                    "verification_uri": "https://dashboard.mergify.com/device",
+                    "expires_in": 600,
+                    "interval": 0,
+                })))
+                .mount(&server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path("/v1/oauth/token"))
+                .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                    "error": "access_denied",
+                    "error_description": "The request was denied by the user.",
+                })))
+                .mount(&server)
+                .await;
+            let (dir, store) = file_store();
+            let mut captured = Captured::human();
+
+            let err = run(
+                LoginOptions {
+                    api_url: Some(&server.uri()),
+                    store: &store,
+                },
+                &mut captured.output,
+            )
+            .await
+            .unwrap_err();
+
+            assert!(err.to_string().contains("denied by the user"), "got {err}");
+            let api_url = Url::parse(&server.uri()).unwrap();
+            assert_eq!(store.get(&api_url).unwrap(), None);
+            drop(dir);
+        });
+    }
+
+    // Without `verification_uri_complete` the user has to type the
+    // code, so the plain page is the one to point them at.
+    #[test]
+    fn the_instructions_fall_back_to_the_plain_verification_url() {
+        let mut authorization = authorization();
+        authorization.verification_uri_complete = None;
+        let rendered = instructions(&authorization);
+        assert!(
+            rendered.contains("https://dashboard.mergify.com/device\n"),
+            "got {rendered:?}",
+        );
+        assert!(rendered.contains("BCDF-GHJK"), "got {rendered:?}");
+    }
+
+    #[test]
+    fn expires_at_turns_the_servers_lifetime_into_a_moment() {
+        let now = DateTime::parse_from_rfc3339("2026-09-04T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(
+            expires_at(now, 31_536_000).unwrap().to_rfc3339(),
+            "2027-09-04T00:00:00+00:00",
+        );
+    }
+
+    #[test]
+    fn a_nonsensical_lifetime_yields_no_expiry_rather_than_a_panic() {
+        let now = DateTime::parse_from_rfc3339("2026-09-04T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(expires_at(now, u64::MAX), None);
+    }
+}

--- a/crates/mergify-auth/src/logout.rs
+++ b/crates/mergify-auth/src/logout.rs
@@ -1,0 +1,273 @@
+//! `mergify auth logout` — revoke the stored credential and forget it.
+
+use std::io::Write;
+
+use mergify_core::CliError;
+use mergify_core::CredentialStore;
+use mergify_core::Output;
+use mergify_core::auth;
+use serde::Serialize;
+use url::Url;
+
+use crate::device;
+
+pub struct LogoutOptions<'a> {
+    pub api_url: Option<&'a str>,
+    pub store: &'a CredentialStore,
+}
+
+#[derive(Serialize)]
+struct LogoutResult {
+    api_url: String,
+    /// Whether there was a credential to remove. `false` is a
+    /// successful no-op, not a failure: `logout` promises that the
+    /// machine holds no credential afterwards, and it does.
+    was_logged_in: bool,
+    /// Whether the revocation request was accepted. It is not a
+    /// promise that the token is dead: RFC 7009 has the endpoint
+    /// answer 200 for any string, so this says the server took the
+    /// request, never that it found something to delete.
+    revoked: bool,
+}
+
+/// Run the `auth logout` command.
+pub async fn run(opts: LogoutOptions<'_>, output: &mut dyn Output) -> Result<(), CliError> {
+    let api_url = auth::resolve_api_url(opts.api_url)?;
+    let stored = opts.store.get(&api_url)?;
+    let Some(stored) = stored else {
+        // Still ask the store to forget: a keychain that refused to
+        // be *read* looks empty to `get` while holding the
+        // credential, and `delete` is the call that finds out.
+        let removed = opts.store.delete(&api_url).map_err(|e| {
+            // The store refused to confirm it is empty, which is the
+            // one shape of this branch that matters: a keychain can
+            // deny a *read* and still delete — macOS deletes an item
+            // whose read ACL it refuses, because deleting needs no
+            // decrypt. So a credential may have been removed without
+            // ever being read, and a token this command never saw is
+            // one it could not ask the server to revoke.
+            CliError::wrap(
+                "a credential for this API may have been removed from this machine without \
+                 being read, in which case the Mergify API was not told to revoke it — \
+                 revoke it from the CLI Tokens page of your Mergify dashboard",
+                e,
+            )
+        })?;
+        return emit(output, &api_url, removed, false);
+    };
+
+    // Revoke first, then forget: the server is the copy that matters,
+    // and a token whose only trace was the file we just deleted can
+    // no longer be revoked from here at all.
+    let client = device::client(api_url.clone())?;
+    let revocation = device::revoke(&client, &stored.credential.token).await;
+
+    // Removed either way. A `logout` that left the credential in
+    // place because the network blinked would have done nothing at
+    // all, which is the worse of the two half-states.
+    opts.store.delete(&api_url)?;
+
+    // A failed revocation is loud but not fatal. The postcondition
+    // the user asked for — this machine no longer holds the
+    // credential — holds, and failing the command would make
+    // `auth logout` unusable in the teardown scripts that are
+    // exactly where it belongs.
+    let revoked = match revocation {
+        Ok(()) => true,
+        Err(e) => {
+            output.status(&format!(
+                "Warning: the credential was removed from this machine, but the Mergify API \
+                 could not be told to revoke it ({e}). Revoke it from the CLI Tokens page of \
+                 your Mergify dashboard.",
+            ))?;
+            false
+        }
+    };
+
+    emit(output, &api_url, true, revoked)
+}
+
+fn emit(
+    output: &mut dyn Output,
+    api_url: &Url,
+    was_logged_in: bool,
+    revoked: bool,
+) -> Result<(), CliError> {
+    let result = LogoutResult {
+        api_url: api_url.to_string(),
+        was_logged_in,
+        revoked,
+    };
+    output.emit(&result, &mut |w: &mut dyn Write| {
+        if was_logged_in {
+            // Says only what is true. The revocation endpoint
+            // answers 200 for any string and is rate limited per IP,
+            // so "the token is dead everywhere" is a claim this
+            // command is not in a position to make.
+            writeln!(w, "Logged out of {api_url}.")?;
+        } else {
+            writeln!(w, "No credential stored for {api_url}.")?;
+        }
+        Ok(())
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use mergify_core::Credential;
+    use mergify_test_support::Captured;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::body_string_contains;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    use super::*;
+    use crate::testing::file_store;
+    use crate::testing::with_mergify_token;
+
+    fn credential() -> Credential {
+        Credential {
+            token: "mut_secret".to_string(),
+            expires_at: None,
+        }
+    }
+
+    #[test]
+    fn logout_revokes_server_side_and_forgets_locally() {
+        with_mergify_token(None, async {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/oauth/revoke"))
+                .and(body_string_contains("token=mut_secret"))
+                .respond_with(ResponseTemplate::new(200))
+                .expect(1)
+                .mount(&server)
+                .await;
+            let (dir, store) = file_store();
+            let api_url = Url::parse(&server.uri()).unwrap();
+            store.set(&api_url, &credential()).unwrap();
+            let mut captured = Captured::human();
+
+            run(
+                LogoutOptions {
+                    api_url: Some(&server.uri()),
+                    store: &store,
+                },
+                &mut captured.output,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(store.get(&api_url).unwrap(), None);
+            assert!(captured.stdout().contains("Logged out of"));
+            drop(dir);
+        });
+    }
+
+    // Nothing stored is a successful no-op: the postcondition the
+    // user asked for already holds.
+    #[test]
+    fn logout_without_a_credential_calls_nothing_and_succeeds() {
+        with_mergify_token(None, async {
+            let server = MockServer::start().await;
+            let (dir, store) = file_store();
+            let mut captured = Captured::human();
+
+            run(
+                LogoutOptions {
+                    api_url: Some(&server.uri()),
+                    store: &store,
+                },
+                &mut captured.output,
+            )
+            .await
+            .unwrap();
+
+            assert!(captured.stdout().contains("No credential stored"));
+            assert!(
+                server.received_requests().await.unwrap().is_empty(),
+                "logout must not call an API it has no credential for",
+            );
+            drop(dir);
+        });
+    }
+
+    // A failed revocation still clears the machine, says so, and does
+    // not fail the command: the postcondition the user asked for
+    // holds, and `auth logout` belongs in teardown scripts.
+    // A keychain can refuse a *read* and still delete: macOS deletes
+    // an item whose read ACL it denies, because deleting needs no
+    // decrypt. `logout` then removes a credential it never saw, so
+    // there was no token to revoke — and the warning that says so
+    // lives in the branch `get` -> `None` reaches, not the other one.
+    #[test]
+    fn a_credential_removed_without_being_read_warns_that_it_was_not_revoked() {
+        with_mergify_token(None, async {
+            let server = MockServer::start().await;
+            let store = mergify_core::CredentialStore::with_unreadable_keychain("mut_secret");
+            let mut captured = Captured::human();
+
+            let err = run(
+                LogoutOptions {
+                    api_url: Some(&server.uri()),
+                    store: &store,
+                },
+                &mut captured.output,
+            )
+            .await
+            .unwrap_err();
+
+            let message = err.to_string();
+            assert!(message.contains("without being read"), "got {message:?}");
+            assert!(message.contains("CLI Tokens"), "got {message:?}");
+            assert!(
+                server.received_requests().await.unwrap().is_empty(),
+                "there was no token to revoke, so nothing may be sent",
+            );
+        });
+    }
+
+    #[test]
+    fn a_failed_revocation_still_removes_the_local_credential() {
+        with_mergify_token(None, async {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/oauth/revoke"))
+                .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                    "error": "invalid_client",
+                    "error_description": "Unknown client_id.",
+                })))
+                .mount(&server)
+                .await;
+            let (dir, store) = file_store();
+            let api_url = Url::parse(&server.uri()).unwrap();
+            store.set(&api_url, &credential()).unwrap();
+            let mut captured = Captured::human();
+
+            run(
+                LogoutOptions {
+                    api_url: Some(&server.uri()),
+                    store: &store,
+                },
+                &mut captured.output,
+            )
+            .await
+            .unwrap();
+
+            assert!(
+                captured.stderr().contains("CLI Tokens page"),
+                "got {:?}",
+                captured.stderr(),
+            );
+            assert_eq!(
+                store.get(&api_url).unwrap(),
+                None,
+                "the local credential must be gone even when the revocation failed",
+            );
+            drop(dir);
+        });
+    }
+}

--- a/crates/mergify-auth/src/status.rs
+++ b/crates/mergify-auth/src/status.rs
@@ -1,0 +1,322 @@
+//! `mergify auth status` — is there a credential, whose is it, and
+//! does the API still accept it?
+//!
+//! The last question is the one only the API can answer. A stored
+//! token carries an expiry, but it can be revoked from the dashboard
+//! long before that, so a `status` that only read the local file
+//! would happily call a dead credential live.
+
+use std::io::Write;
+
+use chrono::DateTime;
+use chrono::SecondsFormat;
+use chrono::Utc;
+use mergify_core::CliError;
+use mergify_core::CredentialStore;
+use mergify_core::Output;
+use mergify_core::auth;
+use mergify_core::credentials::StoredCredential;
+use serde::Serialize;
+use url::Url;
+
+use crate::identity;
+use crate::identity::Identity;
+
+pub struct StatusOptions<'a> {
+    pub api_url: Option<&'a str>,
+    pub store: &'a CredentialStore,
+}
+
+#[derive(Serialize)]
+struct StatusResult {
+    api_url: String,
+    login: Option<String>,
+    stored_in: String,
+    expires_at: Option<String>,
+}
+
+/// Run the `auth status` command.
+pub async fn run(opts: StatusOptions<'_>, output: &mut dyn Output) -> Result<(), CliError> {
+    let api_url = auth::resolve_api_url(opts.api_url)?;
+
+    let Some(stored) = opts.store.get(&api_url)? else {
+        return Err(CliError::Configuration(format!(
+            "not logged in to {api_url}. Run `mergify auth login`.",
+        )));
+    };
+
+    match identity::whoami(api_url.clone(), &stored.credential.token).await? {
+        Identity::Known(user) => emit(output, &api_url, &stored, Some(&user.login), Utc::now()),
+        // The credential is real enough to be stored and useless
+        // enough that every command will fail. Saying "logged in"
+        // here would be the one answer a user cannot act on.
+        Identity::Refused => Err(CliError::Configuration(format!(
+            "the credential stored for {api_url} is no longer valid — it may have been \
+             revoked or have expired. Run `mergify auth login`.",
+        ))),
+        // A deployment older than `GET /v1/user`. There is a
+        // credential and no way to check it; report both.
+        Identity::Unsupported => emit(output, &api_url, &stored, None, Utc::now()),
+    }
+}
+
+fn emit(
+    output: &mut dyn Output,
+    api_url: &Url,
+    stored: &StoredCredential,
+    login: Option<&str>,
+    now: DateTime<Utc>,
+) -> Result<(), CliError> {
+    // Seconds, not the nanoseconds `Utc::now()` carries: this is a
+    // date a year out, and six digits of subsecond precision on it
+    // is noise.
+    let expires_at = stored
+        .credential
+        .expires_at
+        .map(|at| at.to_rfc3339_opts(SecondsFormat::Secs, true));
+    let expired = stored.credential.expires_at.is_some_and(|at| at <= now);
+    let result = StatusResult {
+        api_url: api_url.to_string(),
+        login: login.map(str::to_owned),
+        stored_in: stored.location.to_string(),
+        expires_at: expires_at.clone(),
+    };
+    let theme = mergify_tui::Theme::detect();
+    let location = stored.location.to_string();
+    output.emit(&result, &mut |w: &mut dyn Write| {
+        match login {
+            Some(login) => writeln!(
+                w,
+                "{green}✓{reset} Logged in to {api_url} as {login}.",
+                green = theme.green.render(),
+                reset = theme.reset,
+            )?,
+            None => writeln!(
+                w,
+                "{green}✓{reset} Logged in to {api_url}. This deployment cannot confirm \
+                 which account the credential belongs to.",
+                green = theme.green.render(),
+                reset = theme.reset,
+            )?,
+        }
+        writeln!(w, "  Credential: {location}")?;
+        if let Some(at) = &expires_at {
+            // `relative_time` takes an absolute delta, so asking it
+            // for a future rendering of a past moment prints an
+            // expired credential as "expires in about a year".
+            let (label, relative) = if expired {
+                ("Expired:", mergify_tui::relative_time(at, now, false))
+            } else {
+                ("Expires:", mergify_tui::relative_time(at, now, true))
+            };
+            writeln!(w, "  {label:<11} {at} ({relative})")?;
+        }
+        Ok(())
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use mergify_core::Credential;
+    use mergify_test_support::Captured;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    use super::*;
+    use crate::testing::file_store;
+    use crate::testing::with_mergify_token;
+
+    fn credential() -> Credential {
+        Credential {
+            token: "mut_secret".to_string(),
+            expires_at: Some(
+                DateTime::parse_from_rfc3339("2027-09-04T00:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            ),
+        }
+    }
+
+    async fn mount_user(server: &MockServer, response: ResponseTemplate) {
+        Mock::given(method("GET"))
+            .and(path("/v1/user"))
+            .respond_with(response)
+            .mount(server)
+            .await;
+    }
+
+    #[test]
+    fn status_reports_the_account_the_store_and_the_expiry() {
+        with_mergify_token(None, async {
+            let server = MockServer::start().await;
+            mount_user(
+                &server,
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"id": 42, "login": "sileht"})),
+            )
+            .await;
+            let (dir, store) = file_store();
+            store
+                .set(&Url::parse(&server.uri()).unwrap(), &credential())
+                .unwrap();
+            let mut captured = Captured::human();
+
+            run(
+                StatusOptions {
+                    api_url: Some(&server.uri()),
+                    store: &store,
+                },
+                &mut captured.output,
+            )
+            .await
+            .unwrap();
+
+            let stdout = captured.stdout();
+            assert!(stdout.contains("as sileht."), "got {stdout:?}");
+            assert!(stdout.contains("credentials.json"), "got {stdout:?}");
+            assert!(stdout.contains("2027-09-04"), "got {stdout:?}");
+            assert!(
+                !stdout.contains("mut_secret"),
+                "the token must never be printed, got {stdout:?}",
+            );
+            drop(dir);
+        });
+    }
+
+    #[test]
+    fn status_without_a_credential_says_so_and_fails() {
+        with_mergify_token(None, async {
+            let server = MockServer::start().await;
+            let (dir, store) = file_store();
+            let mut captured = Captured::human();
+
+            let err = run(
+                StatusOptions {
+                    api_url: Some(&server.uri()),
+                    store: &store,
+                },
+                &mut captured.output,
+            )
+            .await
+            .unwrap_err();
+
+            assert!(err.to_string().contains("not logged in"), "got {err}");
+            assert!(err.to_string().contains("auth login"), "got {err}");
+            assert!(
+                server.received_requests().await.unwrap().is_empty(),
+                "with nothing stored there is nothing to check against the API",
+            );
+            drop(dir);
+        });
+    }
+
+    // A credential the dashboard revoked is still on disk. Reading
+    // only the disk would call it live.
+    #[test]
+    fn status_reports_a_revoked_credential_as_invalid() {
+        with_mergify_token(None, async {
+            let server = MockServer::start().await;
+            mount_user(
+                &server,
+                ResponseTemplate::new(403)
+                    .set_body_json(serde_json::json!({"detail": "forbidden"})),
+            )
+            .await;
+            let (dir, store) = file_store();
+            store
+                .set(&Url::parse(&server.uri()).unwrap(), &credential())
+                .unwrap();
+            let mut captured = Captured::human();
+
+            let err = run(
+                StatusOptions {
+                    api_url: Some(&server.uri()),
+                    store: &store,
+                },
+                &mut captured.output,
+            )
+            .await
+            .unwrap_err();
+
+            assert!(err.to_string().contains("no longer valid"), "got {err}");
+            assert!(err.to_string().contains("auth login"), "got {err}");
+            drop(dir);
+        });
+    }
+
+    fn stored() -> StoredCredential {
+        StoredCredential {
+            credential: credential(),
+            location: mergify_core::credentials::Location::Keychain,
+        }
+    }
+
+    fn now() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-09-04T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    // `relative_time` works on an absolute delta, so a past moment
+    // asked for a future rendering reads as "expires in a year".
+    #[test]
+    fn an_expired_credential_is_not_rendered_as_a_future_one() {
+        let mut captured = Captured::human();
+        let mut stored = stored();
+        stored.credential.expires_at = Some(
+            DateTime::parse_from_rfc3339("2025-09-04T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        );
+        emit(
+            &mut captured.output,
+            &Url::parse("https://api.mergify.com").unwrap(),
+            &stored,
+            None,
+            now(),
+        )
+        .unwrap();
+
+        let stdout = captured.stdout();
+        assert!(stdout.contains("Expired:"), "got {stdout:?}");
+        assert!(stdout.contains("ago"), "got {stdout:?}");
+        assert!(!stdout.contains("(~"), "got {stdout:?}");
+    }
+
+    #[test]
+    fn status_says_when_the_deployment_cannot_confirm_the_account() {
+        with_mergify_token(None, async {
+            let server = MockServer::start().await;
+            mount_user(
+                &server,
+                ResponseTemplate::new(404)
+                    .set_body_json(serde_json::json!({"detail": "Not Found"})),
+            )
+            .await;
+            let (dir, store) = file_store();
+            store
+                .set(&Url::parse(&server.uri()).unwrap(), &credential())
+                .unwrap();
+            let mut captured = Captured::human();
+
+            run(
+                StatusOptions {
+                    api_url: Some(&server.uri()),
+                    store: &store,
+                },
+                &mut captured.output,
+            )
+            .await
+            .unwrap();
+
+            let stdout = captured.stdout();
+            assert!(stdout.contains("Logged in to"), "got {stdout:?}");
+            assert!(stdout.contains("cannot confirm"), "got {stdout:?}");
+            drop(dir);
+        });
+    }
+}

--- a/crates/mergify-cli/Cargo.toml
+++ b/crates/mergify-cli/Cargo.toml
@@ -18,6 +18,7 @@ chrono = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 clap_mangen = { workspace = true }
+mergify-auth = { path = "../mergify-auth" }
 mergify-ci = { path = "../mergify-ci" }
 mergify-config = { path = "../mergify-config" }
 mergify-core = { path = "../mergify-core" }

--- a/crates/mergify-cli/src/main.rs
+++ b/crates/mergify-cli/src/main.rs
@@ -103,6 +103,9 @@ enum Dispatch {
 /// it. Add new entries here when porting a command; the matching
 /// `clap` `Subcommands` variant is what actually wires it up.
 const NATIVE_COMMANDS: &[(&str, &str)] = &[
+    ("auth", "login"),
+    ("auth", "logout"),
+    ("auth", "status"),
     ("config", "validate"),
     ("config", "simulate"),
     ("ci", "scopes"),
@@ -157,6 +160,16 @@ const NATIVE_COMMANDS: &[(&str, &str)] = &[
 /// Native commands the Rust binary handles without delegating to
 /// the Python shim.
 enum NativeCommand {
+    /// `mergify auth login [--api-url URL]` — run the device grant
+    /// and store the credential it mints.
+    AuthLogin(AuthOpts),
+    /// `mergify auth logout [--api-url URL]` — revoke the stored
+    /// credential and forget it.
+    AuthLogout(AuthOpts),
+    /// `mergify auth status [--api-url URL]` — report whether there
+    /// is a credential, whose it is, and whether the API still
+    /// accepts it.
+    AuthStatus(AuthOpts),
     ConfigValidate {
         config_file: Option<PathBuf>,
     },
@@ -320,6 +333,13 @@ enum StackMovePosition {
     Last,
     Before,
     After,
+}
+
+/// The whole surface of every `auth` subcommand: which deployment
+/// to talk to. There is deliberately no `--token` — `auth login`
+/// mints one, and the other two act on what it stored.
+struct AuthOpts {
+    api_url: Option<String>,
 }
 
 struct StackSquashOpts {
@@ -688,7 +708,7 @@ fn init_tracing(verbose: u8, debug: bool) {
     let directives = format!(
         "warn,mergify_cli={level},mergify_core={level},mergify_stack={level},\
          mergify_ci={level},mergify_queue={level},mergify_freeze={level},\
-         mergify_config={level},mergify_tui={level}"
+         mergify_config={level},mergify_tui={level},mergify_auth={level}"
     );
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(directives));
     let _ = tracing_subscriber::fmt()
@@ -901,6 +921,14 @@ fn dispatch_from_parsed(parsed: CliRoot) -> Dispatch {
             test_exit_code,
             files,
         })),
+        Subcommands::Auth(AuthArgs { api_url, command }) => {
+            let opts = AuthOpts { api_url };
+            Dispatch::Native(match command {
+                AuthSubcommand::Login => NativeCommand::AuthLogin(opts),
+                AuthSubcommand::Logout => NativeCommand::AuthLogout(opts),
+                AuthSubcommand::Status => NativeCommand::AuthStatus(opts),
+            })
+        }
         Subcommands::Config(ConfigArgs {
             config_file,
             command: ConfigSubcommand::Validate(_),
@@ -1524,6 +1552,42 @@ fn run_native(cmd: NativeCommand) -> ExitCode {
             | NativeCommand::Completions(_)
             | NativeCommand::InternalManPage => {
                 unreachable!("introspection commands are handled before the runtime starts")
+            }
+            NativeCommand::AuthLogin(opts) => {
+                let store = mergify_core::CredentialStore::discover();
+                mergify_auth::login::run(
+                    mergify_auth::login::LoginOptions {
+                        api_url: opts.api_url.as_deref(),
+                        store: &store,
+                    },
+                    &mut output,
+                )
+                .await
+                .map(|()| mergify_core::ExitCode::Success)
+            }
+            NativeCommand::AuthLogout(opts) => {
+                let store = mergify_core::CredentialStore::discover();
+                mergify_auth::logout::run(
+                    mergify_auth::logout::LogoutOptions {
+                        api_url: opts.api_url.as_deref(),
+                        store: &store,
+                    },
+                    &mut output,
+                )
+                .await
+                .map(|()| mergify_core::ExitCode::Success)
+            }
+            NativeCommand::AuthStatus(opts) => {
+                let store = mergify_core::CredentialStore::discover();
+                mergify_auth::status::run(
+                    mergify_auth::status::StatusOptions {
+                        api_url: opts.api_url.as_deref(),
+                        store: &store,
+                    },
+                    &mut output,
+                )
+                .await
+                .map(|()| mergify_core::ExitCode::Success)
             }
             NativeCommand::ConfigValidate { config_file } => {
                 mergify_config::validate::run(config_file.as_deref(), &mut output)
@@ -2739,6 +2803,13 @@ impl From<ColorArg> for mergify_tui::ColorChoice {
 
 #[derive(Subcommand)]
 enum Subcommands {
+    /// Sign in to Mergify, and manage the stored credential.
+    ///
+    /// `mergify auth login` runs an OAuth device flow against the
+    /// Mergify API and stores the per-user token it mints, so the
+    /// commands that talk to Mergify need no token in your
+    /// environment.
+    Auth(AuthArgs),
     /// Validate and simulate your Mergify configuration.
     ///
     /// Check your `.mergify.yml` against the schema before pushing it,
@@ -4363,6 +4434,40 @@ struct EventsCliArgs {
 }
 
 #[derive(clap::Args)]
+struct AuthArgs {
+    /// Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var,
+    /// then to the default.
+    #[arg(long = "api-url", short = 'u', global = true)]
+    api_url: Option<String>,
+
+    #[command(subcommand)]
+    command: AuthSubcommand,
+}
+
+#[derive(Subcommand)]
+enum AuthSubcommand {
+    /// Sign in to Mergify and store the credential.
+    ///
+    /// Prints a URL and a code: open the one, enter the other, and
+    /// approve. The credential lands in your OS keychain, or in a
+    /// `0600` file when the machine has no keychain to offer.
+    Login,
+    /// Revoke the stored credential and forget it.
+    ///
+    /// Tells the Mergify API to revoke the token as well as deleting
+    /// the local copy, so a machine you are handing back stops being
+    /// signed in everywhere.
+    Logout,
+    /// Show whether this machine is signed in to Mergify.
+    ///
+    /// Names the account, where the credential is stored, and when it
+    /// runs out. Checks the credential against the API rather than
+    /// trusting the local copy, so one revoked from the dashboard is
+    /// reported as invalid.
+    Status,
+}
+
+#[derive(clap::Args)]
 struct FreezeArgs {
     /// Mergify or GitHub token. Falls back to ``MERGIFY_TOKEN`` and
     /// then ``GITHUB_TOKEN`` env vars.
@@ -4530,6 +4635,7 @@ mod tests {
         assert_eq!(
             groups,
             [
+                "auth",
                 "config",
                 "ci",
                 "tests",

--- a/crates/mergify-cli/src/snapshots/mergify__tests__cli_schema_golden.snap
+++ b/crates/mergify-cli/src/snapshots/mergify__tests__cli_schema_golden.snap
@@ -78,6 +78,89 @@ expression: schema
     ],
     "commands": [
       {
+        "about": "Sign in to Mergify, and manage the stored credential",
+        "aliases": [],
+        "args": [
+          {
+            "default": null,
+            "env": null,
+            "global": true,
+            "help": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+            "id": "api_url",
+            "kind": "option",
+            "long": "api-url",
+            "longHelp": "Mergify API URL. Falls back to ``MERGIFY_API_URL`` env var, then to the default",
+            "numArgs": "1",
+            "possibleValues": [],
+            "required": false,
+            "short": "u",
+            "valueHint": null,
+            "valueNames": [
+              "API_URL"
+            ]
+          }
+        ],
+        "commands": [
+          {
+            "about": "Sign in to Mergify and store the credential",
+            "aliases": [],
+            "args": [],
+            "commands": [],
+            "longAbout": "Sign in to Mergify and store the credential.\n\nPrints a URL and a code: open the one, enter the other, and approve. The credential lands in your OS keychain, or in a `0600` file when the machine has no keychain to offer.",
+            "name": "login",
+            "path": [
+              "mergify",
+              "auth",
+              "login"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify auth login [OPTIONS]"
+          },
+          {
+            "about": "Revoke the stored credential and forget it",
+            "aliases": [],
+            "args": [],
+            "commands": [],
+            "longAbout": "Revoke the stored credential and forget it.\n\nTells the Mergify API to revoke the token as well as deleting the local copy, so a machine you are handing back stops being signed in everywhere.",
+            "name": "logout",
+            "path": [
+              "mergify",
+              "auth",
+              "logout"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify auth logout [OPTIONS]"
+          },
+          {
+            "about": "Show whether this machine is signed in to Mergify",
+            "aliases": [],
+            "args": [],
+            "commands": [],
+            "longAbout": "Show whether this machine is signed in to Mergify.\n\nNames the account, where the credential is stored, and when it runs out. Checks the credential against the API rather than trusting the local copy, so one revoked from the dashboard is reported as invalid.",
+            "name": "status",
+            "path": [
+              "mergify",
+              "auth",
+              "status"
+            ],
+            "source": "native",
+            "subcommandRequired": false,
+            "usage": "mergify auth status [OPTIONS]"
+          }
+        ],
+        "longAbout": "Sign in to Mergify, and manage the stored credential.\n\n`mergify auth login` runs an OAuth device flow against the Mergify API and stores the per-user token it mints, so the commands that talk to Mergify need no token in your environment.",
+        "name": "auth",
+        "path": [
+          "mergify",
+          "auth"
+        ],
+        "source": "native",
+        "subcommandRequired": true,
+        "usage": "mergify auth [OPTIONS] <COMMAND>"
+      },
+      {
         "about": "Validate and simulate your Mergify configuration",
         "aliases": [],
         "args": [
@@ -3981,7 +4064,7 @@ expression: schema
     },
     {
       "code": 8,
-      "description": "Configuration file missing, unparseable, or failing validation.",
+      "description": "Configuration or credentials missing, unparseable, or failing validation.",
       "name": "ConfigurationError"
     }
   ],

--- a/crates/mergify-core/src/error.rs
+++ b/crates/mergify-core/src/error.rs
@@ -25,8 +25,11 @@ use crate::exit_code::ExitCode;
 
 #[derive(thiserror::Error, Debug)]
 pub enum CliError {
-    /// Configuration file missing, unparseable, or failing schema
-    /// validation. Maps to [`ExitCode::ConfigurationError`].
+    /// Configuration or credentials missing, unparseable, or failing
+    /// validation — the config file the user pointed at, and equally
+    /// the credential a Mergify command could not find anywhere in
+    /// its resolution chain. Maps to
+    /// [`ExitCode::ConfigurationError`].
     #[error("{0}")]
     Configuration(String),
 

--- a/crates/mergify-core/src/exit_code.rs
+++ b/crates/mergify-core/src/exit_code.rs
@@ -62,7 +62,7 @@ exit_codes! {
     GitHubApiError = 5 => "GitHub API request failed.",
     MergifyApiError = 6 => "Mergify API request failed.",
     InvalidState = 7 => "CLI invariant violated (e.g. command run outside a valid context).",
-    ConfigurationError = 8 => "Configuration file missing, unparseable, or failing validation.",
+    ConfigurationError = 8 => "Configuration or credentials missing, unparseable, or failing validation.",
 }
 
 impl ExitCode {


### PR DESCRIPTION
The three commands that give a machine a Mergify credential, take it
away, and say which one it holds.

`login` prints a URL and a code and waits. The credential lands in the
OS keychain, or in a `0600` file when the machine has none, and the
command says which -- a user who has to reason about where their secret
is should not have to guess.

`logout` revokes server-side before it deletes locally, because the
server's copy is the one that matters and a token whose only trace was
the file we just deleted can no longer be revoked from here at all. If
the revocation fails the local copy still goes: a `logout` that left the
credential in place because the network blinked would have done nothing
at all. The command says so, and names where to finish the job.

`status` asks the API rather than trusting the disk. A token revoked
from the dashboard is still on the machine and still carries a
year-away expiry, so a `status` that read only the local copy would
report a dead credential as live.

Three deliberate calls:

- **No `--json`.** The surface is exactly `login|logout|status
  [--api-url URL]`, which is what the docs are being written against
  right now.
- **No browser is opened.** The device grant exists because the CLI runs
  where there is no browser to open -- over SSH, in a container -- and a
  command that only works when there is one would be a different
  feature.
- **A deployment without `GET /v1/user` still works.** Self-hosted
  installs upgrade on their own schedule, so a 404 there means "cannot
  name the account", not "login failed" -- `login` stores the credential
  and `status` reports it, both saying what they could not check.

`login` revokes the credential it replaces, and the one it minted but
could not store. Neither is reachable from this machine afterwards,
and both stay live on the server for a year -- leaking one per login
walks the user into the twenty-token cap that only the dashboard can
clear. When the revocation of the *replaced* one fails, the command
says so out loud rather than in a debug line: that token is the leak
this block exists to prevent, and the user is the only one who can
finish it. The other case stays quiet, since the command is already
returning its own error about a token that never reached the store.

Two ordering rules, both about a grant the user may have approved:

- The store is read **before** the grant is opened, not merely before
  it is spent. A corrupt `credentials.json` read afterwards kills the
  command with the approval page already on screen, and whatever the
  user approves there mints a token nothing stores and nothing
  revokes. `authorize` needs no store, so this costs nothing.
- `logout`'s no-credential branch still asks the store to forget, and
  now reports what a *refused* answer there means. A keychain can deny
  a read and still delete -- macOS deletes an item whose read ACL it
  refuses, since deleting needs no decrypt -- so a credential can be
  removed without ever being read, which is a token this command could
  not ask the server to revoke. The error names the dashboard.

`auth status` exits 8 when there is no usable credential, which is the
code every Mergify command has always returned for that condition. The
published description of that code said "configuration file", which was
never true of a missing token; it now says configuration *or*
credentials.

The credential is stored but nothing else reads it yet; the next commit
puts it in the resolution chain. No message here claims otherwise.

Fixes MRGFY-8703