### PR TITLE
feat(ci): declare how many uploads make up a test session

### DIFF
--- a/crates/mergify-ci/src/junit_process/command.rs
+++ b/crates/mergify-ci/src/junit_process/command.rs
@@ -173,11 +173,18 @@ async fn run_with_cap(
     };
     let mut built = spans::build_traces(&parsed, &metadata);
 
-    // Cap each gzipped upload at MAX_GZIPPED_UPLOAD_BYTES. A normal
-    // report is one chunk (byte-identical to before); only an
-    // oversized payload fans out into several uploads.
+    // Size each gzipped upload against MAX_GZIPPED_UPLOAD_BYTES. A
+    // normal report is one chunk, and byte-identical to before as
+    // long as it lost nothing; only an oversized payload fans out
+    // into several uploads.
+    //
+    // The cases already refused on name length go in as well: the
+    // split is what declares a session amputated, and that count has
+    // to cover every result missing from the upload, not only the
+    // ones this step drops. Counted before the two lists are merged
+    // below, which is the same total by construction.
     let (chunks, mut oversized_cases, mut upload_error) =
-        match split::split_request(&built.request, upload_cap) {
+        match split::split_request(&built.request, upload_cap, built.oversized_case_names.len()) {
             Ok(outcome) => (outcome.chunks, outcome.oversized_cases, None),
             // gzip is an in-memory write and effectively never fails,
             // but if it does we surface it as an upload error rather
@@ -208,6 +215,14 @@ async fn run_with_cap(
     // before the loop consumes `chunks`. That must not be reported as
     // a successful upload.
     let nothing_uploaded = chunks.is_empty();
+    // Since a fanned-out upload declares its own total (see `split`),
+    // "4 of 5 chunks sent" is no longer a transient hiccup: it leaves
+    // a session a backend can see is unfinished — once it reads the
+    // declaration, which is MRGFY-9121 and not yet deployed. This
+    // process is the only place that ever knew the total, so the line
+    // is worth printing before that lands.
+    let chunks_produced = chunks.len();
+    let mut chunks_accepted = 0usize;
 
     // Post each chunk. Stop early only on a permanent rejection (bad
     // token / no ingest access) — it would fail every remaining chunk
@@ -232,6 +247,8 @@ async fn run_with_cap(
             if permanent {
                 break;
             }
+        } else {
+            chunks_accepted += 1;
         }
     }
 
@@ -250,6 +267,7 @@ async fn run_with_cap(
         nb_failures,
         upload_failed,
     );
+    write_chunked_delivery(&mut report, chunks_produced, chunks_accepted);
 
     if let Some(err) = &upload_error {
         write_upload_error_block(&mut report, &err.to_string(), err.is_rejection());
@@ -525,6 +543,38 @@ fn write_upload_summary(
         out.push_str(&format!("      ☁️ {reports_label} uploaded\n"));
     }
     out.push_str(&format!("      🧪 {tests} tests ({failures_label})\n"));
+}
+
+/// Report how a fanned-out session was delivered. "Chunk" is the
+/// wire's own word for one upload of a split session
+/// (`mergify.test.session.chunk.count`); using it here too means an
+/// operator reading this line and someone grepping the backend look
+/// for the same term.
+///
+/// Silent for the ordinary single-upload run, which must keep reading
+/// exactly as it does today. Counts only, never a line per chunk: a
+/// report large enough to split can produce arbitrarily many, and no
+/// individual one is worth a line in a CI log.
+///
+/// The incompleteness wording is claimed only where it is true — some
+/// chunks landed and the rest did not, so what ingest holds is a
+/// session that will never reach its declared total (readable as such
+/// once MRGFY-9121 ships). When nothing landed there is no such
+/// session, only a failed upload, which
+/// [`write_upload_error_block`] already explains.
+fn write_chunked_delivery(out: &mut String, produced: usize, accepted: usize) {
+    if produced <= 1 {
+        return;
+    }
+    if accepted == produced {
+        out.push_str(&format!("      ☁️ sent in {produced} chunks\n"));
+    } else if accepted == 0 {
+        out.push_str(&format!("      ☁️ none of the {produced} chunks sent\n"));
+    } else {
+        out.push_str(&format!(
+            "      ☁️ only {accepted} of {produced} chunks sent — this test session is incomplete\n"
+        ));
+    }
 }
 
 /// `$GITHUB_OUTPUT` key reporting the upload outcome:
@@ -1273,6 +1323,463 @@ mod tests {
                     req.body.len()
                 );
             }
+        }
+
+        /// The `(index, count)` completeness markers carried by every
+        /// traces upload the server received, in arrival order, each
+        /// read independently — a chunk carrying one without the
+        /// other is a half-marked state a reader would misinterpret
+        /// as a declared total, and collapsing the pair would hide it.
+        /// Decodes the real wire body (gzip → protobuf), so this
+        /// asserts what the backend will read, not what the splitter
+        /// intended.
+        async fn uploaded_chunk_markers(server: &MockServer) -> Vec<(Option<i64>, Option<i64>)> {
+            use crate::junit_process::split::{CHUNK_COUNT_ATTRIBUTE, CHUNK_INDEX_ATTRIBUTE};
+            use flate2::read::GzDecoder;
+            use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+            use opentelemetry_proto::tonic::common::v1::any_value::Value;
+            use prost::Message as _;
+            use std::io::Read as _;
+
+            let mut markers = Vec::new();
+            for req in server.received_requests().await.unwrap() {
+                if req.url.path() != "/v1/repos/owner/repo/ci/traces" {
+                    continue;
+                }
+                let mut unzipped = Vec::new();
+                GzDecoder::new(req.body.as_slice())
+                    .read_to_end(&mut unzipped)
+                    .expect("upload body decompresses");
+                let decoded =
+                    ExportTraceServiceRequest::decode(unzipped.as_slice()).expect("body decodes");
+                let attributes = &decoded.resource_spans[0]
+                    .resource
+                    .as_ref()
+                    .expect("uploads carry a resource")
+                    .attributes;
+                let read = |key: &str| {
+                    attributes.iter().find(|kv| kv.key == key).and_then(|kv| {
+                        match kv.value.as_ref()?.value.as_ref()? {
+                            Value::IntValue(v) => Some(*v),
+                            _ => None,
+                        }
+                    })
+                };
+                markers.push((read(CHUNK_INDEX_ATTRIBUTE), read(CHUNK_COUNT_ATTRIBUTE)));
+            }
+            markers
+        }
+
+        /// The set of resource attribute keys on every traces upload
+        /// the server received, decoded from the real wire body.
+        async fn uploaded_resource_keys(server: &MockServer) -> Vec<Vec<String>> {
+            use flate2::read::GzDecoder;
+            use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+            use prost::Message as _;
+            use std::io::Read as _;
+
+            let mut per_upload = Vec::new();
+            for req in server.received_requests().await.unwrap() {
+                if req.url.path() != "/v1/repos/owner/repo/ci/traces" {
+                    continue;
+                }
+                let mut unzipped = Vec::new();
+                GzDecoder::new(req.body.as_slice())
+                    .read_to_end(&mut unzipped)
+                    .expect("upload body decompresses");
+                let decoded =
+                    ExportTraceServiceRequest::decode(unzipped.as_slice()).expect("body decodes");
+                per_upload.push(
+                    decoded.resource_spans[0]
+                        .resource
+                        .as_ref()
+                        .expect("uploads carry a resource")
+                        .attributes
+                        .iter()
+                        .map(|kv| kv.key.clone())
+                        .collect(),
+                );
+            }
+            per_upload
+        }
+
+        // Every upload of a fanned-out session must tell the backend
+        // that it is one piece of `n`, so a consumer answering "did
+        // this session report a failing test?" can tell a
+        // half-delivered session from a finished one instead of
+        // answering from the first piece to land.
+        #[tokio::test]
+        async fn fanned_out_uploads_declare_their_position_in_the_session() {
+            let server = MockServer::start().await;
+            mount_mocks(&server).await;
+            let tmp = tempfile::tempdir().unwrap();
+            let file = write_xml(&tmp, "report.xml", &incompressible_failures_xml(30, 2048));
+
+            let api_url = server.uri();
+            let mut cap = captured();
+            // A populated CI environment, so `build_resource` emits
+            // the routing and attribution attributes this test then
+            // checks survive stamping. With the environment scrubbed
+            // it would only ever emit `test.run.id`, and the check
+            // would pass on an empty resource.
+            with_ci_env_async(
+                &[
+                    ("GITHUB_ACTIONS", Some("true")),
+                    ("GITHUB_REPOSITORY", Some("owner/repo")),
+                    (
+                        "GITHUB_SHA",
+                        Some("cafe1234cafe1234cafe1234cafe1234cafe1234"),
+                    ),
+                    ("GITHUB_RUN_ID", Some("42")),
+                ],
+                async {
+                    let opts = JunitProcessOptions {
+                        api_url: Some(&api_url),
+                        token: Some("secret"),
+                        repository: Some("owner/repo"),
+                        test_framework: None,
+                        test_language: None,
+                        tests_target_branch: Some("main"),
+                        test_exit_code: None,
+                        files: &[file],
+                    };
+                    run_with_cap(opts, &mut cap.output, 4 * 1024).await.unwrap()
+                },
+            )
+            .await;
+
+            let markers = uploaded_chunk_markers(&server).await;
+            let total = i64::try_from(markers.len()).unwrap();
+            assert!(total > 1, "expected a fan-out, got {total} upload(s)");
+            let expected: Vec<(Option<i64>, Option<i64>)> = (1..=total)
+                .map(|index| (Some(index), Some(total)))
+                .collect();
+            assert_eq!(
+                markers, expected,
+                "the delivered sequence must be 1..=n, each declaring n"
+            );
+
+            // This run lost nothing, so no upload declares a loss.
+            // Absence is the convention; a `0` stamped here instead
+            // would ride on the most ordinary fan-out there is.
+            assert!(
+                uploaded_dropped_counts(&server)
+                    .await
+                    .iter()
+                    .all(Option::is_none),
+                "an upload declared a loss that never happened"
+            );
+
+            // Stamping extends the resource; it must not replace it.
+            // The markers are the only thing this code adds, so every
+            // routing and attribution attribute `build_resource` put
+            // there has to still be on every chunk — a resource
+            // rebuilt from scratch would lose them silently, and only
+            // on the split path.
+            for keys in uploaded_resource_keys(&server).await {
+                for required in [
+                    "test.run.id",
+                    "vcs.repository.name",
+                    "vcs.ref.head.revision",
+                    "cicd.pipeline.run.id",
+                ] {
+                    assert!(
+                        keys.contains(&required.to_string()),
+                        "a fanned-out chunk lost `{required}`; it carries {keys:?}"
+                    );
+                }
+            }
+        }
+
+        // A fan-out where the backend takes the first chunk and
+        // refuses the rest leaves a session it can see is incomplete.
+        // Nothing else in the report says so, and this process is the
+        // only place that ever knew the total.
+        #[tokio::test]
+        async fn partial_fan_out_reports_the_session_as_incomplete() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/ci/owner/repositories/repo/quarantines/check"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "quarantined_tests_names": [],
+                    "non_quarantined_tests_names": [],
+                })))
+                .mount(&server)
+                .await;
+            // First chunk accepted, every later one transiently
+            // refused — a 503 keeps the loop going, so the run really
+            // does attempt them all and end up short.
+            Mock::given(method("POST"))
+                .and(path("/v1/repos/owner/repo/ci/traces"))
+                .respond_with(ResponseTemplate::new(200))
+                .up_to_n_times(1)
+                .mount(&server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path("/v1/repos/owner/repo/ci/traces"))
+                .respond_with(ResponseTemplate::new(503).set_body_string("try later"))
+                .mount(&server)
+                .await;
+
+            let tmp = tempfile::tempdir().unwrap();
+            let file = write_xml(&tmp, "report.xml", &incompressible_failures_xml(30, 2048));
+            let api_url = server.uri();
+            let mut cap = captured();
+            with_ci_env_async(&[], async {
+                let opts = JunitProcessOptions {
+                    api_url: Some(&api_url),
+                    token: Some("secret"),
+                    repository: Some("owner/repo"),
+                    test_framework: None,
+                    test_language: None,
+                    tests_target_branch: Some("main"),
+                    test_exit_code: None,
+                    files: &[file],
+                };
+                run_with_cap(opts, &mut cap.output, 4 * 1024).await.unwrap()
+            })
+            .await;
+
+            let produced = traces_requests(&server).await;
+            assert!(produced > 1, "expected a fan-out, got {produced} upload(s)");
+            let stdout = String::from_utf8(cap.stdout.lock().unwrap().clone()).unwrap();
+            assert!(
+                stdout.contains(&format!(
+                    "only 1 of {produced} chunks sent — this test session is incomplete"
+                )),
+                "{stdout}"
+            );
+        }
+
+        // A fan-out whose very first chunk is permanently rejected
+        // never declares anything: the loop breaks, nothing reached
+        // ingest, and there is no session for the backend to hold. So
+        // the counts are stated without claiming an incomplete
+        // session — that claim belongs to a delivery that partly
+        // landed, and asserting it here would be false.
+        #[tokio::test]
+        async fn a_fan_out_rejected_outright_claims_no_incomplete_session() {
+            let server = MockServer::start().await;
+            mount_mocks_with_upload_status(&server, 403).await;
+            let tmp = tempfile::tempdir().unwrap();
+            let file = write_xml(&tmp, "report.xml", &incompressible_failures_xml(30, 2048));
+
+            let api_url = server.uri();
+            let mut cap = captured();
+            with_ci_env_async(&[], async {
+                let opts = JunitProcessOptions {
+                    api_url: Some(&api_url),
+                    token: Some("secret"),
+                    repository: Some("owner/repo"),
+                    test_framework: None,
+                    test_language: None,
+                    tests_target_branch: Some("main"),
+                    test_exit_code: None,
+                    files: &[file],
+                };
+                run_with_cap(opts, &mut cap.output, 4 * 1024).await.unwrap()
+            })
+            .await;
+
+            // A permanent rejection stops the loop after one attempt,
+            // so the request count is 1 while the split produced many.
+            assert_eq!(traces_requests(&server).await, 1);
+            let stdout = String::from_utf8(cap.stdout.lock().unwrap().clone()).unwrap();
+            assert!(stdout.contains("none of the"), "{stdout}");
+            assert!(stdout.contains("chunks sent"), "{stdout}");
+            assert!(
+                !stdout.contains("this test session is incomplete"),
+                "nothing reached ingest, so no session is incomplete: {stdout}"
+            );
+        }
+
+        // The same fan-out, fully delivered: the counts are stated
+        // without the incompleteness wording.
+        #[tokio::test]
+        async fn fully_delivered_fan_out_reports_its_part_count() {
+            let server = MockServer::start().await;
+            mount_mocks(&server).await;
+            let tmp = tempfile::tempdir().unwrap();
+            let file = write_xml(&tmp, "report.xml", &incompressible_failures_xml(30, 2048));
+
+            let api_url = server.uri();
+            let mut cap = captured();
+            with_ci_env_async(&[], async {
+                let opts = JunitProcessOptions {
+                    api_url: Some(&api_url),
+                    token: Some("secret"),
+                    repository: Some("owner/repo"),
+                    test_framework: None,
+                    test_language: None,
+                    tests_target_branch: Some("main"),
+                    test_exit_code: None,
+                    files: &[file],
+                };
+                run_with_cap(opts, &mut cap.output, 4 * 1024).await.unwrap()
+            })
+            .await;
+
+            let produced = traces_requests(&server).await;
+            assert!(produced > 1, "expected a fan-out, got {produced} upload(s)");
+            let stdout = String::from_utf8(cap.stdout.lock().unwrap().clone()).unwrap();
+            assert!(
+                stdout.contains(&format!("sent in {produced} chunks")),
+                "{stdout}"
+            );
+            assert!(!stdout.contains("incomplete"), "{stdout}");
+        }
+
+        // The ordinary run must keep reading exactly as it does
+        // today: no chunking language at all.
+        #[tokio::test]
+        async fn single_upload_reports_no_chunk_count() {
+            let server = MockServer::start().await;
+            mount_mocks(&server).await;
+            let tmp = tempfile::tempdir().unwrap();
+            let file = write_xml(&tmp, "report.xml", ONE_PASSING_TEST_XML);
+
+            let api_url = server.uri();
+            let mut cap = captured();
+            with_ci_env_async(&[], async {
+                let opts = JunitProcessOptions {
+                    api_url: Some(&api_url),
+                    token: Some("secret"),
+                    repository: Some("owner/repo"),
+                    test_framework: None,
+                    test_language: None,
+                    tests_target_branch: Some("main"),
+                    test_exit_code: None,
+                    files: &[file],
+                };
+                run(opts, &mut cap.output).await.unwrap()
+            })
+            .await;
+
+            assert_eq!(traces_requests(&server).await, 1);
+            let stdout = String::from_utf8(cap.stdout.lock().unwrap().clone()).unwrap();
+            assert!(!stdout.contains("chunks"), "{stdout}");
+        }
+
+        // The compatibility hinge, asserted at the wire: a report
+        // that fits in one upload sends neither attribute. Each is
+        // read separately — half a marker is worse than none, since a
+        // lone count reads as a declared total.
+        async fn uploaded_dropped_counts(server: &MockServer) -> Vec<Option<i64>> {
+            use crate::junit_process::split::DROPPED_CASES_ATTRIBUTE;
+            use flate2::read::GzDecoder;
+            use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+            use opentelemetry_proto::tonic::common::v1::any_value::Value;
+            use prost::Message as _;
+            use std::io::Read as _;
+
+            let mut counts = Vec::new();
+            for req in server.received_requests().await.unwrap() {
+                if req.url.path() != "/v1/repos/owner/repo/ci/traces" {
+                    continue;
+                }
+                let mut unzipped = Vec::new();
+                GzDecoder::new(req.body.as_slice())
+                    .read_to_end(&mut unzipped)
+                    .expect("upload body decompresses");
+                let decoded =
+                    ExportTraceServiceRequest::decode(unzipped.as_slice()).expect("body decodes");
+                counts.push(
+                    decoded.resource_spans[0]
+                        .resource
+                        .as_ref()
+                        .expect("uploads carry a resource")
+                        .attributes
+                        .iter()
+                        .find(|kv| kv.key == DROPPED_CASES_ATTRIBUTE)
+                        .and_then(|kv| match kv.value.as_ref()?.value.as_ref()? {
+                            Value::IntValue(v) => Some(*v),
+                            _ => None,
+                        }),
+                );
+            }
+            counts
+        }
+
+        // A run that fits in one upload and lost a case to the name
+        // limit: complete as far as the sequence goes, and still
+        // missing a result. The count has to reach the wire, or the
+        // session reads as whole.
+        #[tokio::test]
+        async fn a_single_upload_missing_a_case_declares_the_loss() {
+            let server = MockServer::start().await;
+            mount_mocks(&server).await;
+            let tmp = tempfile::tempdir().unwrap();
+            // Two refused names, not one: this is the only test
+            // covering the whole name-limit → wire path, so it has to
+            // pin that the count says *how many* results are missing
+            // and not merely that some are.
+            let too_long = "x".repeat(spans::MAX_TEST_NAME_BYTES + 1);
+            let also_too_long = "y".repeat(spans::MAX_TEST_NAME_BYTES + 1);
+            let file = write_xml(
+                &tmp,
+                "report.xml",
+                &format!(
+                    r#"<?xml version="1.0"?>
+<testsuites>
+  <testsuite name="pytest" tests="3" failures="0">
+    <testcase classname="tests" name="test_kept"/>
+    <testcase classname="tests" name="{too_long}"/>
+    <testcase classname="tests" name="{also_too_long}"/>
+  </testsuite>
+</testsuites>"#
+                ),
+            );
+
+            let api_url = server.uri();
+            let mut cap = captured();
+            with_ci_env_async(&[], async {
+                let opts = JunitProcessOptions {
+                    api_url: Some(&api_url),
+                    token: Some("secret"),
+                    repository: Some("owner/repo"),
+                    test_framework: None,
+                    test_language: None,
+                    tests_target_branch: Some("main"),
+                    test_exit_code: None,
+                    files: &[file],
+                };
+                run(opts, &mut cap.output).await.unwrap()
+            })
+            .await;
+
+            assert_eq!(uploaded_dropped_counts(&server).await, vec![Some(2)]);
+            // One upload: no sequence to declare.
+            assert_eq!(uploaded_chunk_markers(&server).await, vec![(None, None)]);
+        }
+
+        #[tokio::test]
+        async fn a_single_upload_declares_no_chunk_markers() {
+            let server = MockServer::start().await;
+            mount_mocks(&server).await;
+            let tmp = tempfile::tempdir().unwrap();
+            let file = write_xml(&tmp, "report.xml", &incompressible_failures_xml(3, 64));
+
+            let api_url = server.uri();
+            let mut cap = captured();
+            with_ci_env_async(&[], async {
+                let opts = JunitProcessOptions {
+                    api_url: Some(&api_url),
+                    token: Some("secret"),
+                    repository: Some("owner/repo"),
+                    test_framework: None,
+                    test_language: None,
+                    tests_target_branch: Some("main"),
+                    test_exit_code: None,
+                    files: &[file],
+                };
+                run(opts, &mut cap.output).await.unwrap()
+            })
+            .await;
+
+            assert_eq!(uploaded_chunk_markers(&server).await, vec![(None, None)]);
+            // Nothing lost either: an ordinary run declares none of
+            // the three markers.
+            assert_eq!(uploaded_dropped_counts(&server).await, vec![None]);
         }
 
         // A JUnit report of `n` failing cases, each with a

--- a/crates/mergify-ci/src/junit_process/spans.rs
+++ b/crates/mergify-ci/src/junit_process/spans.rs
@@ -396,7 +396,9 @@ fn kv_bool(key: &str, value: bool) -> KeyValue {
     kv(key, AnyValueOneof::BoolValue(value))
 }
 
-fn kv_int(key: &str, value: i64) -> KeyValue {
+/// Shared with [`crate::junit_process::split`], which stamps the
+/// per-chunk completeness markers onto an already-built resource.
+pub(super) fn kv_int(key: &str, value: i64) -> KeyValue {
     kv(key, AnyValueOneof::IntValue(value))
 }
 

--- a/crates/mergify-ci/src/junit_process/split.rs
+++ b/crates/mergify-ci/src/junit_process/split.rs
@@ -1,5 +1,7 @@
-//! Split an oversized OTLP trace request into several uploads that
-//! each gzip under [`upload::MAX_GZIPPED_UPLOAD_BYTES`].
+//! Split an oversized OTLP trace request into several uploads sized
+//! against [`upload::MAX_GZIPPED_UPLOAD_BYTES`] — "against" and not
+//! "under", by a bounded margin two paths take deliberately; see
+//! [`Chunk`].
 //!
 //! [`spans::build_traces`] produces one `ExportTraceServiceRequest`
 //! for a whole run: a session root span, one suite span per
@@ -21,23 +23,163 @@
 //! dominated by megabyte stack traces, so a raw-size heuristic can't
 //! predict the compressed body.
 //!
-//! Each returned [`Chunk`] carries the gzipped bytes it was sized
-//! against, so the upload step posts them directly instead of
-//! re-compressing.
+//! Each returned [`Chunk`] carries the gzipped bytes to post, so the
+//! upload step never compresses again. They are the bytes the chunk
+//! was sized against unless it was stamped, in which case they are
+//! the gzip of the stamped payload — always what goes on the wire.
+//!
+//! # Declaring completeness
+//!
+//! Self-containment is what makes a chunk unreadable as a *part*:
+//! once ingested it carries the session span and a set of case spans
+//! that read as a whole run — the cases it happens to hold, with
+//! nothing saying how many there were — so a consumer asking "did
+//! this session report a failing test?" gets an answer from the
+//! first chunk alone, before the rest of the run has landed. Every
+//! chunk of a multi-chunk delivery therefore declares its own
+//! position ([`CHUNK_INDEX_ATTRIBUTE`]) and the length of the
+//! sequence ([`CHUNK_COUNT_ATTRIBUTE`]) as resource attributes.
+//!
+//! **Both attributes absent means "a single upload, and it is the
+//! whole session".** That is the compatibility hinge, and it is why
+//! a lone chunk is left unmarked: a session counts as incomplete only
+//! when it declares a total it has not reached, so every client
+//! published before this existed keeps counting as complete. Any
+//! other convention (a required marker, a `0`-based index colliding
+//! with proto defaults) would strip "complete" from every deployed
+//! client at once.
+//!
+//! Strictly, absence means "this client says nothing", and an older
+//! one that fanned out says nothing either — MRGFY-9128 carries what
+//! it would take to tell the two apart, and the blind spot is spelled
+//! out on [`DROPPED_CASES_ATTRIBUTE`], where it bites the same way.
+//!
+//! `i of n` rather than a "last chunk" flag: neither is knowable
+//! until packing has finished, so both need the same after-the-fact
+//! stamping pass, and the pair additionally distinguishes a *stalled*
+//! delivery (chunk 3 of 5, an hour old) from one that merely hasn't
+//! finished arriving.
+//!
+//! On the resource rather than in an HTTP header, though the header
+//! would be cheaper — it would leave both the resource and the
+//! session span byte-identical across chunks, and delete the re-gzip
+//! pass with them. A header does not survive ingest: the consumer has
+//! to answer "is this session complete?" long after the upload,
+//! against stored telemetry, so the declaration has to sit in a field
+//! that gets persisted. The cost is that one session then presents a
+//! different resource attribute set per chunk, which assumes the
+//! consumer does not key or dedupe on resource identity.
+//!
+//! # Declaring loss
+//!
+//! Reaching the declared total says every upload arrived; it does not
+//! say every result did. A case whose own payload fits in no upload
+//! is dropped here, and one whose name exceeds
+//! [`spans::MAX_TEST_NAME_BYTES`] is dropped before this module ever
+//! sees it — so a session can announce itself complete and still be
+//! missing tests, biased towards the failing ones, since a megabyte
+//! stack trace is what makes a case oversized in the first place.
+//!
+//! [`DROPPED_CASES_ATTRIBUTE`] carries how many were left out,
+//! session-wide, on every chunk — so whichever chunk a consumer holds
+//! tells it the session is amputated. Absent means nothing was
+//! dropped, the same hinge as above.
+//!
+//! Nothing else in the payload says it. A dropped case span is the
+//! only record of its own failure: the session and suite spans carry
+//! no counters, and the run's failure count never leaves this process
+//! — it feeds the CI verdict and the printed report, not the wire. So
+//! a session that lost a failing case is, without this attribute,
+//! byte-for-byte a session where that test never ran.
 //!
 //! [`spans::build_traces`]: crate::junit_process::spans::build_traces
+//! [`spans::MAX_TEST_NAME_BYTES`]: crate::junit_process::spans::MAX_TEST_NAME_BYTES
 
 use std::collections::HashMap;
 
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+use opentelemetry_proto::tonic::resource::v1::Resource;
 use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span};
 use prost::Message as _;
 
+use crate::junit_process::spans::kv_int;
 use crate::junit_process::upload;
 
-/// One upload: the request plus the gzipped bytes to POST. The bytes
-/// are the exact payload the chunk was measured against, so the
-/// caller never gzips twice.
+/// Resource attribute carrying this upload's 1-based position in the
+/// session's chunk sequence. 1-based so it reads as "3 of 5" to
+/// whoever ends up looking at it — not to keep an absent attribute
+/// distinguishable from the first chunk, which it is anyway: resource
+/// attributes are a repeated field, so absence here is absence from
+/// the list and never a zero. That collision is only a risk further
+/// downstream, in a consumer that stores the index in a column with a
+/// default.
+pub const CHUNK_INDEX_ATTRIBUTE: &str = "mergify.test.session.chunk.index";
+
+/// Resource attribute carrying how many uploads the session was
+/// split into. A reader has the whole session once it has seen this
+/// many distinct chunks of the run.
+pub const CHUNK_COUNT_ATTRIBUTE: &str = "mergify.test.session.chunk.count";
+
+/// Resource attribute carrying how many test cases this client left
+/// out of the upload entirely, across the whole session.
+///
+/// The key spells out what it counts because it sits next to
+/// [`CHUNK_COUNT_ATTRIBUTE`], and `dropped.count` there reads just as
+/// easily as "how many chunks were dropped" — from which a consumer
+/// could derive `received + dropped == chunk.count`, a rule that is
+/// self-consistent and closes a session while results are missing.
+/// That is the misread this whole module exists to prevent, so the
+/// unit goes in the key; OTLP spells its own equivalent
+/// `dropped_attributes_count` in the same protobuf.
+///
+/// Omitted rather than stamped as `0` when nothing was lost, on the
+/// same compatibility hinge as the chunk markers — and with the same
+/// blind spot, which a consumer has to know: absent means "nothing
+/// lost" from a client that stamps this, and "unknown" from an older
+/// one. Today that gap is the chunk markers' alone — splitting has
+/// been released since `2026.7.21.1`, so deployed clients do fan out
+/// and say nothing about it, while the other refusal (a name over
+/// [`spans::MAX_TEST_NAME_BYTES`]) is on `main` and in no release
+/// yet, so no client in the wild drops a case for it. Reading absence
+/// as whole is the deliberate trade the hinge makes; separating the
+/// two needs a producer version on the resource and a consumer that
+/// gates on it, which is MRGFY-9128.
+///
+/// Session-wide rather than per-chunk on purpose: a consumer decides
+/// on the session, and a per-chunk tally would make the answer depend
+/// on which chunk it happened to read.
+pub const DROPPED_CASES_ATTRIBUTE: &str = "mergify.test.session.dropped_cases.count";
+
+/// Room held back from `cap` while packing, so stamping the
+/// completeness attributes afterwards cannot push a packed chunk over
+/// the real cap.
+///
+/// The markers are stamped *after* packing because their values do
+/// not exist until the partition is final. At most three ride on one
+/// chunk — index, count and a drop tally — for ~145 bytes of protobuf
+/// before compression, so a kibibyte is an order
+/// of magnitude more than deflate can turn that into — and against
+/// the production cap it is 0.005% of a 20 MiB budget that already
+/// sits 5 MiB below the server's hard limit. What holds the constant
+/// honest is `stamping_overhead_fits_in_the_reserved_headroom`, which
+/// measures the gzipped cost of stamping; asserting that chunks land
+/// under the cap does not, because on any ordinary fixture they land
+/// far below it.
+const CHUNK_MARKER_RESERVE_BYTES: usize = 1024;
+
+/// One upload: the request plus the gzipped bytes to post. The bytes
+/// are always the gzip of `request` — including after
+/// [`stamp_completeness_markers`] rewrites both — so the caller posts
+/// them as they are and never gzips twice.
+///
+/// What they were *sized* against depends on the path. A chunk out of
+/// a fan-out is sized against `cap` minus
+/// [`CHUNK_MARKER_RESERVE_BYTES`], which is what leaves stamping the
+/// room to stay under `cap`. Two paths deliberately do not: a lone
+/// case admitted at the hard cap, and a single upload that fits and
+/// then declares a loss. Both can land a few dozen bytes past `cap`,
+/// which is a client-side target sitting 5 MiB below what ingest
+/// actually refuses (see [`upload::MAX_GZIPPED_UPLOAD_BYTES`]).
 #[derive(Debug)]
 pub struct Chunk {
     pub request: ExportTraceServiceRequest,
@@ -47,9 +189,11 @@ pub struct Chunk {
 /// Outcome of [`split_request`].
 #[derive(Debug)]
 pub struct SplitOutcome {
-    /// One gzip-under-cap upload per entry, in order. Empty only in
-    /// the pathological case where every case is individually
-    /// oversized (see `oversized_cases`).
+    /// One upload per entry, in order, each sized to gzip under the
+    /// cap (see [`Chunk`] for what "under" means once the
+    /// completeness markers are stamped). Empty only in the
+    /// pathological case where every case is individually oversized
+    /// (see `oversized_cases`).
     pub chunks: Vec<Chunk>,
     /// Names of case spans that gzip past the cap on their own — a
     /// single test whose captured output/stack trace is so large it
@@ -60,14 +204,30 @@ pub struct SplitOutcome {
     pub oversized_cases: Vec<String>,
 }
 
-/// Partition `request` into uploads that each gzip to at most `cap`
-/// bytes.
+/// Partition `request` into uploads sized so their gzipped bodies fit
+/// `cap` — see [`Chunk`] for the two paths that overshoot it by a
+/// bounded margin.
+///
+/// A `cap` above [`CHUNK_MARKER_RESERVE_BYTES`] is what makes the
+/// partition useful: a fanned-out one is packed to `cap` minus that
+/// reserve, so the completeness markers stamped afterwards still fit.
+/// Nothing enforces it — a smaller `cap` saturates the packing budget
+/// to zero and degrades to one upload per case, or, for a case that
+/// overflows `cap` on its own, to dropping it. Degrading beats
+/// refusing here, and the tests use tiny caps deliberately. The
+/// production caller passes [`upload::MAX_GZIPPED_UPLOAD_BYTES`].
 ///
 /// The common case is a small report: the whole request already fits,
 /// so a single-element `chunks` is returned after one gzip and the
 /// upload path posts that exact payload. Only when the full payload
 /// exceeds `cap` do we decompose it and pack the case spans into
 /// several requests.
+///
+/// `dropped_before_split` is how many cases the span builder already
+/// refused on name length. They join the ones dropped here for
+/// [`DROPPED_CASES_ATTRIBUTE`], because the two are one fact for a
+/// consumer — a result missing from the session — and the report the
+/// user reads already merges them into a single list.
 ///
 /// Returns `Err` only if gzip itself fails (an in-memory
 /// `flate2` write, so effectively never) — surfaced rather than
@@ -76,16 +236,11 @@ pub struct SplitOutcome {
 pub fn split_request(
     request: &ExportTraceServiceRequest,
     cap: usize,
+    dropped_before_split: usize,
 ) -> Result<SplitOutcome, std::io::Error> {
     let compressed = gzip_request(request)?;
     if compressed.len() <= cap {
-        return Ok(SplitOutcome {
-            chunks: vec![Chunk {
-                request: request.clone(),
-                compressed,
-            }],
-            oversized_cases: Vec::new(),
-        });
+        return single_upload(request, compressed, dropped_before_split);
     }
 
     // Decompose the single-resource / single-scope layout that
@@ -94,22 +249,122 @@ pub fn split_request(
     // the upload may be refused, but that's strictly better than
     // panicking, and this branch is unreachable for our own builder.
     let Some(decomposed) = Decomposed::from_request(request) else {
-        return Ok(SplitOutcome {
-            chunks: vec![Chunk {
-                request: request.clone(),
-                compressed,
-            }],
-            oversized_cases: Vec::new(),
-        });
+        return single_upload(request, compressed, dropped_before_split);
     };
 
     let mut chunks = Vec::new();
     let mut oversized_cases = Vec::new();
-    decomposed.pack(&decomposed.cases, cap, &mut chunks, &mut oversized_cases)?;
+    decomposed.pack(
+        &decomposed.cases,
+        cap.saturating_sub(CHUNK_MARKER_RESERVE_BYTES),
+        cap,
+        &mut chunks,
+        &mut oversized_cases,
+    )?;
+    stamp_completeness_markers(&mut chunks, dropped_before_split + oversized_cases.len())?;
     Ok(SplitOutcome {
         chunks,
         oversized_cases,
     })
+}
+
+/// The whole run in one upload: the payload fit, or it could not be
+/// taken apart. It carries no chunk markers — a single upload *is*
+/// the session — but it still declares any cases dropped before it,
+/// which is the one thing a lone chunk can be missing.
+///
+/// When the payload fit, those bytes were sized against the full
+/// `cap`, not the packing budget, so stamping a drop count can push
+/// them a few dozen bytes past `cap` — the same trade the packer
+/// already takes for a lone oversized-but-shippable case, and worth
+/// far more than fanning out a report that fits, against a cap that
+/// keeps 5 MiB clear of the ingest limit.
+///
+/// The other entry is the undecomposable payload, which was already
+/// over `cap` before anything was stamped; nothing bounds it here and
+/// nothing did before. It is unreachable for requests this crate
+/// builds — it exists so an unexpected layout ships rather than
+/// panics.
+fn single_upload(
+    request: &ExportTraceServiceRequest,
+    compressed: Vec<u8>,
+    dropped_cases: usize,
+) -> Result<SplitOutcome, std::io::Error> {
+    let mut chunks = vec![Chunk {
+        request: request.clone(),
+        compressed,
+    }];
+    stamp_completeness_markers(&mut chunks, dropped_cases)?;
+    Ok(SplitOutcome {
+        chunks,
+        oversized_cases: Vec::new(),
+    })
+}
+
+/// Stamp each chunk with its position in the sequence and the
+/// session's dropped-case tally, and re-gzip so the stored bytes stay
+/// the ones that will be posted.
+///
+/// A lone chunk that lost nothing is left untouched — attributes and
+/// bytes both — which is the compatibility hinge in the module docs.
+/// Re-compressing is otherwise confined to a fan-out, where the
+/// multi-MiB upload I/O dwarfs one more gzip per chunk, or to the
+/// rare lone upload that did lose a case.
+fn stamp_completeness_markers(
+    chunks: &mut [Chunk],
+    dropped_cases: usize,
+) -> Result<(), std::io::Error> {
+    // Both conversions are unreachable — neither a partition nor a
+    // drop tally that large fits in memory — and both resolve the
+    // same way when in doubt: never claim more completeness than we
+    // have. Declining to mark leaves a total unstated, which a reader
+    // treats as one upload; saturating a drop tally over-declares a
+    // loss, which costs a consumer its reduction. Under-declaring
+    // either would hand back a "complete" we cannot stand behind.
+    let Ok(count) = i64::try_from(chunks.len()) else {
+        return Ok(());
+    };
+    let dropped = i64::try_from(dropped_cases).unwrap_or(i64::MAX);
+    if count <= 1 && dropped == 0 {
+        return Ok(());
+    }
+
+    // The index comes out of a range typed by `count`, so it is an
+    // `i64` by construction and this loop needs no second conversion
+    // — no second answer to the impossibility decided above.
+    for (index, chunk) in (1..=count).zip(chunks.iter_mut()) {
+        // Only a request with no `ResourceSpans` at all reaches this
+        // skip, and it can only arrive through `single_upload` — the
+        // packed path builds every chunk with `assemble`, which
+        // always emits exactly one. Such a request carries no spans
+        // either, so there is no session to declare anything about;
+        // inventing a resource the payload does not have would say
+        // less than nothing.
+        let Some(resource_spans) = chunk.request.resource_spans.first_mut() else {
+            continue;
+        };
+        let resource = resource_spans
+            .resource
+            .get_or_insert_with(Resource::default);
+        // A lone chunk reaches here only to declare a loss: marking
+        // it `1 of 1` would say "multi-chunk" about an upload that is
+        // the whole sequence, which is what absence already says.
+        if count > 1 {
+            resource
+                .attributes
+                .push(kv_int(CHUNK_INDEX_ATTRIBUTE, index));
+            resource
+                .attributes
+                .push(kv_int(CHUNK_COUNT_ATTRIBUTE, count));
+        }
+        if dropped > 0 {
+            resource
+                .attributes
+                .push(kv_int(DROPPED_CASES_ATTRIBUTE, dropped));
+        }
+        chunk.compressed = gzip_request(&chunk.request)?;
+    }
+    Ok(())
 }
 
 /// A case span together with the suite span it hangs off (if any) and
@@ -179,33 +434,57 @@ impl<'a> Decomposed<'a> {
     /// the cap, where the multi-MiB upload I/O dwarfs the extra
     /// compression. Correctness (never ship an over-cap chunk) is
     /// worth the ~log(chunk-count) re-compressions.
+    /// Two caps, and the difference matters. `soft_cap` is the
+    /// packing target — `cap` minus the room stamping will need — and
+    /// it decides when to keep splitting. `hard_cap` is the real
+    /// limit, and it decides only whether a case is droppable: a lone
+    /// case that overflows the soft cap but fits the hard one is
+    /// shipped rather than discarded. Testing the drop against the
+    /// soft cap instead would move the "too large to upload"
+    /// threshold down by the reserve and silently stop delivering
+    /// results this CLI used to deliver — a test's results are worth
+    /// far more than the ~100 bytes of overshoot, which the hard
+    /// cap's own 5 MiB of headroom below the ingest limit absorbs.
     fn pack(
         &self,
         cases: &[CaseEntry<'a>],
-        cap: usize,
+        soft_cap: usize,
+        hard_cap: usize,
         chunks: &mut Vec<Chunk>,
         oversized: &mut Vec<String>,
     ) -> Result<(), std::io::Error> {
         let request = self.assemble(cases);
         let compressed = gzip_request(&request)?;
-        if compressed.len() <= cap {
+        if compressed.len() <= soft_cap {
             chunks.push(Chunk {
                 request,
                 compressed,
             });
             return Ok(());
         }
-        if cases.len() <= 1 {
+        match cases {
+            // Nothing to ship and nothing to report: only the
+            // top-level call can arrive here empty, since
+            // `split_index` never yields an empty half.
+            [] => return Ok(()),
             // The lone case (plus the unavoidable session/suite
             // framing) still overflows — nowhere left to split.
-            if let Some(entry) = cases.first() {
-                oversized.push(entry.case.name.clone());
+            [entry] => {
+                if compressed.len() <= hard_cap {
+                    chunks.push(Chunk {
+                        request,
+                        compressed,
+                    });
+                } else {
+                    oversized.push(entry.case.name.clone());
+                }
+                return Ok(());
             }
-            return Ok(());
+            _ => {}
         }
         let mid = split_index(cases);
-        self.pack(&cases[..mid], cap, chunks, oversized)?;
-        self.pack(&cases[mid..], cap, chunks, oversized)
+        self.pack(&cases[..mid], soft_cap, hard_cap, chunks, oversized)?;
+        self.pack(&cases[mid..], soft_cap, hard_cap, chunks, oversized)
     }
 
     /// Build a standalone request carrying `cases`: the session span,
@@ -326,6 +605,22 @@ mod tests {
             .collect()
     }
 
+    /// Read an integer resource attribute off a chunk, or `None`
+    /// when the chunk doesn't carry it.
+    fn resource_int(chunk: &Chunk, key: &str) -> Option<i64> {
+        use opentelemetry_proto::tonic::common::v1::any_value::Value;
+        chunk.request.resource_spans[0]
+            .resource
+            .as_ref()?
+            .attributes
+            .iter()
+            .find(|kv| kv.key == key)
+            .and_then(|kv| match kv.value.as_ref()?.value.as_ref()? {
+                Value::IntValue(v) => Some(*v),
+                _ => None,
+            })
+    }
+
     /// Iterate the spans of a chunk whose `test.scope` attribute
     /// equals `scope` (`session` / `suite` / `case`).
     fn spans_with_scope<'a>(chunk: &'a Chunk, scope: &'a str) -> impl Iterator<Item = &'a Span> {
@@ -347,7 +642,7 @@ mod tests {
     #[test]
     fn small_report_stays_a_single_chunk() {
         let request = build(vec![case("t.a", "suite", 0), case("t.b", "suite", 0)]);
-        let outcome = split_request(&request, upload::MAX_GZIPPED_UPLOAD_BYTES).unwrap();
+        let outcome = split_request(&request, upload::MAX_GZIPPED_UPLOAD_BYTES, 0).unwrap();
         assert_eq!(outcome.chunks.len(), 1);
         assert!(outcome.oversized_cases.is_empty());
         // Byte-identical to the un-split request: the common path must
@@ -373,7 +668,7 @@ mod tests {
         let request = build(cases);
         let cap = 4 * 1024;
 
-        let outcome = split_request(&request, cap).unwrap();
+        let outcome = split_request(&request, cap, 0).unwrap();
 
         assert!(
             outcome.chunks.len() > 1,
@@ -424,7 +719,7 @@ mod tests {
             case("t.normal_b", "suite", 256),
         ]);
 
-        let outcome = split_request(&request, cap).unwrap();
+        let outcome = split_request(&request, cap, 0).unwrap();
 
         assert_eq!(outcome.oversized_cases, vec!["t.monster".to_string()]);
         for chunk in &outcome.chunks {
@@ -436,6 +731,380 @@ mod tests {
         assert!(
             !uploaded.contains(&"t.monster".to_string()),
             "oversized case must not be uploaded"
+        );
+    }
+
+    #[test]
+    fn single_chunk_carries_no_completeness_marker() {
+        let request = build(vec![case("t.a", "suite", 0), case("t.b", "suite", 0)]);
+        let outcome = split_request(&request, upload::MAX_GZIPPED_UPLOAD_BYTES, 0).unwrap();
+        assert_eq!(outcome.chunks.len(), 1);
+        assert_eq!(
+            resource_int(&outcome.chunks[0], CHUNK_INDEX_ATTRIBUTE),
+            None
+        );
+        assert_eq!(
+            resource_int(&outcome.chunks[0], CHUNK_COUNT_ATTRIBUTE),
+            None
+        );
+        // Nothing was lost either, so the third marker is absent too:
+        // this payload is what every deployed client sends, and all
+        // three absences have to keep meaning "whole".
+        assert_eq!(
+            resource_int(&outcome.chunks[0], DROPPED_CASES_ATTRIBUTE),
+            None
+        );
+    }
+
+    #[test]
+    fn unsplittable_request_shape_stays_unmarked() {
+        // `Decomposed::from_request` bails on any layout our builder
+        // doesn't emit, and the lone fallback chunk is the whole
+        // payload. `cap: 0` forces the over-cap branch without needing
+        // a multi-MiB fixture.
+        let mut request = build(vec![case("t.a", "suite", 0)]);
+        // Two resource_spans is not the single-resource layout
+        // `build_traces` produces, so decomposition declines.
+        let extra = request.resource_spans[0].clone();
+        request.resource_spans.push(extra);
+
+        let outcome = split_request(&request, 0, 0).unwrap();
+
+        assert_eq!(outcome.chunks.len(), 1);
+        assert!(outcome.oversized_cases.is_empty());
+        assert_eq!(
+            resource_int(&outcome.chunks[0], CHUNK_INDEX_ATTRIBUTE),
+            None
+        );
+        assert_eq!(
+            resource_int(&outcome.chunks[0], CHUNK_COUNT_ATTRIBUTE),
+            None
+        );
+    }
+
+    #[test]
+    fn split_chunks_declare_their_position_and_stay_under_cap() {
+        let cases: Vec<TestCase> = (0..40)
+            .map(|i| case(&format!("t.case_{i}"), "suite", 2048))
+            .collect();
+        let request = build(cases);
+        let cap = 4 * 1024;
+
+        let outcome = split_request(&request, cap, 0).unwrap();
+        let total = i64::try_from(outcome.chunks.len()).unwrap();
+        assert!(total > 1, "expected a fan-out, got {total} chunk(s)");
+
+        for (position, chunk) in outcome.chunks.iter().enumerate() {
+            let index = i64::try_from(position).unwrap() + 1;
+            assert_eq!(
+                resource_int(chunk, CHUNK_INDEX_ATTRIBUTE),
+                Some(index),
+                "chunk {index} misdeclares its position"
+            );
+            assert_eq!(
+                resource_int(chunk, CHUNK_COUNT_ATTRIBUTE),
+                Some(total),
+                "chunk {index} misdeclares the sequence length"
+            );
+            // The reserve exists so stamping can't push a packed
+            // chunk past the cap. Measure the stamped bytes rather
+            // than trusting the constant, and check the stored body
+            // is the one that will actually be POSTed.
+            assert_eq!(chunk.compressed, gzip_request(&chunk.request).unwrap());
+            assert!(
+                chunk.compressed.len() <= cap,
+                "chunk {index} exceeds the cap once marked: {} > {cap}",
+                chunk.compressed.len()
+            );
+            // Nothing was dropped here, so nothing claims a loss:
+            // absence is the whole convention, and stamping a `0`
+            // instead would say "amputated by nothing" on the most
+            // ordinary fan-out there is.
+            assert_eq!(
+                resource_int(chunk, DROPPED_CASES_ATTRIBUTE),
+                None,
+                "chunk {index} declared a loss that never happened"
+            );
+        }
+    }
+
+    #[test]
+    fn marker_keys_are_pinned_in_the_mergify_namespace() {
+        // These strings are the wire contract the engine reads;
+        // renaming the constant is free, renaming its value is a
+        // protocol break. `mergify.` is where this builder already
+        // files its vendor-only concepts (`mergify.test.job.name`),
+        // which is what a chunk total is.
+        assert_eq!(CHUNK_INDEX_ATTRIBUTE, "mergify.test.session.chunk.index");
+        assert_eq!(CHUNK_COUNT_ATTRIBUTE, "mergify.test.session.chunk.count");
+        assert_eq!(
+            DROPPED_CASES_ATTRIBUTE,
+            "mergify.test.session.dropped_cases.count"
+        );
+    }
+
+    #[test]
+    fn a_fan_out_declares_the_cases_it_could_not_carry() {
+        // Reaching the declared total says every upload arrived, not
+        // that every result did: the monster case fits in no upload
+        // and is dropped. Without a count, that session announces
+        // itself whole while missing a test — and the missing ones
+        // skew towards failures, which is what the reduction would
+        // then be answering over.
+        let cap = 4 * 1024;
+        let request = build(vec![
+            case("t.normal_a", "suite", 2048),
+            case("t.monster", "suite", 64 * 1024),
+            case("t.normal_b", "suite", 2048),
+            case("t.normal_c", "suite", 2048),
+        ]);
+
+        let outcome = split_request(&request, cap, 0).unwrap();
+
+        assert_eq!(outcome.oversized_cases, vec!["t.monster".to_string()]);
+        assert!(
+            outcome.chunks.len() > 1,
+            "fixture must fan out for this test to say anything"
+        );
+        for chunk in &outcome.chunks {
+            // On every chunk, not just one: a consumer holding any
+            // single upload has to be able to tell.
+            assert_eq!(
+                resource_int(chunk, DROPPED_CASES_ATTRIBUTE),
+                Some(1),
+                "a chunk carried no loss count"
+            );
+            assert_eq!(chunk.compressed, gzip_request(&chunk.request).unwrap());
+        }
+    }
+
+    #[test]
+    fn a_lone_upload_missing_a_case_declares_the_loss_and_no_sequence() {
+        // The span builder refuses an over-long test name before the
+        // split runs, so a report that fits in one upload can still
+        // be missing results. The loss is declared; the chunk markers
+        // are not, because one upload is the whole sequence.
+        let request = build(vec![case("t.a", "suite", 0)]);
+
+        let outcome = split_request(&request, upload::MAX_GZIPPED_UPLOAD_BYTES, 2).unwrap();
+
+        assert_eq!(outcome.chunks.len(), 1);
+        let chunk = &outcome.chunks[0];
+        assert_eq!(resource_int(chunk, DROPPED_CASES_ATTRIBUTE), Some(2));
+        assert_eq!(resource_int(chunk, CHUNK_INDEX_ATTRIBUTE), None);
+        assert_eq!(resource_int(chunk, CHUNK_COUNT_ATTRIBUTE), None);
+        // Stamped after the sizing gzip, so the stored bytes must
+        // have been recomputed — they are the ones posted.
+        assert_eq!(chunk.compressed, gzip_request(&chunk.request).unwrap());
+    }
+
+    #[test]
+    fn losses_from_both_causes_are_added_up() {
+        // The two refusals — a name over the limit, a payload over
+        // the cap — are independent, and the report most likely to
+        // hit both at once is exactly the one that fans out: a huge
+        // run with megabyte stack traces. Taking either side alone
+        // (a max, a forgotten addend) under-counts the amputation on
+        // the one shape this attribute exists for.
+        let cap = 4 * 1024;
+        let request = build(vec![
+            case("t.normal_a", "suite", 2048),
+            case("t.monster_a", "suite", 64 * 1024),
+            case("t.normal_b", "suite", 2048),
+            case("t.monster_b", "suite", 64 * 1024),
+        ]);
+
+        // Both addends above one, so a tally that collapsed either
+        // side to "some were lost" would show here. The consumer acts
+        // on how amputated a session is, not on whether it is.
+        let outcome = split_request(&request, cap, 3).unwrap();
+
+        assert_eq!(outcome.oversized_cases.len(), 2);
+        for chunk in &outcome.chunks {
+            assert_eq!(
+                resource_int(chunk, DROPPED_CASES_ATTRIBUTE),
+                Some(5),
+                "3 refused on name length + 2 refused on size = 5"
+            );
+        }
+    }
+
+    #[test]
+    fn every_chunk_of_a_split_is_a_distinct_payload() {
+        // The backend registers arrivals by payload hash
+        // (`span_test_summary.processed_chunk_hashes`, MRGFY-9104), so
+        // two identical bodies would collapse into one and a session
+        // could never reach its declared total. Distinctness comes
+        // from `pack` giving each chunk a different set of cases —
+        // this pins that, not the markers; the distinct index each
+        // chunk carries is a second line of defence, not the one
+        // under test here.
+        let cases: Vec<TestCase> = (0..40)
+            .map(|i| case(&format!("t.case_{i}"), "suite", 2048))
+            .collect();
+        let outcome = split_request(&build(cases), 4 * 1024, 0).unwrap();
+        assert!(outcome.chunks.len() > 1);
+
+        let distinct: BTreeSet<&[u8]> = outcome
+            .chunks
+            .iter()
+            .map(|c| c.compressed.as_slice())
+            .collect();
+        assert_eq!(
+            distinct.len(),
+            outcome.chunks.len(),
+            "two chunks share a payload; the backend would count them once"
+        );
+    }
+
+    #[test]
+    fn the_session_span_stays_byte_identical_across_chunks() {
+        // The module's idempotent-upsert promise — every chunk
+        // re-sends the same session span, keyed `(trace_id, span_id)`
+        // — is why repeating it across uploads is safe. The
+        // completeness markers ride on the *resource* precisely so
+        // that promise survives: a per-chunk-varying session-span
+        // attribute would make whichever upload lands last decide the
+        // session's value.
+        let cases: Vec<TestCase> = (0..40)
+            .map(|i| case(&format!("t.case_{i}"), "suite", 2048))
+            .collect();
+        let outcome = split_request(&build(cases), 4 * 1024, 0).unwrap();
+        assert!(outcome.chunks.len() > 1);
+
+        let encoded: BTreeSet<Vec<u8>> = outcome
+            .chunks
+            .iter()
+            .map(|chunk| {
+                spans_with_scope(chunk, "session")
+                    .next()
+                    .expect("every chunk carries the session span")
+                    .encode_to_vec()
+            })
+            .collect();
+        assert_eq!(encoded.len(), 1, "the session span drifted across chunks");
+    }
+
+    #[test]
+    fn a_lone_case_between_the_packing_budget_and_the_cap_still_ships() {
+        // The reserve narrows what `pack` will accept, and it must not
+        // narrow what counts as undeliverable with it: a case that
+        // cannot be split further but does fit the real cap has to
+        // ship. Testing the drop against the packing budget instead
+        // would move the "too large to upload" threshold down by the
+        // reserve and stop delivering results this CLI used to
+        // deliver — for the sake of ~40 bytes of stamping, against a
+        // cap that already keeps 5 MiB clear of the ingest limit.
+        let request = build(vec![
+            case("t.case_a", "suite", 4096),
+            case("t.case_b", "suite", 4096),
+        ]);
+        // Size a lone case's own chunk exactly as `pack` would, then
+        // set the cap just above it — so each case clears the cap and
+        // fails the packing budget, which is the band at issue.
+        let decomposed = Decomposed::from_request(&request).expect("built layout decomposes");
+        let lone = gzip_request(&decomposed.assemble(&decomposed.cases[..1]))
+            .unwrap()
+            .len();
+        let cap = lone + 16;
+        assert!(
+            cap > CHUNK_MARKER_RESERVE_BYTES,
+            "fixture must leave a real packing budget"
+        );
+
+        let outcome = split_request(&request, cap, 0).unwrap();
+
+        assert!(
+            outcome.oversized_cases.is_empty(),
+            "a case that fits the cap was dropped: {:?}",
+            outcome.oversized_cases
+        );
+        let mut names: Vec<String> = outcome.chunks.iter().flat_map(case_names).collect();
+        names.sort();
+        assert_eq!(names, vec!["t.case_a".to_string(), "t.case_b".to_string()]);
+
+        // Chunks taking this escape are stamped like any other, so
+        // they can end up a few dozen bytes past `cap`. That overshoot
+        // is the deliberate trade, and it is bounded by the reserve.
+        for chunk in &outcome.chunks {
+            assert!(
+                chunk.compressed.len() <= cap + CHUNK_MARKER_RESERVE_BYTES,
+                "overshoot beyond the reserved headroom: {} > {}",
+                chunk.compressed.len(),
+                cap + CHUNK_MARKER_RESERVE_BYTES
+            );
+        }
+    }
+
+    #[test]
+    fn a_lone_packed_chunk_is_left_unmarked() {
+        // Packing can land on a single chunk: `assemble` reorders the
+        // spans (session, then suites, then cases) and that layout can
+        // gzip smaller than the one `build_traces` emitted. The result
+        // is still the whole session, so it must read as unmarked like
+        // any other single upload.
+        let request = build(vec![case("t.a", "suite", 0)]);
+        let compressed = gzip_request(&request).unwrap();
+        let mut chunks = vec![Chunk {
+            request,
+            compressed,
+        }];
+
+        stamp_completeness_markers(&mut chunks, 0).unwrap();
+
+        assert_eq!(resource_int(&chunks[0], CHUNK_INDEX_ATTRIBUTE), None);
+        assert_eq!(resource_int(&chunks[0], CHUNK_COUNT_ATTRIBUTE), None);
+    }
+
+    #[test]
+    fn stamping_overhead_fits_in_the_reserved_headroom() {
+        // What `CHUNK_MARKER_RESERVE_BYTES` claims is that stamping a
+        // packed chunk cannot grow its gzipped body by more than the
+        // reserve — that claim is about deflate, so measure it rather
+        // than reason about it. Asserting the chunks land under the
+        // cap does not cover this: on any ordinary fixture they land
+        // far below it, so the reserve could be zero and nothing
+        // would notice until a report packed right up to the line.
+        let cases: Vec<TestCase> = (0..40)
+            .map(|i| case(&format!("t.case_{i}"), "suite", 2048))
+            .collect();
+        // Stamped with all three markers — a fan-out that also lost a
+        // case is the widest stamp there is, so it is the one the
+        // reserve has to cover.
+        let outcome = split_request(&build(cases), 4 * 1024, 7).unwrap();
+        assert!(outcome.chunks.len() > 1);
+
+        let mut largest_overhead = 0usize;
+        for chunk in &outcome.chunks {
+            let mut bare = chunk.request.clone();
+            let attributes = &mut bare.resource_spans[0]
+                .resource
+                .as_mut()
+                .expect("built chunks carry a resource")
+                .attributes;
+            let before = attributes.len();
+            attributes.retain(|kv| {
+                kv.key != CHUNK_INDEX_ATTRIBUTE
+                    && kv.key != CHUNK_COUNT_ATTRIBUTE
+                    && kv.key != DROPPED_CASES_ATTRIBUTE
+            });
+            assert_eq!(before - attributes.len(), 3, "all markers must be present");
+
+            let overhead = chunk
+                .compressed
+                .len()
+                .saturating_sub(gzip_request(&bare).unwrap().len());
+            largest_overhead = largest_overhead.max(overhead);
+        }
+
+        assert!(
+            largest_overhead > 0,
+            "measured no overhead at all — the comparison is not exercising the markers"
+        );
+        assert!(
+            largest_overhead <= CHUNK_MARKER_RESERVE_BYTES,
+            "stamping costs {largest_overhead} gzipped bytes, more than the \
+             {CHUNK_MARKER_RESERVE_BYTES} held back while packing"
         );
     }
 
@@ -452,7 +1121,7 @@ mod tests {
         let request = build(cases);
         let cap = 4 * 1024;
 
-        let outcome = split_request(&request, cap).unwrap();
+        let outcome = split_request(&request, cap, 0).unwrap();
         assert!(outcome.chunks.len() > 1);
 
         for chunk in &outcome.chunks {

--- a/crates/mergify-ci/src/junit_process/upload.rs
+++ b/crates/mergify-ci/src/junit_process/upload.rs
@@ -66,10 +66,11 @@ const ENDPOINT_SUFFIX: &str = "/ci/traces";
 /// limit: the ingest endpoint hard-caps payloads at 25 MiB
 /// (MRGFY-8124), so sizing each chunk under 20 MiB leaves 5 MiB of
 /// headroom below the rejection threshold. [`crate::junit_process::split`]
-/// partitions an oversized trace into several uploads that each gzip
-/// under this cap. The cap is on the *compressed* body — the exact
-/// bytes we put on the wire — not the raw XML or the uncompressed
-/// protobuf.
+/// partitions an oversized trace into several uploads sized against
+/// this cap — two of its paths land a few dozen bytes over it on
+/// purpose, which is what the 5 MiB is for. The cap is on the
+/// *compressed* body — the exact bytes we put on the wire — not the
+/// raw XML or the uncompressed protobuf.
 pub const MAX_GZIPPED_UPLOAD_BYTES: usize = 20 * 1024 * 1024;
 
 // The soft cap is only safe if it stays under the ingest server's hard
@@ -126,10 +127,11 @@ pub async fn upload(
 }
 
 /// POST an already-gzipped OTLP payload. The splitting path
-/// ([`crate::junit_process::split`]) gzips each chunk once to size it
-/// against the cap and hands the compressed bytes straight here, so
-/// the payload is never gzipped twice. Callers guarantee `compressed`
-/// is a non-empty gzipped `ExportTraceServiceRequest`.
+/// ([`crate::junit_process::split`]) hands over the exact bytes it
+/// means to send — gzipped once when the chunk ships as it was sized,
+/// once more when it was stamped with its position in the session —
+/// so nothing is compressed again here. Callers guarantee
+/// `compressed` is a non-empty gzipped `ExportTraceServiceRequest`.
 pub async fn upload_compressed(
     client: &reqwest::Client,
     api_url: &str,


### PR DESCRIPTION
A JUnit report too large for the ingest cap is split into several OTLP
uploads. Each one is a self-contained trace that re-reports the session
span, so once ingested it is indistinguishable from a whole session: it
carries coherent counters over the cases it happens to hold. A consumer
asking "did this session report a failing test?" therefore gets an
answer from the first upload to land, before the rest of the run has
arrived — and the answer it acts on is "run no test, exit green".

Every upload of a fanned-out session now declares its own position
(`mergify.test.session.chunk.index`) and the length of the sequence
(`mergify.test.session.chunk.count`) as resource attributes. The
splitter already knows both — it partitions the whole run before
sending anything — so the information was free at the source and simply
was not carried.

Absence of both attributes keeps meaning "a single upload, and it is the
whole session". That is the compatibility hinge, and it is why a lone
chunk stays unmarked: every published client sends neither attribute and
its uploads are complete, so a session counts as incomplete only when it
declares a total it has not reached. Of the 55 000 sessions measured over
24 h on 2026-09-07, none was recorded as multi-chunk; their payloads
are unchanged, byte for byte.

`i of n` rather than a "last chunk" flag: neither is knowable until
packing has finished, so both need the same after-the-fact stamping
pass, and the pair also tells a stalled delivery (chunk 3 of 5, an hour
old) from one still arriving. Stamping costs one extra gzip per chunk,
which is immaterial against the multi-MiB upload I/O of a fan-out.

Nothing reads the index today, and that is deliberate rather than an
oversight: the engine counts arrivals in a ledger keyed by payload and
says outright that it does not store the index. It is here for the
stalled-delivery question above, which the count alone cannot answer,
and it is also the only attribute that differs between the uploads of
one session — inert, since no consumer keys or dedupes on the resource,
but worth knowing before anyone removes it as unused.

The markers ride on the resource, not the session span, so the module's
idempotent-upsert promise — every chunk re-sends a byte-identical
session span keyed `(trace_id, span_id)` — survives untouched. They are
stamped after packing, against a reserved slice of the cap, since
neither value exists until the partition is final. That reserve narrows
the packing budget only: a lone case that cannot be split further but
still fits the real cap ships rather than being dropped, so the "too
large to upload" threshold is exactly where it was.

A third attribute says what "all chunks arrived" does not:
`mergify.test.session.dropped_cases.count`, how many test cases this
client left out of the upload entirely. The key spells out what it
counts because it sits beside `chunk.count`, where a bare
`dropped.count` reads just as easily as "how many chunks were
dropped" — and from that a consumer derives `received + dropped ==
chunk.count`, a self-consistent rule that closes a session while
results are missing. Naming it after the wrong entity would have
reintroduced this change's own failure through the front door. Two refusals produce them — a case
whose own payload gzips past the cap, and a name over
`MAX_TEST_NAME_BYTES` — and they are summed, because for a consumer
they are one fact: a result missing from the session. Without it a
session can announce itself complete while missing tests, and the
missing ones skew towards failures, since a megabyte stack trace is
what makes a case oversized in the first place. That is the same
"reads green while it is not" the chunk markers close, arriving by the
other door.

The alternative was to establish that such a session can never be
served a reduced run anyway. The code does not support it: the dropped
case span is the only record of its own failure, the session and suite
spans carry no counters, and the run's failure count never leaves this
process — it feeds the CI verdict and the printed report, not the wire.
A session that lost a failing case is otherwise byte-for-byte a session
where that test never ran.

Absent means nothing was dropped, the same hinge as the chunk markers,
so an ordinary upload is still stamped with nothing at all and posted
as the exact bytes it was sized against. The count is session-wide and
repeated on every chunk rather than tallied per chunk: a consumer
decides on the session, and whichever upload it happens to read has to
be able to tell it the session is amputated.

The report gains the counts when a run fans out: "4 of 5 chunks sent —
this test session is incomplete" is no longer a transient upload hiccup
but a durable state the backend can see, and this process is the only
place that ever knew the total. Ordinary single-upload runs are silent
as before.

The three keys sit under `mergify.`, not `test.`. The engine reads
about thirty resource attributes and all but one are OpenTelemetry
semantic conventions (`cicd.*`, `vcs.*`, `code.*`,
`test.collection.fingerprint`); the exception is `mergify.test.job.name`.
The line between the two families is whether the attribute states a
fact about the test or a fact about our own tooling. Chunking exists
only because *our* ingest has a ceiling and *our* CLI splits to respect
it, and the loss count counts what *our* splitter discarded — no
OpenTelemetry convention will ever define either, and filing them under
`test.*` would squat a namespace a third party governs while misstating
what they are. `marker_keys_are_pinned_in_the_mergify_namespace` is
what keeps that decision from being undone by a rename.

One objection was raised in review and declined: if chunk *k* fails in
transit while chunk *n* succeeds, does the session read as complete
because the last index to land was the total? It does not. The engine
compares the declared total against `processed_chunk_hashes`, a ledger
of arrivals keyed by payload, and deliberately does not store the index
at all. That ledger needs each chunk to be a distinct payload, which is
exactly what `every_chunk_of_a_split_is_a_distinct_payload` pins here.

The limitation to know, on all three attributes: absence means "whole"
by convention, but strictly it means "this client says nothing". A CLI
released before this can fan out and stamp nothing, and no producer
version on the resource lets a consumer tell it from a new client with
nothing to declare. That is the chunk markers' gap alone: splitting has
been released since `2026.7.21.1`, whereas the name-length refusal is
on `main` and in no release, so no deployed client drops a case for it
yet. Reading absence as whole is what keeps the reduction working for
every deployed client, which is the trade the ticket locks. The residue
is small — of 55 000 sessions over 24 h none was recorded as
multi-chunk — though that figure is a floor rather than a census: it
counts sessions whose chunks arrived, so a run whose other chunks never
landed is exactly what it cannot see. Closing the gap needs a producer
identity on the resource and a consumer that gates on it — a contract
decision for both halves, carried by MRGFY-9128 rather than settled
here.

What this does not do is close the risk that had Test Selection
disabled on Mergifyio on 2026-09-07. The engine must persist these
attributes and answer "is this session complete?" before that gate
lifts (MRGFY-9121). The two halves are safe to land in either order:
the engine mangles `.` to `_` and validates resources with
`extra="ignore"`, so the attributes are ignored, not rejected, by the
version deployed today.

Fixes MRGFY-9104
Related to MRGFY-9121, MRGFY-9128

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>