### PR TITLE
chore(rust): bump toolchain to 1.98

### DIFF
--- a/crates/mergify-ci/src/detector.rs
+++ b/crates/mergify-ci/src/detector.rs
@@ -38,7 +38,7 @@ impl CIProvider {
 
 #[must_use]
 pub fn get_ci_provider() -> Option<CIProvider> {
-    if env::var("JENKINS_URL").ok().is_some_and(|v| !v.is_empty()) {
+    if env::var("JENKINS_URL").is_ok_and(|v| !v.is_empty()) {
         return Some(CIProvider::Jenkins);
     }
     if env::var("GITHUB_ACTIONS").as_deref() == Ok("true") {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,5 +3,5 @@
 # proposes bumps (after the 7-day minimumReleaseAge); a bump PR that
 # trips new lints fails CI and must fix them in the same PR.
 [toolchain]
-channel = "1.97"
+channel = "1.98"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
renovate opened #1790 for this bump on 2026-08-27 and it has been red
for two weeks: 1.98's clippy adds `manual_is_variant_and`, which fires
once, on a `Result` treated as an `Option`:

    env::var("JENKINS_URL").ok().is_some_and(|v| !v.is_empty())
    -> env::var("JENKINS_URL").is_ok_and(|v| !v.is_empty())

rust-toolchain.toml's own comment states the policy this follows: a
bump PR that trips new lints fails CI and must fix them in the same
PR, so the fix travels with the bump rather than in a follow-up.

Verified locally against 1.98.1 with the exact CI steps (cargo fmt
--check, clippy --workspace --all-targets --all-features --locked -D
warnings, test --workspace --all-features --locked, build --release
--locked): all pass, and clippy surfaces no other new lint beyond the
one above.

Supersedes #1790.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>